### PR TITLE
Add a test giving unicode and byte strings as string options to pycurl.

### DIFF
--- a/tests/app.py
+++ b/tests/app.py
@@ -81,6 +81,15 @@ def header():
         header_value = header_value.decode('utf8')
     return header_value
 
+@app.route('/param_utf8_hack', method='post')
+def param_utf8_hack():
+    param = bottle.request.forms['p']
+    if py3:
+        # python 3 decodes bytes as latin1 perhaps?
+        # apply the latin1-utf8 hack
+        param = param.encode('latin').decode('utf8')
+    return param
+
 def pause_writer():
     yield 'part1'
     _time.sleep(0.5)

--- a/tests/setopt_unicode_test.py
+++ b/tests/setopt_unicode_test.py
@@ -1,0 +1,41 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# vi:ts=4:et
+
+import pycurl
+import unittest
+import nose.tools
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
+from . import appmanager
+from . import util
+
+setup_module, teardown_module = appmanager.setup(('app', 8380))
+
+class SetoptUnicodeTest(unittest.TestCase):
+    def setUp(self):
+        self.curl = pycurl.Curl()
+    
+    def tearDown(self):
+        self.curl.close()
+    
+    def test_ascii_string(self):
+        self.check('p=test', 'test')
+    
+    @nose.tools.raises(UnicodeEncodeError)
+    def test_unicode_string(self):
+        self.check(util.u('p=Москва'), util.u('Москва'))
+    
+    def test_unicode_encoded(self):
+        self.check(util.u('p=Москва').encode('utf8'), util.u('Москва'))
+    
+    def check(self, send, expected):
+        self.curl.setopt(pycurl.URL, 'http://localhost:8380/param_utf8_hack')
+        sio = util.BytesIO()
+        self.curl.setopt(pycurl.WRITEFUNCTION, sio.write)
+        self.curl.setopt(pycurl.POSTFIELDS, send)
+        self.curl.perform()
+        self.assertEqual(expected, sio.getvalue().decode('utf-8'))


### PR DESCRIPTION
Fixes #133
