### PR TITLE
Use bytes for OPENSOCKETFUNCTION address with AF_UNIX, as documented

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,11 @@
 master
 ------
 
+        * OPENSOCKETFUNCTION callback for AF_UNIX sockets was mistakenly
+          invoked with the address as a `string' rather than `bytes' on
+          Python 3. The callback now receives a `bytes' instance as was
+          documented.
+
 
 Version 7.21.5 [requires libcurl-7.19.0 or better] - 2016-01-05
 ---------------------------------------------------------------

--- a/src/easy.c
+++ b/src/easy.c
@@ -609,7 +609,11 @@ convert_protocol_address(struct sockaddr* saddr, unsigned int saddrlen)
         {
             struct sockaddr_un* sun = (struct sockaddr_un*)saddr;
 
+#if PY_MAJOR_VERSION >= 3
+            res_obj = Py_BuildValue("y", sun->sun_path);
+#else
             res_obj = Py_BuildValue("s", sun->sun_path);
+#endif
         }
         break;
 #endif

--- a/tests/open_socket_cb_test.py
+++ b/tests/open_socket_cb_test.py
@@ -104,9 +104,10 @@ class OpenSocketCbTest(unittest.TestCase):
         assert socket_open_called_unix
         if util.py3:
             assert isinstance(socket_open_address, bytes)
+            self.assertEqual(b'/tmp/pycurl-test-path.sock', socket_open_address)
         else:
             assert isinstance(socket_open_address, str)
-        self.assertEqual('/tmp/pycurl-test-path.sock', socket_open_address)
+            self.assertEqual('/tmp/pycurl-test-path.sock', socket_open_address)
 
     def test_socket_open_none(self):
         self.curl.setopt(pycurl.OPENSOCKETFUNCTION, None)


### PR DESCRIPTION
Fixes #357 