### PR TITLE
Debugfunction now is passed a bytestring in second argument

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,13 @@
 master
 ------
 
+        * The second argument of DEBUGFUNCTION callback is now of type bytes on
+          Python 3. When response body contains non-ASCII data and
+          DEBUGFUNCTION is enabled, this argument would receive non-ASCII data.
+          Which encoding this data is in is unknown by PycURL, and e.g. in
+          the case of HTTP requires parsing response headers. GitHub issue
+          #210, patch by Barry Warsaw with help from Gregory Petukhov.
+
         * Fixed build on GCC 4.4.5 (patch by Travis Jensen).
 
         * Added CURLOPT_GSSAPI_DELEGATION, CURLGSSAPI_DELEGATION_FLAG,

--- a/doc/callbacks.rst
+++ b/doc/callbacks.rst
@@ -45,7 +45,11 @@ The signature of each callback used in pycurl is as follows:
 
 .. function:: PROGRESSFUNCTION(download total, downloaded, upload total, uploaded) -> status
 
-.. function:: DEBUGFUNCTION(debug message type, debug message string) -> None
+.. function:: DEBUGFUNCTION(debug message type, debug message byte string) -> None
+
+    *Changed in version 7.19.5.2:* The second argument to a ``DEBUGFUNCTION``
+    callback is now of type ``bytes`` on Python 3. Previously the argument was
+    of type ``str``.
 
 .. function:: IOCTLFUNCTION(ioctl cmd) -> status
 

--- a/doc/callbacks.rst
+++ b/doc/callbacks.rst
@@ -77,6 +77,8 @@ The signature of each callback used in pycurl is as follows:
     callback is now of type ``bytes`` on Python 3. Previously the argument was
     of type ``str``.
 
+.. _SEEKFUNCTION:
+
 .. function:: SEEKFUNCTION(offset, origin) -> status
 
     Callback for seek operations. Corresponds to `CURLOPT_SEEKFUNCTION`_
@@ -87,7 +89,7 @@ The signature of each callback used in pycurl is as follows:
     Callback for I/O operations. Corresponds to `CURLOPT_IOCTLFUNCTION`_
     in libcurl.
     
-    *Note:* this callback is deprecated. Use :ref:`SEEKFUNCTION` instead.
+    *Note:* this callback is deprecated. Use :ref:`SEEKFUNCTION <SEEKFUNCTION>` instead.
 
 Example: Callbacks for document header and body
 -----------------------------------------------

--- a/doc/callbacks.rst
+++ b/doc/callbacks.rst
@@ -25,28 +25,39 @@ callbacks.
 
 The signature of each callback used in pycurl is as follows:
 
-.. function:: HEADERFUNCTION(string) -> number of characters written
+.. function:: HEADERFUNCTION(byte string) -> number of characters written
 
     Callback for writing received headers. Corresponds to
     `CURLOPT_HEADERFUNCTION`_ in libcurl.
+    
+    On Python 3, the argument is of type ``bytes``.
 
-    The ``HEADERFUNCTION`` callback may also return
-    ``None``, which is an alternate way of indicating that the callback has
-    consumed all of the string passed to it.
+    The ``HEADERFUNCTION`` callback may return the number of bytes written.
+    If this number is not equal to the size of the byte string, this signifies
+    an error and libcurl will abort the request. Returning ``None`` is an
+    alternate way of indicating that the callback has consumed all of the
+    string passed to it and, hence, succeeded.
 
-.. function:: WRITEFUNCTION(string) -> number of characters written
+.. function:: WRITEFUNCTION(byte string) -> number of characters written
 
     Callback for writing data. Corresponds to `CURLOPT_WRITEFUNCTION`_
     in libcurl.
 
-    The ``WRITEFUNCTION`` callback may also return
-    ``None``, which is an alternate way of indicating that the callback has
-    consumed all of the string passed to it.
+    On Python 3, the argument is of type ``bytes``.
 
-.. function:: READFUNCTION(number of characters to read) -> string
+    The ``WRITEFUNCTION`` callback may return the number of bytes written.
+    If this number is not equal to the size of the byte string, this signifies
+    an error and libcurl will abort the request. Returning ``None`` is an
+    alternate way of indicating that the callback has consumed all of the
+    string passed to it and, hence, succeeded.
+
+.. function:: READFUNCTION(number of characters to read) -> byte string
 
     Callback for reading data. Corresponds to `CURLOPT_READFUNCTION`_ in
     libcurl.
