### PR TITLE
Skip test if curl is not linking with openssl.

### DIFF
--- a/tests/certinfo_test.py
+++ b/tests/certinfo_test.py
@@ -46,6 +46,9 @@ class CertinfoTest(unittest.TestCase):
         # CURLOPT_CERTINFO was introduced in libcurl-7.19.1
         if util.pycurl_version_less_than(7, 19, 1):
             raise nose.plugins.skip.SkipTest('libcurl < 7.19.1')
+        # CURLOPT_CERTINFO only works with OpenSSL
+        if 'openssl' not in pycurl.version.lower():
+            raise nose.plugins.skip.SkipTest('libcurl does not use openssl')
         
         self.curl.setopt(pycurl.URL, 'https://localhost:8383/success')
         sio = util.StringIO()


### PR DESCRIPTION
Setting the OPT_CERTINFO of a curl handle will throw an exception if curl does not link against openssl (see: http://curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTCERTINFO).  My solution is to check the version info string for "openssl" in a case-insensitive manner.
