### PR TITLE
Fix memory leak in Curl's HTTPPOST setopt for multiple FORM_BUFFERPTR.

### DIFF
--- a/src/easy.c
+++ b/src/easy.c
@@ -1593,12 +1593,14 @@ do_curl_setopt(CurlObject *self, PyObject *args)
                         else if (val == CURLFORM_BUFFERPTR) {
                             PyObject *obj = PyTuple_GET_ITEM(t, j+1);
 
-                            ref_params = PyList_New((Py_ssize_t)0);
                             if (ref_params == NULL) {
-                                PyText_EncodedDecref(oencoded_obj);
-                                PyMem_Free(forms);
-                                curl_formfree(post);
-                                return NULL;
+                                ref_params = PyList_New((Py_ssize_t)0);
+                                if (ref_params == NULL) {
+                                    PyText_EncodedDecref(oencoded_obj);
+                                    PyMem_Free(forms);
+                                    curl_formfree(post);
+                                    return NULL;
+                                }
                             }
                             
                             /* Ensure that the buffer remains alive until curl_easy_cleanup() */


### PR DESCRIPTION
Fix a memory leak in Curl object's HTTPPOST setopt where passing
multiple FORM_BUFFERPTR option would only release the last
FORM_BUFFERPTR option / the internal ref_params list that holds
the buffer for FORM_BUFFERPTR was being set to a new list for
each FORM_BUFFERPTR option.

# steps
1. View initial memory
2. Call Curl object's setopt HTTPPOST with one FORM_BUFFERPTR option 2000000 times.
3. View memory.
4. Call Curl object's setopt HTTPPOST with two FORM_BUFFERPTR options 2000000 times.
5. View memory.
6. Unset the HTTPPOST option / close the Curl object and set it to None.


# pre-patch
```
Python 2.7.9 (default, Apr  2 2015, 15:33:21) 
[GCC 4.9.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> os.getpid()
2691
>>> import pycurl
>>> c = pycurl.Curl()
>>> 



# View initial memory.
zsh: suspended  PYTHONPATH=./build/lib.linux-x86_64-2.7 python
cclayton@ubuntu ~/dev/github/clintclayton/pycurl
 % ps u 2691
USER        PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
cclayton   2691  0.1  1.3 121724 13368 pts/6    T    00:40   0:00 python
cclayton@ubuntu ~/dev/github/clintclayton/pycurl
 % %
[2]  - continued  PYTHONPATH=./build/lib.linux-x86_64-2.7 python




# Set a single FORM_BUFFERPTR option 2000000 times.
>>> for i in xrange(2000000):
...   c.setopt(pycurl.HTTPPOST, [("post1", (pycurl.FORM_BUFFERPTR, "data1"))])                                                        
... 
>>> 



# View memory after setting a single FORM_BUFFERPTR option 2000000 times.
zsh: suspended  PYTHONPATH=./build/lib.linux-x86_64-2.7 python
cclayton@ubuntu ~/dev/github/clintclayton/pycurl
 % ps u 2691
USER        PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
cclayton   2691  2.5  1.3 121724 13368 pts/6    T    00:40   0:02 python
cclayton@ubuntu ~/dev/github/clintclayton/pycurl
 % %
[2]  - continued  PYTHONPATH=./build/lib.linux-x86_64-2.7 python



# Set two FORM_BUFFERPTR options 2000000 times.
>>> for i in xrange(2000000):
...   c.setopt(pycurl.HTTPPOST, [("post1", (pycurl.FORM_BUFFERPTR, "data1")), ("post2", (pycurl.FORM_BUFFERPTR, "data2"))])
... 
>>> 



# View memory after setting two FORM_BUFFERPTR options 2000000 times (using a lot of memory).
zsh: suspended  PYTHONPATH=./build/lib.linux-x86_64-2.7 python
cclayton@ubuntu ~/dev/github/clintclayton/pycurl
 % ps u 2691
USER        PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
cclayton   2691  9.9 24.9 358372 249856 pts/6   T    00:40   0:11 python
cclayton@ubuntu ~/dev/github/clintclayton/pycurl
 % %
[2]  - continued  PYTHONPATH=./build/lib.linux-x86_64-2.7 python



# Cleanup
>>> c.unsetopt(pycurl.HTTPPOST)
>>> c.close()
>>> c = None
>>> 
zsh: suspended  PYTHONPATH=./build/lib.linux-x86_64-2.7 python
cclayton@ubuntu ~/dev/github/clintclayton/pycurl
 % ps u 2691
USER        PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
cclayton   2691  8.0 24.9 358372 249856 pts/6   T    00:40   0:11 python
```


## gdb
```
>>> import pycurl
>>> c = pycurl.Curl()
>>> c.setopt(pycurl.HTTPPOST, [("post1", (pycurl.FORM_BUFFERPTR, "data1")), ("post2", (pycurl.FORM_BUFFERPTR, "data2"))])

Breakpoint 1, 0x00007ffff5cf7c60 in curl_formadd () from /usr/lib/x86_64-linux-gnu/libcurl.so.4
(gdb) bt 2
#0  0x00007ffff5cf7c60 in curl_formadd () from /usr/lib/x86_64-linux-gnu/libcurl.so.4
#1  0x00007ffff5f5ddbb in do_curl_setopt (self=<optimized out>, args=<optimized out>) at src/easy.c:1620
(More stack frames follow...)
(gdb) finish
Run till exit from #0  0x00007ffff5cf7c60 in curl_formadd () from /usr/lib/x86_64-linux-gnu/libcurl.so.4
do_curl_setopt (self=<optimized out>, args=<optimized out>) at src/easy.c:1625
1625                        PyText_EncodedDecref(oencoded_obj);
(gdb) p ref_params
$4 = ['data1']
(gdb) c
Continuing.

Breakpoint 1, 0x00007ffff5cf7c60 in curl_formadd () from /usr/lib/x86_64-linux-gnu/libcurl.so.4
(gdb) bt 2
#0  0x00007ffff5cf7c60 in curl_formadd () from /usr/lib/x86_64-linux-gnu/libcurl.so.4
#1  0x00007ffff5f5ddbb in do_curl_setopt (self=<optimized out>, args=<optimized out>) at src/easy.c:1620
(More stack frames follow...)
(gdb) finish
Run till exit from #0  0x00007ffff5cf7c60 in curl_formadd () from /usr/lib/x86_64-linux-gnu/libcurl.so.4
do_curl_setopt (self=<optimized out>, args=<optimized out>) at src/easy.c:1625
1625                        PyText_EncodedDecref(oencoded_obj);
(gdb) p ref_params
$5 = ['data2']
```


# with patch:
```
Python 2.7.9 (default, Apr  2 2015, 15:33:21) 
[GCC 4.9.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> import pycurl
>>> os.getpid()
3184
>>> c = pycurl.Curl()
>>> 



# View initial memory
zsh: suspended  PYTHONPATH=./build/lib.linux-x86_64-2.7 python
cclayton@ubuntu ~/dev/github/clintclayton/pycurl
 % ps u 3184
USER        PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
cclayton   3184  0.1  1.2 121724 12956 pts/6    T    00:51   0:00 python
cclayton@ubuntu ~/dev/github/clintclayton/pycurl
 % %                                             
[3]    continued  PYTHONPATH=./build/lib.linux-x86_64-2.7 python



# set a single FORM_BUFFERPTR option 2000000 times.
>>> for i in xrange(2000000):
...   c.setopt(pycurl.HTTPPOST, [("post1", (pycurl.FORM_BUFFERPTR, "data1"))])                                                                                  
... 
>>> 



# View memory after setting a single FORM_BUFFERPTR option 2000000 times.
zsh: suspended  PYTHONPATH=./build/lib.linux-x86_64-2.7 python
cclayton@ubuntu ~/dev/github/clintclayton/pycurl
 % ps u 3184
USER        PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
cclayton   3184  3.7  1.2 121724 12956 pts/6    T    00:51   0:02 python
cclayton@ubuntu ~/dev/github/clintclayton/pycurl
 % %
[3]    continued  PYTHONPATH=./build/lib.linux-x86_64-2.7 python



# Set two FORM_BUFFERPTR options 2000000 times.
>>> for i in xrange(2000000):
...   c.setopt(pycurl.HTTPPOST, [("post1", (pycurl.FORM_BUFFERPTR, "data1")), ("post2", (pycurl.FORM_BUFFERPTR, "data2"))])
... 
>>> 



# View memory after setting two FORM_BUFFERPTR options 2000000 times (no more leak) .
zsh: suspended  PYTHONPATH=./build/lib.linux-x86_64-2.7 python
cclayton@ubuntu ~/dev/github/clintclayton/pycurl
 % ps u 3184
USER        PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
cclayton   3184  6.5  1.2 121724 12956 pts/6    T    00:51   0:05 python
cclayton@ubuntu ~/dev/github/clintclayton/pycurl
 % %
[3]    continued  PYTHONPATH=./build/lib.linux-x86_64-2.7 python



# Cleaup
>>> c.unsetopt(pycurl.HTTPPOST)
>>> c.close()
>>> c = None
>>> exit()
```
## gdb
```
>>> import pycurl
>>> c = pycurl.Curl()
>>> c.setopt(pycurl.HTTPPOST, [("post1", (pycurl.FORM_BUFFERPTR, "data1")), ("post2", (pycurl.FORM_BUFFERPTR, "data2"))])

Breakpoint 1, 0x00007ffff5cf7c60 in curl_formadd () from /usr/lib/x86_64-linux-gnu/libcurl.so.4
(gdb) bt 2
#0  0x00007ffff5cf7c60 in curl_formadd () from /usr/lib/x86_64-linux-gnu/libcurl.so.4
#1  0x00007ffff5f5de43 in do_curl_setopt (self=<optimized out>, args=<optimized out>) at src/easy.c:1622
(More stack frames follow...)
(gdb) finish
Run till exit from #0  0x00007ffff5cf7c60 in curl_formadd () from /usr/lib/x86_64-linux-gnu/libcurl.so.4
do_curl_setopt (self=<optimized out>, args=<optimized out>) at src/easy.c:1627
1627                        PyText_EncodedDecref(oencoded_obj);
(gdb) p ref_params 
$1 = ['data1']
(gdb) c
Continuing.

Breakpoint 1, 0x00007ffff5cf7c60 in curl_formadd () from /usr/lib/x86_64-linux-gnu/libcurl.so.4
(gdb) bt 2
#0  0x00007ffff5cf7c60 in curl_formadd () from /usr/lib/x86_64-linux-gnu/libcurl.so.4
#1  0x00007ffff5f5de43 in do_curl_setopt (self=<optimized out>, args=<optimized out>) at src/easy.c:1622
(More stack frames follow...)
(gdb) finish
Run till exit from #0  0x00007ffff5cf7c60 in curl_formadd () from /usr/lib/x86_64-linux-gnu/libcurl.so.4
do_curl_setopt (self=<optimized out>, args=<optimized out>) at src/easy.c:1627
1627                        PyText_EncodedDecref(oencoded_obj);
(gdb) p ref_params
$2 = ['data1', 'data2']
```


