### PR TITLE
SSL library detection on CentOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ class ExtensionConfiguration(object):
         self.extra_objects = []
         self.extra_compile_args = []
         self.extra_link_args = []
-        
+
         self.configure()
 
     @property
@@ -91,6 +91,8 @@ class ExtensionConfiguration(object):
             self.include_dirs.append(os.path.join(OPENSSL_DIR, "include"))
         CURL_CONFIG = os.environ.get('PYCURL_CURL_CONFIG', "curl-config")
         CURL_CONFIG = scan_argv("--curl-config=", CURL_CONFIG)
+        CURL = os.environ.get('PYCURL_CURL', "curl")
+        CURL = scan_argv("--curl=", CURL)
         try:
             p = subprocess.Popen((CURL_CONFIG, '--version'),
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -168,13 +170,14 @@ class ExtensionConfiguration(object):
                     # first call succeeded and second call failed
                     # ignore stderr and the error exit
                     pass
+
         if optbuf == "":
             msg = "Neither curl-config --libs nor curl-config --static-libs" +\
                 " succeeded and produced output"
             if errtext:
                 msg += ":\n" + errtext
             raise ConfigurationError(msg)
-        
+
         ssl_lib_detected = False
         if 'PYCURL_SSL_LIBRARY' in os.environ:
             ssl_lib = os.environ['PYCURL_SSL_LIBRARY']
@@ -225,6 +228,34 @@ class ExtensionConfiguration(object):
                     self.define_macros.append(('HAVE_CURL_NSS', 1))
                     ssl_lib_detected = True
                     self.libraries.append('ssl3')
+
+        if not ssl_lib_detected:
+            # tries to detect using curl -V.
+            # On Centos and RedHat libcurl are built with
+            # static libraries disabled and 'curl-config --libs'
+            # returns nothing. 'curl -V' shows information
+            # about the ssl libraries.
+            p = subprocess.Popen((CURL, '-V'),
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+            stdout, stderr = p.communicate()
+
+            if p.wait() == 0:
+                curl_version_info = stdout.decode()
+
+                if 'OpenSSL' in curl_version_info:
+                    self.define_macros.append(('HAVE_CURL_OPENSSL', 1))
+                    ssl_lib_detected = True
+                    self.libraries.append('crypto')
+                if not ssl_lib_detected and 'GnuTLS' in curl_version_info:
+                    self.define_macros.append(('HAVE_CURL_GNUTLS', 1))
+                    ssl_lib_detected = True
+                    self.libraries.append('gnutls')
+                if not ssl_lib_detected and 'NSS' in curl_version_info:
+                    self.define_macros.append(('HAVE_CURL_NSS', 1))
+                    ssl_lib_detected = True
+                    self.libraries.append('ssl3')
+
         if not ssl_lib_detected:
             p = subprocess.Popen((CURL_CONFIG, '--features'),
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -244,11 +275,11 @@ class ExtensionConfiguration(object):
             self.define_macros.append(('HAVE_CURL_SSL', 1))
         if not self.libraries:
             self.libraries.append("curl")
-        
+
         # Add extra compile flag for MacOS X
         if sys.platform[:-1] == "darwin":
             self.extra_link_args.append("-flat_namespace")
-        
+
         # Recognize --avoid-stdio on Unix so that it can be tested
         self.check_avoid_stdio()
 
@@ -286,9 +317,9 @@ class ExtensionConfiguration(object):
         if not os.path.exists(libcurl_lib_path):
             fail("libcurl.lib does not exist at %s.\nCurl directory must point to compiled libcurl (bin/include/lib subdirectories): %s" %(libcurl_lib_path, curl_dir))
         self.extra_objects.append(libcurl_lib_path)
-        
+
         self.check_avoid_stdio()
-        
+
         # make pycurl binary work on windows xp.
         # we use inet_ntop which was added in vista and implement a fallback.
         # our implementation will not be compiled with _WIN32_WINNT targeting
@@ -312,8 +343,8 @@ class ExtensionConfiguration(object):
         configure = configure_windows
     else:
         configure = configure_unix
-    
-    
+
+
     def check_avoid_stdio(self):
         if 'PYCURL_SETUP_OPTIONS' in os.environ and '--avoid-stdio' in os.environ['PYCURL_SETUP_OPTIONS']:
             self.extra_compile_args.append("-DPYCURL_AVOID_STDIO")
@@ -329,7 +360,7 @@ def get_bdist_msi_version_hack():
     import inspect
     import types
     import re
-    
+
     class bdist_msi_version_hack(bdist_msi):
         """ MSI builder requires version to be in the x.x.x format """
         def run(self):
@@ -350,7 +381,7 @@ def get_bdist_msi_version_hack():
             self.distribution.metadata.get_version = \
                 types.MethodType(monkey_get_version, self.distribution.metadata)
             bdist_msi.run(self)
-    
+
     return bdist_msi_version_hack
 
 
@@ -442,7 +473,7 @@ def get_data_files():
 
 def check_manifest():
     import fnmatch
-    
+
     f = open('MANIFEST.in')
     globs = []
     try:
@@ -455,7 +486,7 @@ def check_manifest():
             globs.append(glob)
     finally:
         f.close()
-    
+
     paths = []
     start = os.path.abspath(os.path.dirname(__file__))
     for root, dirs, files in os.walk(start):
@@ -466,7 +497,7 @@ def check_manifest():
                 continue
             rel = os.path.join(root, file)[len(start)+1:]
             paths.append(rel)
-    
+
     for path in paths:
         included = False
         for glob in globs:
@@ -484,11 +515,11 @@ def check_authors():
         contents = f.read()
     finally:
         f.close()
-    
+
     paras = contents.split("\n\n")
     authors_para = paras[AUTHORS_PARAGRAPH]
     authors = [author for author in authors_para.strip().split("\n")]
-    
+
     log = subprocess.check_output(['git', 'log', '--format=%an (%ae)'])
     for author in log.strip().split("\n"):
         author = author.replace('@', ' at ').replace('(', '<').replace(')', '>')
@@ -508,7 +539,7 @@ def convert_docstrings():
     for entry in sorted(os.listdir('doc/docstrings')):
         if not entry.endswith('.rst'):
             continue
-        
+
         name = entry.replace('.rst', '')
         f = open('doc/docstrings/%s' % entry)
         try:
@@ -633,7 +664,7 @@ if __name__ == "__main__":
             split_extension_source = True
         ext = get_extension(split_extension_source=split_extension_source)
         setup_args['ext_modules'] = [ext]
-        
+
         for o in ext.extra_objects:
             assert os.path.isfile(o), o
         setup(**setup_args)

--- a/tests/fake-curl/curl-no-ssl
+++ b/tests/fake-curl/curl-no-ssl
@@ -1,9 +1,12 @@
 #!/bin/sh
 
-# a curl-config that returns -lssl in --libs but not in --static-libs
+# curl -V output without ssl libraries listed.
+# The first line includes the full version of curl,
+# libcurl and other 3rd party libraries linked with the executable.
+# see: http://curl.haxx.se/docs/manpage.html#-V
+# output from Cent OS 6.5.
 
 output=
-
 
 while test -n "$1"; do
   case "$1" in

--- a/tests/fake-curl/curl-no-ssl
+++ b/tests/fake-curl/curl-no-ssl
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# a curl-config that returns -lssl in --libs but not in --static-libs
+
+output=
+
+while test -n "$1"; do
+  case "$1" in
+  -V)
+    echo 'curl 7.35.0 (i686-pc-linux-gnu) libcurl/7.35.0 openssl/1.0.1f zlib/1.2.8 libidn/1.28 librtmp/2.3'
+    echo 'protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtmp rtsp smtp smtps telnet tftp'
+    echo 'features: asynchdns gss-negotiate idn ipv6 largefile ntlm ntlm_wb libz tls-srp'
+    ;;
+  esac
+  shift
+done
+

--- a/tests/fake-curl/curl-no-ssl
+++ b/tests/fake-curl/curl-no-ssl
@@ -4,14 +4,14 @@
 
 output=
 
+
 while test -n "$1"; do
   case "$1" in
   -V)
-    echo 'curl 7.35.0 (i686-pc-linux-gnu) libcurl/7.35.0 openssl/1.0.1f zlib/1.2.8 libidn/1.28 librtmp/2.3'
-    echo 'protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtmp rtsp smtp smtps telnet tftp'
-    echo 'features: asynchdns gss-negotiate idn ipv6 largefile ntlm ntlm_wb libz tls-srp'
+    echo 'curl 7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 zlib/1.2.3 libidn/1.18 libssh2/1.4.2'
+    echo 'Protocols: tftp ftp telnet dict ldap ldaps http file https ftps scp sftp'
+    echo 'Features: GSS-Negotiate IDN IPv6 Largefile NTLM libz'
     ;;
   esac
   shift
 done
-

--- a/tests/fake-curl/curl-with-ssl
+++ b/tests/fake-curl/curl-with-ssl
@@ -1,6 +1,10 @@
 #!/bin/sh
 
-# a curl-config that returns -lssl in --libs but not in --static-libs
+# curl -V showing NSS as one of the linked libraries.
+# The first line includes the full version of curl,
+# libcurl and other 3rd party libraries linked with the executable.
+# see: http://curl.haxx.se/docs/manpage.html#-V
+# output from Cent OS 6.5.
 
 output=
 
@@ -14,4 +18,3 @@ while test -n "$1"; do
   esac
   shift
 done
-

--- a/tests/fake-curl/curl-with-ssl
+++ b/tests/fake-curl/curl-with-ssl
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# a curl-config that returns -lssl in --libs but not in --static-libs
+
+output=
+
+while test -n "$1"; do
+  case "$1" in
+  -V)
+    echo 'curl 7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.15.3 zlib/1.2.3 libidn/1.18 libssh2/1.4.2'
+    echo 'Protocols: tftp ftp telnet dict ldap ldaps http file https ftps scp sftp'
+    echo 'Features: GSS-Negotiate IDN IPv6 Largefile NTLM SSL libz'
+    ;;
+  esac
+  shift
+done
+