+    
+    On Python 3, the callback must return either a byte string or a Unicode
+    string consisting of ASCII code points only.
 
     In addition, ``READFUNCTION`` may return ``READFUNC_ABORT`` or
     ``READFUNC_PAUSE``. See the libcurl documentation for an explanation

--- a/doc/callbacks.rst
+++ b/doc/callbacks.rst
@@ -25,7 +25,19 @@ callbacks.
 
 The signature of each callback used in pycurl is as follows:
 
+.. function:: HEADERFUNCTION(string) -> number of characters written
+
+    Callback for writing received headers. Corresponds to
+    `CURLOPT_HEADERFUNCTION`_ in libcurl.
+
+    The ``HEADERFUNCTION`` callback may also return
+    ``None``, which is an alternate way of indicating that the callback has
+    consumed all of the string passed to it.
+
 .. function:: WRITEFUNCTION(string) -> number of characters written
+
+    Callback for writing data. Corresponds to `CURLOPT_WRITEFUNCTION`_
+    in libcurl.
 
     The ``WRITEFUNCTION`` callback may also return
     ``None``, which is an alternate way of indicating that the callback has
@@ -33,25 +45,31 @@ The signature of each callback used in pycurl is as follows:
 
 .. function:: READFUNCTION(number of characters to read) -> string
 
+    Callback for reading data. Corresponds to `CURLOPT_READFUNCTION`_ in
+    libcurl.
+
     In addition, ``READFUNCTION`` may return ``READFUNC_ABORT`` or
     ``READFUNC_PAUSE``. See the libcurl documentation for an explanation
     of these values.
 
-.. function:: HEADERFUNCTION(string) -> number of characters written
-
-    The ``HEADERFUNCTION`` callback may also return
-    ``None``, which is an alternate way of indicating that the callback has
-    consumed all of the string passed to it.
-
 .. function:: PROGRESSFUNCTION(download total, downloaded, upload total, uploaded) -> status
 
+    Callback for progress meter. Corresponds to `CURLOPT_PROGRESSFUNCTION`_
+    in libcurl.
+
 .. function:: DEBUGFUNCTION(debug message type, debug message byte string) -> None
+
+    Callback for debug information. Corresponds to `CURLOPT_DEBUGFUNCTION`_
+    in libcurl.
 
     *Changed in version 7.19.5.2:* The second argument to a ``DEBUGFUNCTION``
     callback is now of type ``bytes`` on Python 3. Previously the argument was
     of type ``str``.
 
 .. function:: IOCTLFUNCTION(ioctl cmd) -> status
+
+    Callback for I/O operations. Corresponds to `CURLOPT_IOCTLFUNCTION`_
+    in libcurl.
 
 Example: Callbacks for document header and body
 -----------------------------------------------
@@ -131,3 +149,10 @@ file ``examples/file_upload.py`` in the distribution contains example code for
 using READFUNCTION, ``tests/test_cb.py`` shows WRITEFUNCTION and
 HEADERFUNCTION, ``tests/test_debug.py`` shows DEBUGFUNCTION, and
 ``tests/test_getinfo.py`` shows PROGRESSFUNCTION.
+
+.. _CURLOPT_HEADERFUNCTION: http://curl.haxx.se/libcurl/c/CURLOPT_HEADERFUNCTION.html
+.. _CURLOPT_WRITEFUNCTION: http://curl.haxx.se/libcurl/c/CURLOPT_WRITEFUNCTION.html
+.. _CURLOPT_READFUNCTION: http://curl.haxx.se/libcurl/c/CURLOPT_READFUNCTION.html
+.. _CURLOPT_PROGRESSFUNCTION: http://curl.haxx.se/libcurl/c/CURLOPT_PROGRESSFUNCTION.html
+.. _CURLOPT_DEBUGFUNCTION: http://curl.haxx.se/libcurl/c/CURLOPT_DEBUGFUNCTION.html
+.. _CURLOPT_IOCTLFUNCTION: http://curl.haxx.se/libcurl/c/CURLOPT_IOCTLFUNCTION.html

--- a/doc/callbacks.rst
+++ b/doc/callbacks.rst
@@ -77,10 +77,17 @@ The signature of each callback used in pycurl is as follows:
     callback is now of type ``bytes`` on Python 3. Previously the argument was
     of type ``str``.
 
+.. function:: SEEKFUNCTION(offset, origin) -> status
+
+    Callback for seek operations. Corresponds to `CURLOPT_SEEKFUNCTION`_
+    in libcurl.
+
 .. function:: IOCTLFUNCTION(ioctl cmd) -> status
 
     Callback for I/O operations. Corresponds to `CURLOPT_IOCTLFUNCTION`_
     in libcurl.
