### PR TITLE
trigger ImportError for win32 instead of AttributeError

### DIFF
--- a/python/curl/__init__.py
+++ b/python/curl/__init__.py
@@ -23,7 +23,8 @@ else:
 
 try:
     import signal
-    signal.signal(signal.SIGPIPE, signal.SIG_IGN)
+    from signal import SIGPIPE, SIG_IGN
+    signal.signal(SIGPIPE, SIG_IGN)
 except ImportError:
     pass
 


### PR DESCRIPTION
Without this pycurl is unusable on win32.
