### PR TITLE
Allow overriding of pyflakes executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ SHELL = /bin/sh
 
 PYTHON = python
 NOSETESTS = nosetests
+PYFLAKES = pyflakes
 
 # -c on linux
 # freebsd does not understand -c
@@ -98,7 +99,7 @@ do-test:
 	cd tests/fake-curl/libcurl && make
 	./tests/run.sh
 	./tests/ext/test-suite.sh
-	pyflakes python examples tests setup.py winbuild.py
+	$(PYFLAKES) python examples tests setup.py winbuild.py
 
 test: build do-test
 test-release: build-release do-test


### PR DESCRIPTION
We need to be able to build with pyflakes-3.X.