### PR TITLE
Fix use after free in Curl object's HTTPPOST setopt with unicode FORM…

### DIFF
--- a/src/easy.c
+++ b/src/easy.c
@@ -1591,7 +1591,7 @@ do_curl_setopt(CurlObject *self, PyObject *args)
                             ++k;
                         }
                         else if (val == CURLFORM_BUFFERPTR) {
-                            PyObject *obj = PyTuple_GET_ITEM(t, j+1);
+                            PyObject *obj = NULL;
 
                             ref_params = PyList_New((Py_ssize_t)0);
                             if (ref_params == NULL) {
@@ -1600,7 +1600,15 @@ do_curl_setopt(CurlObject *self, PyObject *args)
                                 curl_formfree(post);
                                 return NULL;
                             }
-                            
+
+                            /* Keep a reference to the object that holds the ostr buffer. */
+                            if (oencoded_obj == NULL) {
+                                obj = PyTuple_GET_ITEM(t, j+1);
+                            }
+                            else {
+                                obj = oencoded_obj;
+                            }
+
                             /* Ensure that the buffer remains alive until curl_easy_cleanup() */
                             if (PyList_Append(ref_params, obj) != 0) {
                                 PyText_EncodedDecref(oencoded_obj);


### PR DESCRIPTION
…_BUFFERPTR.

Fixes use after free in the Curl object's HTTPPOST setopt when a unicode value
is passed as a value with a FORM_BUFFERPTR. The str object created from
the passed in unicode object would have its buffer used but the unicode object
would be stored instead of the str object.


# Info
When a unicode object is passed with a FORM_BUFFERPTR its converted to a
str object, oencoded_obj, and its buffer is returned as the out parameter for ostr in PyText_AsStringAndSize.
Since the ostr buffer needs to be kept alive until curl_easy_cleanup when adding the ostr's owner
object to the ref_params list if a unicode object was passed in to do_curl_setopt ostr is part of
the converted str, oencoded_obj's, buffer, so oencoded_obj needs to be kept in the list, otherwise if
oencoded_obj wasn't created the ostr buffer is part the passed in object str object
and that reference needs to be kept around.

Below shows this using GDB.

# Before Patch
```
>>> import pycurl
>>> c = pycurl.Curl()
>>> 
Program received signal SIGINT, Interrupt.
0x00007ffff78ee723 in __select_nocancel () at ../sysdeps/unix/syscall-template.S:81
81      ../sysdeps/unix/syscall-template.S: No such file or directory.
(gdb) b PyText_AsStringAndSize 
Breakpoint 1 at 0x7ffff5f638d0: file src/stringcompat.c, line 10.
(gdb) c
Continuing.

>>> c.setopt(pycurl.HTTPPOST, [("post", (pycurl.FORM_BUFFERPTR, u"post_data_unicode"))])                                                                   



# Skip first PyText_AsStringAndSize
Breakpoint 1, PyText_AsStringAndSize (obj='post', buffer=0x7fffffffd9f8, length=0x7fffffffda08, encoded_obj=0x7fffffffd9e0) at src/stringcompat.c:10
10          if (PyByteStr_Check(obj)) {
(gdb) c
Continuing.



# Show the passed in obj and finish the second PyText_AsStringAndSize
Breakpoint 1, PyText_AsStringAndSize (obj=u'post_data_unicode', buffer=0x7fffffffda18, length=0x7fffffffda20, encoded_obj=0x7fffffffd9f0)
    at src/stringcompat.c:10
10          if (PyByteStr_Check(obj)) {
(gdb) bt 2
#0  PyText_AsStringAndSize (obj=u'post_data_unicode', buffer=0x7fffffffda18, length=0x7fffffffda20, encoded_obj=0x7fffffffd9f0) at src/stringcompat.c:10
#1  0x00007ffff5f5d591 in do_curl_setopt (self=<optimized out>, args=<optimized out>) at src/easy.c:1577
(More stack frames follow...)
(gdb) x obj
0x7ffff7e964e0: 0x00000003
(gdb) p (PyObject *)0x7ffff7e964e0
$1 = u'post_data_unicode'
(gdb) finish
Run till exit from #0  PyText_AsStringAndSize (obj=u'post_data_unicode', buffer=0x7fffffffda18, length=0x7fffffffda20, encoded_obj=0x7fffffffd9f0)
    at src/stringcompat.c:10
0x00007ffff5f5d591 in do_curl_setopt (self=<optimized out>, args=<optimized out>) at src/easy.c:1577
1577                            if (PyText_AsStringAndSize(PyTuple_GET_ITEM(t, j+1), &ostr, &olen, &oencoded_obj)) {
Value returned is $2 = 0


# Print the oencoded_obj's value
(gdb) p *(PyStringObject **)0x7fffffffd9f0
$3 = (PyStringObject *) 0x7ffff7e9ef80

# Print the oencoded_obj's ref count
(gdb) p ((PyStringObject *)0x7ffff7e9ef80)->ob_refcnt 
$4 = 1

# Print the oencoded_obj's string buffer
(gdb) p &((PyStringObject *)0x7ffff7e9ef80)->ob_sval
$5 = (char (*)[1]) 0x7ffff7e9efa4

# Print the ostr's buffer (the same buffer as oencoded_obj)
(gdb) p *(char **)0x7fffffffda18
$6 = 0x7ffff7e9efa4 "post_data_unicode"



# Finish function and show ref counts
(gdb) c
Continuing.
>>> 
Program received signal SIGINT, Interrupt.
0x00007ffff78ee723 in __select_nocancel () at ../sysdeps/unix/syscall-template.S:81
81      ../sysdeps/unix/syscall-template.S: No such file or directory.

# Show the oencoded_obj's refs. (no longer valid but its buffer was used for ostr)
(gdb) p ((PyStringObject *)0x7ffff7e9ef80)->ob_refcnt 
$7 = 140737352691416

# Show the Unicode object's refs
(gdb) p ((PyObject *)0x7ffff7e964e0)->ob_refcnt 
$8 = 1
(gdb) 

```


# With Patch
```
>>> import pycurl
>>> c = pycurl.Curl()
>>> 
Program received signal SIGINT, Interrupt.
0x00007ffff78ee723 in __select_nocancel () at ../sysdeps/unix/syscall-template.S:81
81      ../sysdeps/unix/syscall-template.S: No such file or directory.
(gdb) break PyText_AsStringAndSize 
Breakpoint 1 at 0x7ffff5f638e0: file src/stringcompat.c, line 10.
(gdb) c
Continuing.

>>> c.setopt(pycurl.HTTPPOST, [("post", (pycurl.FORM_BUFFERPTR, u"post_data_unicode"))])                                                                        



# Skip first PyText_AsStringAndSize
Breakpoint 1, PyText_AsStringAndSize (obj='post', buffer=0x7fffffffd9f8, length=0x7fffffffda08, encoded_obj=0x7fffffffd9e0) at src/stringcompat.c:10
10          if (PyByteStr_Check(obj)) {
(gdb) c
Continuing.



# Print the passed in Unicode object and finish the second / oencoded_obj PyText_AsStringAndSize
Breakpoint 1, PyText_AsStringAndSize (obj=u'post_data_unicode', buffer=0x7fffffffda18, length=0x7fffffffda20, encoded_obj=0x7fffffffd9f0)
    at src/stringcompat.c:10
10          if (PyByteStr_Check(obj)) {
(gdb) bt 2
#0  PyText_AsStringAndSize (obj=u'post_data_unicode', buffer=0x7fffffffda18, length=0x7fffffffda20, encoded_obj=0x7fffffffd9f0) at src/stringcompat.c:10
#1  0x00007ffff5f5d590 in do_curl_setopt (self=<optimized out>, args=<optimized out>) at src/easy.c:1577
(More stack frames follow...)
(gdb) x obj
0x7ffff7e964e0: 0x00000003
(gdb) p (PyObject *)0x7ffff7e964e0
$1 = u'post_data_unicode'
(gdb) finish
Run till exit from #0  PyText_AsStringAndSize (obj=u'post_data_unicode', buffer=0x7fffffffda18, length=0x7fffffffda20, encoded_obj=0x7fffffffd9f0)
    at src/stringcompat.c:10
0x00007ffff5f5d590 in do_curl_setopt (self=<optimized out>, args=<optimized out>) at src/easy.c:1577
1577                            if (PyText_AsStringAndSize(PyTuple_GET_ITEM(t, j+1), &ostr, &olen, &oencoded_obj)) {
Value returned is $2 = 0



# Print value set in oencoded_obj
(gdb) p *((PyStringObject **) 0x7fffffffd9f0)                                                                                                                   
$3 = (PyStringObject *) 0x7ffff7e9ef80

# oencoded_obj ref count
(gdb) p ((PyStringObject *) 0x7ffff7e9ef80)->ob_refcnt 
$4 = 1
 
# oencoded_obj internal string buffer
(gdb) p &((PyStringObject *) 0x7ffff7e9ef80)->ob_sval 
$5 = (char (*)[1]) 0x7ffff7e9efa4

# returned ostr (same as oencoded_obj's string buffer)
(gdb) p *(char **)0x7fffffffda18
$6 = 0x7ffff7e9efa4 "post_data_unicode"

# finish do_curl_setopt function
(gdb) c
Continuing.
>>> 



# View object ref counts
Program received signal SIGINT, Interrupt.
0x00007ffff78ee723 in __select_nocancel () at ../sysdeps/unix/syscall-template.S:81
81      ../sysdeps/unix/syscall-template.S: No such file or directory.

# oencoded_obj
(gdb) p ((PyStringObject *) 0x7ffff7e9ef80)->ob_refcnt 
$7 = 1

# passed in unicode object
(gdb) p ((PyObject *)0x7ffff7e964e0)->ob_refcnt
$8 = 0


# Set a str for FORM_BUFFERPTR
# (same as above except oencoded_obj from PyText_AsStringAndSize is
# returned NULL and the buffer and ref are kept from the passed in string object.)

>>> c.setopt(pycurl.HTTPPOST, [("post", (pycurl.FORM_BUFFERPTR, "post_data_str"))])                                                                             



# Skip first.
Breakpoint 1, PyText_AsStringAndSize (obj='post', buffer=0x7fffffffd9f8, length=0x7fffffffda08, encoded_obj=0x7fffffffd9e0) at src/stringcompat.c:10
10          if (PyByteStr_Check(obj)) {
(gdb) c
Continuing.



# Print the passed in str object and finish the function.
Breakpoint 1, PyText_AsStringAndSize (obj='post_data_str', buffer=0x7fffffffda18, length=0x7fffffffda20, encoded_obj=0x7fffffffd9f0) at src/stringcompat.c:10
10          if (PyByteStr_Check(obj)) {
(gdb) bt 2
#0  PyText_AsStringAndSize (obj='post_data_str', buffer=0x7fffffffda18, length=0x7fffffffda20, encoded_obj=0x7fffffffd9f0) at src/stringcompat.c:10
#1  0x00007ffff5f5d590 in do_curl_setopt (self=<optimized out>, args=<optimized out>) at src/easy.c:1577
(More stack frames follow...)
(gdb) x obj
0x7ffff7ea10a0: 0x00000003
(gdb) p (PyStringObject *) 0x7ffff7ea10a0
$9 = (PyStringObject *) 0x7ffff7ea10a0
(gdb) finish
Run till exit from #0  PyText_AsStringAndSize (obj='post_data_str', buffer=0x7fffffffda18, length=0x7fffffffda20, encoded_obj=0x7fffffffd9f0)
    at src/stringcompat.c:10
0x00007ffff5f5d590 in do_curl_setopt (self=<optimized out>, args=<optimized out>) at src/easy.c:1577
1577                            if (PyText_AsStringAndSize(PyTuple_GET_ITEM(t, j+1), &ostr, &olen, &oencoded_obj)) {
Value returned is $10 = 0

# Print the oencoded_obj is empty
(gdb) p *(PyStringObject **)0x7fffffffd9f0
$11 = (PyStringObject *) 0x0

# Print the passed in str's ref count 
(gdb) p ((PyStringObject *) 0x7ffff7ea10a0)->ob_refcnt 
$12 = 3

# Print the passed in str's buffer
(gdb) p &((PyStringObject *) 0x7ffff7ea10a0)->ob_sval
$13 = (char (*)[1]) 0x7ffff7ea10c4

# Print the ostr's buffer (same as the passed in str's buffer).
(gdb) p *((char **) 0x7fffffffda18)
$14 = 0x7ffff7ea10c4 "post_data_str"

# finish the setopt function.
(gdb) c
Continuing.
>>> 
Program received signal SIGINT, Interrupt.
0x00007ffff78ee723 in __select_nocancel () at ../sysdeps/unix/syscall-template.S:81
81      ../sysdeps/unix/syscall-template.S: No such file or directory.


# View that there is still a ref on the passed in str object.
(gdb) p ((PyStringObject *) 0x7ffff7ea10a0)->ob_refcnt 
$15 = 1

```