--- a/tests/setup_test.py
+++ b/tests/setup_test.py
@@ -46,18 +46,34 @@ def using_curl_config(path, ssl_library=None):
         return decorated
     return decorator
 
+
+def using_curl(path):
+    path = os.path.join(os.path.dirname(__file__), 'fake-curl', path)
+
+    def decorator(fn):
+        @functools.wraps(fn)
+        def decorated(*args, **kwargs):
+            old_path = set_env('PYCURL_CURL', path)
+            try:
+                return fn(*args, **kwargs)
+            finally:
+                reset_env('PYCURL_CURL', old_path)
+        return decorated
+    return decorator
+
 class SetupTest(unittest.TestCase):
     def test_sanity_check(self):
         config = pycurl_setup.ExtensionConfiguration()
         # we should link against libcurl, one would expect
         assert 'curl' in config.libraries
-    
+
     @using_curl_config('curl-config-empty')
+    @using_curl('curl-no-ssl')
     def test_no_ssl(self):
         config = pycurl_setup.ExtensionConfiguration()
         # do not expect anything to do with ssl
         assert 'crypto' not in config.libraries
-    
+
     @using_curl_config('curl-config-libs-and-static-libs')
     def test_does_not_use_static_libs(self):
         config = pycurl_setup.ExtensionConfiguration()