+    
+    *Note:* this callback is deprecated. Use :ref:`SEEKFUNCTION` instead.
 
 Example: Callbacks for document header and body
 -----------------------------------------------
@@ -166,4 +173,5 @@ HEADERFUNCTION, ``tests/test_debug.py`` shows DEBUGFUNCTION, and
 .. _CURLOPT_READFUNCTION: http://curl.haxx.se/libcurl/c/CURLOPT_READFUNCTION.html
 .. _CURLOPT_PROGRESSFUNCTION: http://curl.haxx.se/libcurl/c/CURLOPT_PROGRESSFUNCTION.html
 .. _CURLOPT_DEBUGFUNCTION: http://curl.haxx.se/libcurl/c/CURLOPT_DEBUGFUNCTION.html
+.. _CURLOPT_SEEKFUNCTION: http://curl.haxx.se/libcurl/c/CURLOPT_SEEKFUNCTION.html
 .. _CURLOPT_IOCTLFUNCTION: http://curl.haxx.se/libcurl/c/CURLOPT_IOCTLFUNCTION.html

--- a/src/easy.c
+++ b/src/easy.c
@@ -929,7 +929,11 @@ debug_callback(CURL *curlobj, curl_infotype type,
     }
 
     /* run callback */
+#if PY_MAJOR_VERSION >= 3
+    arglist = Py_BuildValue("(iy#)", (int)type, buffer, (int)total_size);
+#else
     arglist = Py_BuildValue("(is#)", (int)type, buffer, (int)total_size);
+#endif
     if (arglist == NULL)
         goto verbose_error;
     result = PyEval_CallObject(self->debug_cb, arglist);

--- a/tests/app.py
+++ b/tests/app.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vi:ts=4:et
+
 import time as _time, sys
 import bottle
 try:
@@ -111,3 +114,8 @@ def pause_writer():
 @app.route('/pause')
 def pause():
     return pause_writer()
+
+@app.route('/utf8_body')
+def utf8_body():
+    # bottle encodes the body
+    return 'Дружба народов'

--- a/tests/debug_test.py
+++ b/tests/debug_test.py
@@ -30,23 +30,36 @@ class DebugTest(unittest.TestCase):
         self.curl.perform()
         
         # Some checks with no particular intent
-        self.check(0, 'Trying')
+        self.check(0, util.b('Trying'))
         if util.pycurl_version_less_than(7, 24):
-            self.check(0, 'connected')
+            self.check(0, util.b('connected'))
         else:
-            self.check(0, 'Connected to localhost')
-        self.check(0, 'port 8380')
+            self.check(0, util.b('Connected to localhost'))
+        self.check(0, util.b('port 8380'))
         # request
-        self.check(2, 'GET /success HTTP/1.1')
+        self.check(2, util.b('GET /success HTTP/1.1'))
         # response
-        self.check(1, 'HTTP/1.0 200 OK')
-        self.check(1, 'Content-Length: 7')
+        self.check(1, util.b('HTTP/1.0 200 OK'))
+        self.check(1, util.b('Content-Length: 7'))
         # result
-        self.check(3, 'success')
+        self.check(3, util.b('success'))
+    
+    # test for #210
+    def test_debug_unicode(self):
+        self.curl.setopt(pycurl.VERBOSE, 1)
+        self.curl.setopt(pycurl.DEBUGFUNCTION, self.debug_function)
+        self.curl.setopt(pycurl.URL, 'http://localhost:8380/utf8_body')
+        sio = util.BytesIO()
+        self.curl.setopt(pycurl.WRITEFUNCTION, sio.write)
+        self.curl.perform()
+        
+        # 3 = response body
+        search = util.b('\xd0\x94\xd1\x80\xd1\x83\xd0\xb6\xd0\xb1\xd0\xb0 \xd0\xbd\xd0\xb0\xd1\x80\xd0\xbe\xd0\xb4\xd0\xbe\xd0\xb2').decode('utf8')
+        self.check(3, search.encode('utf8'))
     
     def check(self, wanted_t, wanted_b):
         for t, b in self.debug_entries:
             if t == wanted_t and wanted_b in b:
                 return
         assert False, "%d: %s not found in debug entries\nEntries are:\n%s" % \
-            (wanted_t, wanted_b, repr(self.debug_entries))
+            (wanted_t, repr(wanted_b), repr(self.debug_entries))


### PR DESCRIPTION
Fixes #210, supersedes #211.