### PR TITLE
Reimplement SSL serving with Python stdlib's ssl module.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,8 +74,7 @@ PycURL comes with an automated test suite. To run the tests, execute::
 
     make test
 
-The suite depends on packages `nose`_, `bottle`_ and `cherrypy`_,
-as well as `vsftpd`_.
+The suite depends on packages `nose`_ and `bottle`_, as well as `vsftpd`_.
 
 Some tests use vsftpd configured to accept anonymous uploads. These tests
 are not run by default. As configured, vsftpd will allow reads and writes to
@@ -92,7 +91,6 @@ These instructions work for Python 2.5 through 2.7 and 3.1 through 3.3.
 
 .. _nose: https://nose.readthedocs.org/
 .. _bottle: http://bottlepy.org/
-.. _cherrypy: http://www.cherrypy.org/
 .. _vsftpd: http://vsftpd.beasts.org/
 
 Test Matrix

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,2 @@
 bottle
 nose
-cherrypy

--- a/tests/runwsgi.py
+++ b/tests/runwsgi.py
@@ -11,6 +11,10 @@ global_stop = False
 
 class Server(bottle.WSGIRefServer):
     def run(self, handler): # pragma: no cover
+        self.srv = self.make_server(handler)
+        self.serve()
+    
+    def make_server(self, handler):
         from wsgiref.simple_server import make_server, WSGIRequestHandler
         if self.quiet:
             base = self.options.get('handler_class', WSGIRequestHandler)
@@ -18,7 +22,10 @@ class Server(bottle.WSGIRefServer):
                 def log_request(*args, **kw):
                     pass
             self.options['handler_class'] = QuietHandler
-        self.srv = make_server(self.host, self.port, handler, **self.options)
+        srv = make_server(self.host, self.port, handler, **self.options)
+        return srv
+    
+    def serve(self):
         if sys.version_info[0] == 2 and sys.version_info[1] < 6:
             # python 2.5 has no poll_interval
             # and thus no way to stop the server
@@ -27,20 +34,21 @@ class Server(bottle.WSGIRefServer):
         else:
             self.srv.serve_forever(poll_interval=0.1)
 
-class SslServer(bottle.CherryPyServer):
-    def run(self, handler):
-        import cherrypy.wsgiserver, cherrypy.wsgiserver.ssl_builtin
-        server = cherrypy.wsgiserver.CherryPyWSGIServer((self.host, self.port), handler)
+# http://www.socouldanyone.com/2014/01/bottle-with-ssl.html
+# https://github.com/mfm24/miscpython/blob/master/bottle_ssl.py
+class SslServer(Server):
+    def run(self, handler): # pragma: no cover
+        self.srv = self.make_server(handler)
+        
+        import ssl
         cert_dir = os.path.join(os.path.dirname(__file__), 'certs')
-        ssl_adapter = cherrypy.wsgiserver.ssl_builtin.BuiltinSSLAdapter(
-            os.path.join(cert_dir, 'server.crt'),
-            os.path.join(cert_dir, 'server.key'),
-        )
-        server.ssl_adapter = ssl_adapter
-        try:
-            server.start()
-        finally:
-            server.stop()
+        self.srv.socket = ssl.wrap_socket(
+            self.srv.socket,
+            keyfile=os.path.join(cert_dir, 'server.key'),
+            certfile=os.path.join(cert_dir, 'server.crt'),
+            server_side=True)
+        
+        self.serve()
 
 def start_bottle_server(app, port, server, **kwargs):
     server_thread = ServerThread(app, port, server, kwargs)


### PR DESCRIPTION
SSL via CherryPy would fail on recent GNU userlands thusly:

error: (56, 'SSL read: error:1408F10B:SSL routines:SSL3_GET_RECORD:wrong version number, errno 0')

Reported in #180 as well as for a while now by travis.