@@ -65,37 +81,38 @@ class SetupTest(unittest.TestCase):
         # --libs succeeded
         assert 'flurby' in config.libraries
         assert 'kzzert' not in config.libraries
-    
+
     @using_curl_config('curl-config-ssl-in-libs')
     def test_ssl_in_libs(self):
         config = pycurl_setup.ExtensionConfiguration()
         # should link against openssl
         assert 'crypto' in config.libraries
-    
+
     @using_curl_config('curl-config-ssl-in-static-libs')
     def test_ssl_in_static_libs(self):
         config = pycurl_setup.ExtensionConfiguration()
         # should link against openssl
         assert 'crypto' in config.libraries
-    
+
     @using_curl_config('curl-config-empty')
+    @using_curl('curl-no-ssl')
     def test_no_ssl_define(self):
         config = pycurl_setup.ExtensionConfiguration()
         # ssl define should be off
         assert 'HAVE_CURL_SSL' not in config.define_symbols
-    
+
     @using_curl_config('curl-config-ssl-in-libs')
     def test_ssl_in_libs_sets_ssl_define(self):
         config = pycurl_setup.ExtensionConfiguration()
         # ssl define should be on
         assert 'HAVE_CURL_SSL' in config.define_symbols
-    
+
     @using_curl_config('curl-config-ssl-in-static-libs')
     def test_ssl_in_static_libs_sets_ssl_define(self):
         config = pycurl_setup.ExtensionConfiguration()
         # ssl define should be on
         assert 'HAVE_CURL_SSL' in config.define_symbols
-    
+
     @using_curl_config('curl-config-ssl-feature-only')
     def test_ssl_feature_sets_ssl_define(self):
         config = pycurl_setup.ExtensionConfiguration()

--- a/tests/setup_test.py
+++ b/tests/setup_test.py
@@ -101,6 +101,13 @@ class SetupTest(unittest.TestCase):
         # ssl define should be off
         assert 'HAVE_CURL_SSL' not in config.define_symbols
 
+    @using_curl_config('curl-config-empty')
+    @using_curl('curl-with-ssl')
+    def test_ssl_define_using_curl_version_info(self):
+        config = pycurl_setup.ExtensionConfiguration()
+        # ssl define should be off
+        assert 'HAVE_CURL_SSL' in config.define_symbols
+
     @using_curl_config('curl-config-ssl-in-libs')
     def test_ssl_in_libs_sets_ssl_define(self):
         config = pycurl_setup.ExtensionConfiguration()


### PR DESCRIPTION

CentOS libcurl is compiled without --static-libs and --libs doesn't displays ssl libraries. This code uses curl version info (curl -V) to find out the right ssl library (NSS, OpenSSL or GnuTLS).