### PR TITLE
README.rst -> INSTALL.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Requirements
 Installation
 ------------
 
-Please see README.rst for installation instructions.
+Please see INSTALL.rst for installation instructions.
 
 Support
 -------


### PR DESCRIPTION
Looks like a typo? Unless this doc is supposed to point to itself.
