### PR TITLE
Use runtime libcurl version in pycurl default user agent

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,10 @@
 master
 ------
 
+        * Default PycURL user agent string is now built at runtime, and will
+          include the user agent string of libcurl loaded at runtime rather
+          than the one present at compile time.
+
         * Added CURL_LOCK_DATA_SSL_SESSION (patch by Tom Pierce).
 
         * Added E_OPERATION_TIMEDOUT (patch by Romuald Brunet).

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@
 
 SHELL = /bin/sh
 
-PYTHON = python2.3
 PYTHON = python
 NOSETESTS = nosetests
 
@@ -18,6 +17,8 @@ build-7.10.8:
 test: build
 	mkdir -p tests/tmp
 	PYTHONSUFFIX=$$(python -V 2>&1 |awk '{print $$2}' |awk -F. '{print $$1 "." $$2}') && \
+	PYTHONPATH=$$(ls -d build/lib.*$$PYTHONSUFFIX):$$PYTHONPATH \
+	$(PYTHON) -c 'import pycurl; print(pycurl.version)'
 	PYTHONPATH=$$(ls -d build/lib.*$$PYTHONSUFFIX):$$PYTHONPATH \
 	$(NOSETESTS)
 

--- a/tests/user_agent_string_test.py
+++ b/tests/user_agent_string_test.py
@@ -24,4 +24,4 @@ class UserAgentStringTest(unittest.TestCase):
         self.curl.perform()
         user_agent = sio.getvalue().decode()
         assert user_agent.startswith('PycURL/')
-        assert 'libcurl/' in user_agent
+        assert 'libcurl/' in user_agent, 'User agent did not include libcurl/: %s' % user_agent


### PR DESCRIPTION
Fixes #49.
