### PR TITLE
Add --with-openssl and accept it on Windows to compile OpenSSL crypto…

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,12 @@
 master
 ------
 
+        * --with-openssl and its --win-ssl alias setup.py options are now
+          accepted under Windows in order to use OpenSSL's crypto locks
+          when building against OpenSSL.
+
+        * --with-openssl added as an alias for --with-ssl option to setup.py.
+
         * Official Windows builds are now linked against C-Ares and libssh2.
 
         * Official Windows builds are now linked against OpenSSL instead of

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -51,7 +51,11 @@ It will then fail at runtime as follows::
 
 To fix this, you need to tell ``setup.py`` what SSL backend is used::
 
-    python setup.py --with-[ssl|gnutls|nss] install
+    python setup.py --with-[openssl|gnutls|nss] install
+
+Note: as of PycURL 7.21.5, setup.py accepts ``--with-openssl`` option to
+indicate that libcurl is built against OpenSSL. ``--with-ssl`` is an alias
+for ``--with-openssl`` and continues to be accepted for backwards compatibility.
 
 You can also ask ``setup.py`` to obtain SSL backend information from installed
 libcurl shared library, as follows:
@@ -81,10 +85,6 @@ note above)::
 
     export PYCURL_SSL_LIBRARY=[openssl|gnutls|nss]
     easy_install pycurl
-
-Please note the difference in spelling that concerns OpenSSL: the command-line
-argument is --with-ssl, to match libcurl, but the environment variable value is
-"openssl".
 
 
 pip and cached pycurl package
@@ -178,7 +178,10 @@ Additional Windows setup.py options:
   import library. The default is ``libcurl.lib`` which is appropriate for
   static linking and is sometimes the correct choice for dynamic linking as
   well. The other possibility for dynamic linking is ``libcurl_imp.lib``.
-- ``--avoid-stdio``: on windows, a process and each library it is using
+- ``--with-openssl``: use OpenSSL crypto locks when libcurl was built against
+  OpenSSL.
+- ``--with-ssl``: legacy alias for ``--with-openssl``.
+- ``--avoid-stdio``: on Windows, a process and each library it is using
   may be linked to its own version of the C runtime (msvcrt).
   FILE pointers from one C runtime may not be passed to another C runtime.
   This option prevents direct passing of FILE pointers from Python to libcurl,

--- a/tests/setup_test.py
+++ b/tests/setup_test.py
@@ -178,6 +178,17 @@ class SetupTest(unittest.TestCase):
         assert 'HAVE_CURL_NSS' not in config.define_symbols
     
     @using_curl_config('curl-config-empty')
+    def test_with_openssl_library(self):
+        config = pycurl_setup.ExtensionConfiguration(['',
+            '--with-openssl'])
+        assert 'HAVE_CURL_SSL' in config.define_symbols
+        assert 'HAVE_CURL_OPENSSL' in config.define_symbols
+        assert 'crypto' in config.libraries
+        
+        assert 'HAVE_CURL_GNUTLS' not in config.define_symbols
+        assert 'HAVE_CURL_NSS' not in config.define_symbols
+    
+    @using_curl_config('curl-config-empty')
     def test_with_gnutls_library(self):
         config = pycurl_setup.ExtensionConfiguration(['',
             '--with-gnutls'])

--- a/winbuild.py
+++ b/winbuild.py
@@ -583,7 +583,12 @@ class PycurlBuilder(Builder):
                     libcurl_arg = '--use-libcurl-dll'
                 else:
                     libcurl_arg = '--libcurl-lib-name=libcurl_a.lib'
-                f.write("%s setup.py %s --curl-dir=%s %s\n" % (
+                if self.use_openssl:
+                    libcurl_arg += ' --with-openssl'
+                    openssl_builder = OpensslBuilder(bitness=self.bitness, vc_version=self.vc_version, openssl_version=self.openssl_version)
+                    f.write("set include=%%include%%;%s\n" % openssl_builder.include_path)
+                    f.write("set lib=%%lib%%;%s\n" % openssl_builder.lib_path)
+                    f.write("%s setup.py %s --curl-dir=%s %s\n" % (
                     self.python_path, ' '.join(targets), libcurl_dir, libcurl_arg))
             if 'bdist' in targets:
                 zip_basename_orig = 'pycurl-%s.%s.zip' % (


### PR DESCRIPTION
… locks.

* Add --with-openssl as an alias for --with-ssl.
  --with-ssl is misleading so let's fix it.

* Accept --with-openssl and --with-ssl on Windows to indicate that
  libcurl was built against OpenSSL. --with-gnutls and --with-nss are
  not accepted on Windows because I don't need them yet.

* When winbuild.py has use_openssl=True, pass --with-openssl to setup.py
  so that OpenSSL crypto locks are used by PycURL. This makes
  PycURL importable whereas previously importing it complained
  about SSL backend mismatch between compile time and link time.