### PR TITLE
Close connections in tests by default.

### DIFF
--- a/tests/certinfo_test.py
+++ b/tests/certinfo_test.py
@@ -13,16 +13,16 @@ setup_module, teardown_module = appmanager.setup(('app', 8383, dict(ssl=True)))
 
 class CertinfoTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
-    
+        self.curl = util.default_test_curl()
+
     def tearDown(self):
         self.curl.close()
-    
+
     # CURLOPT_CERTINFO was introduced in libcurl-7.19.1
     @util.min_libcurl(7, 19, 1)
     def test_certinfo_option(self):
         assert hasattr(pycurl, 'OPT_CERTINFO')
-    
+
     # CURLOPT_CERTINFO was introduced in libcurl-7.19.1
     @util.min_libcurl(7, 19, 1)
     @util.only_ssl
@@ -34,10 +34,10 @@ class CertinfoTest(unittest.TestCase):
         self.curl.setopt(pycurl.SSL_VERIFYPEER, 0)
         self.curl.perform()
         assert sio.getvalue().decode() == 'success'
-        
+
         certinfo = self.curl.getinfo(pycurl.INFO_CERTINFO)
         self.assertEqual([], certinfo)
-    
+
     # CURLOPT_CERTINFO was introduced in libcurl-7.19.1
     @util.min_libcurl(7, 19, 1)
     @util.only_ssl
@@ -45,7 +45,7 @@ class CertinfoTest(unittest.TestCase):
         # CURLOPT_CERTINFO only works with OpenSSL
         if 'openssl' not in pycurl.version.lower():
             raise nose.plugins.skip.SkipTest('libcurl does not use openssl')
-        
+
         self.curl.setopt(pycurl.URL, 'https://localhost:8383/success')
         sio = util.BytesIO()
         self.curl.setopt(pycurl.WRITEFUNCTION, sio.write)
@@ -54,7 +54,7 @@ class CertinfoTest(unittest.TestCase):
         self.curl.setopt(pycurl.SSL_VERIFYPEER, 0)
         self.curl.perform()
         assert sio.getvalue().decode() == 'success'
-        
+
         certinfo = self.curl.getinfo(pycurl.INFO_CERTINFO)
         # self signed certificate, one certificate in chain
         assert len(certinfo) == 1

--- a/tests/close_socket_cb_test.py
+++ b/tests/close_socket_cb_test.py
@@ -13,7 +13,7 @@ setup_module, teardown_module = appmanager.setup(('app', 8380))
 
 class CloseSocketCbTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
+        self.curl = util.default_test_curl()
         self.curl.setopt(self.curl.URL, 'http://localhost:8380/success')
         self.curl.setopt(pycurl.FORBID_REUSE, True)
 
@@ -64,7 +64,7 @@ class CloseSocketCbTest(unittest.TestCase):
 
 class CloseSocketCbUnsetTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
+        self.curl = util.default_test_curl()
 
     @util.min_libcurl(7, 21, 7)
     def test_closesocketfunction_none(self):

--- a/tests/curl_object_test.py
+++ b/tests/curl_object_test.py
@@ -6,21 +6,23 @@ import pycurl
 import unittest
 import nose.tools
 
+from . import util
+
 class CurlObjectTest(unittest.TestCase):
     def test_close(self):
-        c = pycurl.Curl()
+        c = util.default_test_curl()
         c.close()
-    
+
     def test_close_twice(self):
-        c = pycurl.Curl()
+        c = util.default_test_curl()
         c.close()
         c.close()
-    
+
     # positional arguments are rejected
     @nose.tools.raises(TypeError)
     def test_positional_arguments(self):
         pycurl.Curl(1)
-    
+
     # keyword arguments are rejected
     @nose.tools.raises(TypeError)
     def test_keyword_arguments(self):

--- a/tests/debug_test.py
+++ b/tests/debug_test.py
@@ -12,15 +12,15 @@ setup_module, teardown_module = appmanager.setup(('app', 8380))
 
 class DebugTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
+        self.curl = util.default_test_curl()
         self.debug_entries = []
-    
+
     def tearDown(self):
         self.curl.close()
-    
+
     def debug_function(self, t, b):
         self.debug_entries.append((t, b))
-    
+
     def test_perform_get_with_debug_function(self):
         self.curl.setopt(pycurl.VERBOSE, 1)
         self.curl.setopt(pycurl.DEBUGFUNCTION, self.debug_function)
@@ -28,7 +28,7 @@ class DebugTest(unittest.TestCase):
         sio = util.BytesIO()
         self.curl.setopt(pycurl.WRITEFUNCTION, sio.write)
         self.curl.perform()
-        
+
         # Some checks with no particular intent
         self.check(0, util.b('Trying'))
         if util.pycurl_version_less_than(7, 24):
@@ -43,7 +43,7 @@ class DebugTest(unittest.TestCase):
         self.check(1, util.b('Content-Length: 7'))
         # result
         self.check(3, util.b('success'))
-    
+
     # test for #210
     def test_debug_unicode(self):
         self.curl.setopt(pycurl.VERBOSE, 1)
@@ -52,11 +52,11 @@ class DebugTest(unittest.TestCase):
         sio = util.BytesIO()
         self.curl.setopt(pycurl.WRITEFUNCTION, sio.write)
         self.curl.perform()
-        
+
         # 3 = response body
         search = util.b('\xd0\x94\xd1\x80\xd1\x83\xd0\xb6\xd0\xb1\xd0\xb0 \xd0\xbd\xd0\xb0\xd1\x80\xd0\xbe\xd0\xb4\xd0\xbe\xd0\xb2').decode('utf8')
         self.check(3, search.encode('utf8'))
-    
+
     def check(self, wanted_t, wanted_b):
         for t, b in self.debug_entries:
             if t == wanted_t and wanted_b in b:

--- a/tests/default_write_cb_test.py
+++ b/tests/default_write_cb_test.py
@@ -9,6 +9,7 @@ import tempfile
 import os
 
 from . import appmanager
+from . import util
 
 setup_module, teardown_module = appmanager.setup(('app', 8380))
 
@@ -25,7 +26,7 @@ def try_fsync(fd):
 
 class DefaultWriteCbTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
+        self.curl = util.default_test_curl()
 
     def tearDown(self):
         self.curl.close()

--- a/tests/error_test.py
+++ b/tests/error_test.py
@@ -6,9 +6,11 @@ import pycurl
 import sys
 import unittest
 
+from . import util
+
 class ErrorTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
+        self.curl = util.default_test_curl()
 
     def tearDown(self):
         self.curl.close()
@@ -32,10 +34,10 @@ class ErrorTest(unittest.TestCase):
             self.assertEqual('No URL set!', msg)
         else:
             self.fail('Expected pycurl.error to be raised')
-    
+
     def test_pycurl_errstr_initially_empty(self):
         self.assertEqual('', self.curl.errstr())
-    
+
     def test_pycurl_errstr_type(self):
         self.assertEqual('', self.curl.errstr())
         try:

--- a/tests/ftp_test.py
+++ b/tests/ftp_test.py
@@ -14,21 +14,21 @@ setup_module, teardown_module = procmgr.vsftpd_setup()
 
 class FtpTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
-    
+        self.curl = util.default_test_curl()
+
     def tearDown(self):
         self.curl.close()
-    
+
     def test_get_ftp(self):
         self.curl.setopt(pycurl.URL, 'ftp://%s:8321' % localhost)
         sio = util.BytesIO()
         self.curl.setopt(pycurl.WRITEFUNCTION, sio.write)
         self.curl.perform()
-        
+
         result = sio.getvalue().decode()
         assert 'README.rst' in result
         assert 'INSTALL.rst' in result
-    
+
     # XXX this test needs to be fixed
     def test_quote(self):
         self.curl.setopt(pycurl.URL, 'ftp://%s:8321' % localhost)
@@ -36,18 +36,18 @@ class FtpTest(unittest.TestCase):
         self.curl.setopt(pycurl.WRITEFUNCTION, sio.write)
         self.curl.setopt(pycurl.QUOTE, ['CWD tests'])
         self.curl.perform()
-        
+
         result = sio.getvalue().decode()
         assert 'README.rst' not in result
         assert 'ftp_test.py' in result
-    
+
     def test_epsv(self):
         self.curl.setopt(pycurl.URL, 'ftp://%s:8321' % localhost)
         sio = util.BytesIO()
         self.curl.setopt(pycurl.WRITEFUNCTION, sio.write)
         self.curl.setopt(pycurl.FTP_USE_EPSV, 1)
         self.curl.perform()
-        
+
         result = sio.getvalue().decode()
         assert 'README.rst' in result
         assert 'INSTALL.rst' in result

--- a/tests/getinfo_test.py
+++ b/tests/getinfo_test.py
@@ -13,7 +13,7 @@ setup_module, teardown_module = appmanager.setup(('app', 8380))
 
 class GetinfoTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
+        self.curl = util.default_test_curl()
 
     def tearDown(self):
         self.curl.close()

--- a/tests/header_cb_test.py
+++ b/tests/header_cb_test.py
@@ -13,7 +13,7 @@ setup_module, teardown_module = appmanager.setup(('app', 8380))
 
 class HeaderCbTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
+        self.curl = util.default_test_curl()
         self.header_lines = []
 
     def tearDown(self):

--- a/tests/header_test.py
+++ b/tests/header_test.py
@@ -16,35 +16,35 @@ setup_module, teardown_module = appmanager.setup(('app', 8380))
 
 class HeaderTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
-    
+        self.curl = util.default_test_curl()
+
     def tearDown(self):
         self.curl.close()
-    
+
     def test_ascii_string_header(self):
         self.check('x-test-header: ascii', 'ascii')
-    
+
     def test_ascii_unicode_header(self):
         self.check(util.u('x-test-header: ascii'), 'ascii')
-    
+
     # on python 2 unicode is accepted in strings because strings are byte strings
     @util.only_python3
     @nose.tools.raises(UnicodeEncodeError)
     def test_unicode_string_header(self):
         self.check('x-test-header: Москва', 'Москва')
-    
+
     @nose.tools.raises(UnicodeEncodeError)
     def test_unicode_unicode_header(self):
         self.check(util.u('x-test-header: Москва'), util.u('Москва'))
-    
+
     def test_encoded_unicode_header(self):
         self.check(util.u('x-test-header: Москва').encode('utf-8'), util.u('Москва'))
-    
+
     def check(self, send, expected):
         # check as list and as tuple, because they may be handled differently
         self.do_check([send], expected)
         self.do_check((send,), expected)
-    
+
     def do_check(self, send, expected):
         self.curl.setopt(pycurl.URL, 'http://localhost:8380/header_utf8?h=x-test-header')
         sio = util.BytesIO()

--- a/tests/info_constants_test.py
+++ b/tests/info_constants_test.py
@@ -11,6 +11,6 @@ class InfoConstantsTest(unittest.TestCase):
     # CURLINFO_CONDITION_UNMET  was introduced in libcurl-7.19.4
     @util.min_libcurl(7, 19, 4)
     def test_condition_unmet(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         assert hasattr(curl, 'CONDITION_UNMET')
         curl.close()

--- a/tests/internals_test.py
+++ b/tests/internals_test.py
@@ -15,19 +15,19 @@ from . import util
 
 class InternalsTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
-    
+        self.curl = util.default_test_curl()
+
     def tearDown(self):
         self.curl.close()
         del self.curl
-    
+
     # /***********************************************************************
     # // test misc
     # ************************************************************************/
-    
+
     def test_constant_aliasing(self):
         assert self.curl.URL is pycurl.URL
-    
+
     # /***********************************************************************
     # // test handles
     # ************************************************************************/
@@ -41,17 +41,17 @@ class InternalsTest(unittest.TestCase):
         else:
             assert False, "No exception when trying to remove a handle that is not in CurlMulti"
         del m
-    
+
     def test_remove_invalid_closed_handle(self):
         m = pycurl.CurlMulti()
-        c = pycurl.Curl()
+        c = util.default_test_curl()
         c.close()
         m.remove_handle(c)
         del m, c
-    
+
     def test_add_closed_handle(self):
         m = pycurl.CurlMulti()
-        c = pycurl.Curl()
+        c = util.default_test_curl()
         c.close()
         try:
             m.add_handle(c)
@@ -61,7 +61,7 @@ class InternalsTest(unittest.TestCase):
             assert 0, "No exception when trying to add a close handle to CurlMulti"
         m.close()
         del m, c
-    
+
     def test_add_handle_twice(self):
         m = pycurl.CurlMulti()
         m.add_handle(self.curl)
@@ -72,7 +72,7 @@ class InternalsTest(unittest.TestCase):
         else:
             assert 0, "No exception when trying to add the same handle twice"
         del m
-    
+
     def test_add_handle_on_multiple_stacks(self):
         m1 = pycurl.CurlMulti()
         m2 = pycurl.CurlMulti()
@@ -84,7 +84,7 @@ class InternalsTest(unittest.TestCase):
         else:
             assert 0, "No exception when trying to add the same handle on multiple stacks"
         del m1, m2
-    
+
     def test_move_handle(self):
         m1 = pycurl.CurlMulti()
         m2 = pycurl.CurlMulti()
@@ -92,7 +92,7 @@ class InternalsTest(unittest.TestCase):
         m1.remove_handle(self.curl)
         m2.add_handle(self.curl)
         del m1, m2
-    
+
     # /***********************************************************************
     # // test copying and pickling - copying and pickling of
     # // instances of Curl and CurlMulti is not allowed
@@ -106,7 +106,7 @@ class InternalsTest(unittest.TestCase):
             pass
         else:
             assert False, "No exception when trying to copy a Curl handle"
-    
+
     def test_copy_multi(self):
         m = pycurl.CurlMulti()
         try:
@@ -115,7 +115,7 @@ class InternalsTest(unittest.TestCase):
             pass
         else:
             assert False, "No exception when trying to copy a CurlMulti handle"
-    
+
     def test_copy_share(self):
         s = pycurl.CurlShare()
         try:
@@ -124,7 +124,7 @@ class InternalsTest(unittest.TestCase):
             pass
         else:
             assert False, "No exception when trying to copy a CurlShare handle"
-    
+
     def test_pickle_curl(self):
         fp = util.StringIO()
         p = pickle.Pickler(fp, 1)
@@ -136,7 +136,7 @@ class InternalsTest(unittest.TestCase):
         else:
             assert 0, "No exception when trying to pickle a Curl handle"
         del fp, p
-    
+
     def test_pickle_multi(self):
         m = pycurl.CurlMulti()
         fp = util.StringIO()
@@ -148,7 +148,7 @@ class InternalsTest(unittest.TestCase):
         else:
             assert 0, "No exception when trying to pickle a CurlMulti handle"
         del m, fp, p
-    
+
     def test_pickle_share(self):
         s = pycurl.CurlShare()
         fp = util.StringIO()
@@ -160,7 +160,7 @@ class InternalsTest(unittest.TestCase):
         else:
             assert 0, "No exception when trying to pickle a CurlShare handle"
         del s, fp, p
-    
+
     def test_pickle_dumps_curl(self):
         try:
             pickle.dumps(self.curl)
@@ -169,7 +169,7 @@ class InternalsTest(unittest.TestCase):
             pass
         else:
             self.fail("No exception when trying to pickle a Curl handle")
-    
+
     def test_pickle_dumps_multi(self):
         m = pycurl.CurlMulti()
         try:
@@ -178,7 +178,7 @@ class InternalsTest(unittest.TestCase):
             pass
         else:
             self.fail("No exception when trying to pickle a CurlMulti handle")
-    
+
     def test_pickle_dumps_share(self):
         s = pycurl.CurlShare()
         try:
@@ -187,7 +187,7 @@ class InternalsTest(unittest.TestCase):
             pass
         else:
             self.fail("No exception when trying to pickle a CurlShare handle")
-    
+
     if cPickle is not None:
         def test_cpickle_curl(self):
             fp = util.StringIO()
@@ -199,7 +199,7 @@ class InternalsTest(unittest.TestCase):
             else:
                 assert 0, "No exception when trying to pickle a Curl handle via cPickle"
             del fp, p
-        
+
         def test_cpickle_multi(self):
             m = pycurl.CurlMulti()
             fp = util.StringIO()
@@ -211,7 +211,7 @@ class InternalsTest(unittest.TestCase):
             else:
                 assert 0, "No exception when trying to pickle a CurlMulti handle via cPickle"
             del m, fp, p
-        
+
         def test_cpickle_share(self):
             s = pycurl.CurlMulti()
             fp = util.StringIO()

--- a/tests/memory_mgmt_test.py
+++ b/tests/memory_mgmt_test.py
@@ -39,7 +39,7 @@ class MemoryMgmtTest(unittest.TestCase):
         t = []
         searches = []
         for a in range(100):
-            curl = pycurl.Curl()
+            curl = util.default_test_curl()
             multi.add_handle(curl)
             t.append(curl)
 
@@ -77,7 +77,7 @@ class MemoryMgmtTest(unittest.TestCase):
         t = []
         searches = []
         for a in range(100):
-            curl = pycurl.Curl()
+            curl = util.default_test_curl()
             multi.add_handle(curl)
             t.append(curl)
 
@@ -109,7 +109,7 @@ class MemoryMgmtTest(unittest.TestCase):
         t = []
         searches = []
         for a in range(100):
-            curl = pycurl.Curl()
+            curl = util.default_test_curl()
             curl.setopt(curl.SHARE, share)
             t.append(curl)
 
@@ -147,7 +147,7 @@ class MemoryMgmtTest(unittest.TestCase):
         t = []
         searches = []
         for a in range(100):
-            curl = pycurl.Curl()
+            curl = util.default_test_curl()
             curl.setopt(curl.SHARE, share)
             t.append(curl)
 
@@ -173,7 +173,7 @@ class MemoryMgmtTest(unittest.TestCase):
 
     # basic check of reference counting (use a memory checker like valgrind)
     def test_reference_counting(self):
-        c = pycurl.Curl()
+        c = util.default_test_curl()
         m = pycurl.CurlMulti()
         m.add_handle(c)
         del m
@@ -183,7 +183,7 @@ class MemoryMgmtTest(unittest.TestCase):
 
     def test_cyclic_gc(self):
         gc.collect()
-        c = pycurl.Curl()
+        c = util.default_test_curl()
         c.m = pycurl.CurlMulti()
         c.m.add_handle(c)
         # create some nasty cyclic references
@@ -220,7 +220,7 @@ class MemoryMgmtTest(unittest.TestCase):
             range_generator = range
         # Ensure that the refcounting error in "reset" is fixed:
         for i in range_generator(100000):
-            c = pycurl.Curl()
+            c = util.default_test_curl()
             c.reset()
 
     def test_writefunction_collection(self):
@@ -259,7 +259,7 @@ class MemoryMgmtTest(unittest.TestCase):
         gc.collect()
         object_count = len(gc.get_objects())
 
-        c = pycurl.Curl()
+        c = util.default_test_curl()
         c.setopt(callback, lambda x: True)
         del c
 
@@ -273,7 +273,7 @@ class MemoryMgmtTest(unittest.TestCase):
         # this test passed even before the memory leak was fixed,
         # not sure why.
 
-        c = pycurl.Curl()
+        c = util.default_test_curl()
         gc.collect()
         before_object_count = len(gc.get_objects())
 
@@ -285,7 +285,7 @@ class MemoryMgmtTest(unittest.TestCase):
         self.assert_(after_object_count <= before_object_count + 1000, 'Grew from %d to %d objects' % (before_object_count, after_object_count))
 
     def test_form_bufferptr_memory_leak_gh267(self):
-        c = pycurl.Curl()
+        c = util.default_test_curl()
         gc.collect()
         before_object_count = len(gc.get_objects())
 

--- a/tests/multi_socket_select_test.py
+++ b/tests/multi_socket_select_test.py
@@ -57,7 +57,7 @@ class MultiSocketSelectTest(unittest.TestCase):
         m.setopt(pycurl.M_SOCKETFUNCTION, socket)
         m.handles = []
         for url in urls:
-            c = pycurl.Curl()
+            c = util.default_test_curl()
             # save info in standard Python attributes
             c.url = url
             c.body = util.BytesIO()

--- a/tests/multi_socket_test.py
+++ b/tests/multi_socket_test.py
@@ -45,7 +45,7 @@ class MultiSocketTest(unittest.TestCase):
         m.setopt(pycurl.M_SOCKETFUNCTION, socket)
         m.handles = []
         for url in urls:
-            c = pycurl.Curl()
+            c = util.default_test_curl()
             # save info in standard Python attributes
             c.url = url
             c.body = util.BytesIO()
@@ -78,18 +78,18 @@ class MultiSocketTest(unittest.TestCase):
         for c in m.handles:
             self.assertEqual('success', c.body.getvalue().decode())
             self.assertEqual(200, c.http_code)
-            
+
             # multi, not curl handle
             self.check(pycurl.POLL_IN, m, socket_events)
             self.check(pycurl.POLL_REMOVE, m, socket_events)
-        
+
         # close handles
         for c in m.handles:
             # pycurl API calls
             m.remove_handle(c)
             c.close()
         m.close()
-    
+
     def check(self, event, multi, socket_events):
         for event_, multi_ in socket_events:
             if event == event_ and multi == multi_:

--- a/tests/multi_test.py
+++ b/tests/multi_test.py
@@ -30,8 +30,8 @@ class MultiTest(unittest.TestCase):
         io2 = util.BytesIO()
         m = pycurl.CurlMulti()
         handles = []
-        c1 = pycurl.Curl()
-        c2 = pycurl.Curl()
+        c1 = util.default_test_curl()
+        c2 = util.default_test_curl()
         c1.setopt(c1.URL, 'http://localhost:8380/success')
         c1.setopt(c1.WRITEFUNCTION, io1.write)
         c2.setopt(c2.URL, 'http://localhost:8381/success')
@@ -54,14 +54,14 @@ class MultiTest(unittest.TestCase):
         m.close()
         c1.close()
         c2.close()
-        
+
         self.assertEqual('success', io1.getvalue().decode())
         self.assertEqual('success', io2.getvalue().decode())
-    
+
     def test_multi_select_fdset(self):
-        c1 = pycurl.Curl()
-        c2 = pycurl.Curl()
-        c3 = pycurl.Curl()
+        c1 = util.default_test_curl()
+        c2 = util.default_test_curl()
+        c3 = util.default_test_curl()
         c1.setopt(c1.URL, "http://localhost:8380/success")
         c2.setopt(c2.URL, "http://localhost:8381/success")
         c3.setopt(c3.URL, "http://localhost:8382/success")
@@ -102,11 +102,11 @@ class MultiTest(unittest.TestCase):
         c1.close()
         c2.close()
         c3.close()
-        
+
         self.assertEqual('success', c1.body.getvalue().decode())
         self.assertEqual('success', c2.body.getvalue().decode())
         self.assertEqual('success', c3.body.getvalue().decode())
-    
+
     def test_multi_status_codes(self):
         # init
         m = pycurl.CurlMulti()
@@ -117,7 +117,7 @@ class MultiTest(unittest.TestCase):
             'http://localhost:8382/status/404',
         ]
         for url in urls:
-            c = pycurl.Curl()
+            c = util.default_test_curl()
             # save info in standard Python attributes
             c.url = url.rstrip()
             c.body = util.BytesIO()
@@ -157,7 +157,7 @@ class MultiTest(unittest.TestCase):
         # bottle generated response body
         self.assertEqual('not found', m.handles[2].body.getvalue().decode())
         self.assertEqual(404, m.handles[2].http_code)
-    
+
     def check_adding_closed_handle(self, close_fn):
         # init
         m = pycurl.CurlMulti()
@@ -168,7 +168,7 @@ class MultiTest(unittest.TestCase):
             'http://localhost:8382/status/404',
         ]
         for url in urls:
-            c = pycurl.Curl()
+            c = util.default_test_curl()
             # save info in standard Python attributes
             c.url = url
             c.body = util.BytesIO()
@@ -218,34 +218,34 @@ class MultiTest(unittest.TestCase):
         # bottle generated response body
         self.assertEqual('', m.handles[2].body.getvalue().decode())
         self.assertEqual(-1, m.handles[2].http_code)
-    
+
     def _remove_then_close(self, m, c):
         m.remove_handle(c)
         c.close()
-    
+
     def _close_then_remove(self, m, c):
         # in the C API this is the wrong calling order, but pycurl
         # handles this automatically
         c.close()
         m.remove_handle(c)
-    
+
     def _close_without_removing(self, m, c):
         # actually, remove_handle is called automatically on close
         c.close
-    
+
     def test_adding_closed_handle_remove_then_close(self):
         self.check_adding_closed_handle(self._remove_then_close)
-    
+
     def test_adding_closed_handle_close_then_remove(self):
         self.check_adding_closed_handle(self._close_then_remove)
-    
+
     def test_adding_closed_handle_close_without_removing(self):
         self.check_adding_closed_handle(self._close_without_removing)
-    
+
     def test_multi_select(self):
-        c1 = pycurl.Curl()
-        c2 = pycurl.Curl()
-        c3 = pycurl.Curl()
+        c1 = util.default_test_curl()
+        c2 = util.default_test_curl()
+        c3 = util.default_test_curl()
         c1.setopt(c1.URL, "http://localhost:8380/success")
         c2.setopt(c2.URL, "http://localhost:8381/success")
         c3.setopt(c3.URL, "http://localhost:8382/success")
@@ -288,15 +288,15 @@ class MultiTest(unittest.TestCase):
         c1.close()
         c2.close()
         c3.close()
-        
+
         self.assertEqual('success', c1.body.getvalue().decode())
         self.assertEqual('success', c2.body.getvalue().decode())
         self.assertEqual('success', c3.body.getvalue().decode())
-    
+
     def test_multi_info_read(self):
-        c1 = pycurl.Curl()
-        c2 = pycurl.Curl()
-        c3 = pycurl.Curl()
+        c1 = util.default_test_curl()
+        c2 = util.default_test_curl()
+        c3 = util.default_test_curl()
         c1.setopt(c1.URL, "http://localhost:8380/short_wait")
         c2.setopt(c2.URL, "http://localhost:8381/short_wait")
         c3.setopt(c3.URL, "http://localhost:8382/short_wait")
@@ -340,12 +340,12 @@ class MultiTest(unittest.TestCase):
             # last info is an empty array
             if handles:
                 all_handles.extend(handles)
-        
+
         self.assertEqual(3, len(all_handles))
         assert c1 in all_handles
         assert c2 in all_handles
         assert c3 in all_handles
-        
+
         # Cleanup
         m.remove_handle(c3)
         m.remove_handle(c2)
@@ -354,25 +354,25 @@ class MultiTest(unittest.TestCase):
         c1.close()
         c2.close()
         c3.close()
-        
+
         self.assertEqual('success', c1.body.getvalue().decode())
         self.assertEqual('success', c2.body.getvalue().decode())
         self.assertEqual('success', c3.body.getvalue().decode())
-    
+
     def test_multi_close(self):
         m = pycurl.CurlMulti()
         m.close()
-    
+
     def test_multi_close_twice(self):
         m = pycurl.CurlMulti()
         m.close()
         m.close()
-    
+
     # positional arguments are rejected
     @nose.tools.raises(TypeError)
     def test_positional_arguments(self):
         pycurl.CurlMulti(1)
-    
+
     # keyword arguments are rejected
     @nose.tools.raises(TypeError)
     def test_keyword_arguments(self):

--- a/tests/multi_timer_test.py
+++ b/tests/multi_timer_test.py
@@ -31,7 +31,7 @@ class MultiSocketTest(unittest.TestCase):
         ]
 
         timers = []
-        
+
         # timer callback
         def timer(msecs):
             #print('Timer callback msecs:', msecs)
@@ -42,7 +42,7 @@ class MultiSocketTest(unittest.TestCase):
         m.setopt(pycurl.M_TIMERFUNCTION, timer)
         m.handles = []
         for url in urls:
-            c = pycurl.Curl()
+            c = util.default_test_curl()
             # save info in standard Python attributes
             c.url = url
             c.body = util.BytesIO()
@@ -72,7 +72,7 @@ class MultiSocketTest(unittest.TestCase):
         for c in m.handles:
             self.assertEqual('success', c.body.getvalue().decode())
             self.assertEqual(200, c.http_code)
-        
+
         assert len(timers) > 0
         # libcurl 7.23.0 produces a 0 timer
         assert timers[0] >= 0

--- a/tests/open_socket_cb_test.py
+++ b/tests/open_socket_cb_test.py
@@ -51,7 +51,7 @@ def socket_open_unix(purpose, curl_address):
 
 class OpenSocketCbTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
+        self.curl = util.default_test_curl()
 
     def tearDown(self):
         self.curl.close()

--- a/tests/option_constants_test.py
+++ b/tests/option_constants_test.py
@@ -24,7 +24,7 @@ class OptionConstantsTest(unittest.TestCase):
         assert hasattr(pycurl, 'DNS_SERVERS')
 
         # Does not work unless libcurl was built against c-ares
-        #c = pycurl.Curl()
+        #c = util.default_test_curl()
         #c.setopt(c.DNS_SERVERS, '1.2.3.4')
         #c.close()
 
@@ -39,7 +39,7 @@ class OptionConstantsTest(unittest.TestCase):
     # CURLOPT_POSTREDIR was introduced in libcurl-7.19.1
     @util.min_libcurl(7, 19, 1)
     def test_postredir_setopt(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.POSTREDIR, curl.REDIR_POST_301)
         curl.close()
 
@@ -72,28 +72,28 @@ class OptionConstantsTest(unittest.TestCase):
     # CURLOPT_NOPROXY was introduced in libcurl-7.19.4
     @util.min_libcurl(7, 19, 4)
     def test_noproxy_setopt(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.NOPROXY, 'localhost')
         curl.close()
 
     # CURLOPT_PROTOCOLS was introduced in libcurl-7.19.4
     @util.min_libcurl(7, 19, 4)
     def test_protocols_setopt(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.PROTOCOLS, curl.PROTO_ALL & ~curl.PROTO_HTTP)
         curl.close()
 
     # CURLOPT_REDIR_PROTOCOLS was introduced in libcurl-7.19.4
     @util.min_libcurl(7, 19, 4)
     def test_redir_protocols_setopt(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.PROTOCOLS, curl.PROTO_ALL & ~curl.PROTO_HTTP)
         curl.close()
 
     # CURLOPT_TFTP_BLKSIZE was introduced in libcurl-7.19.4
     @util.min_libcurl(7, 19, 4)
     def test_tftp_blksize_setopt(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.TFTP_BLKSIZE, 1024)
         curl.close()
 
@@ -101,7 +101,7 @@ class OptionConstantsTest(unittest.TestCase):
     @util.min_libcurl(7, 19, 4)
     @nose.plugins.attrib.attr('gssapi')
     def test_socks5_gssapi_service_setopt(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.SOCKS5_GSSAPI_SERVICE, 'helloworld')
         curl.close()
 
@@ -109,14 +109,14 @@ class OptionConstantsTest(unittest.TestCase):
     @util.min_libcurl(7, 19, 4)
     @nose.plugins.attrib.attr('gssapi')
     def test_socks5_gssapi_nec_setopt(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.SOCKS5_GSSAPI_NEC, True)
         curl.close()
 
     # CURLPROXY_HTTP_1_0 was introduced in libcurl-7.19.4
     @util.min_libcurl(7, 19, 4)
     def test_curlproxy_http_1_0_setopt(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.PROXYTYPE, curl.PROXYTYPE_HTTP_1_0)
         curl.close()
 
@@ -124,35 +124,35 @@ class OptionConstantsTest(unittest.TestCase):
     @util.min_libcurl(7, 19, 6)
     @util.guard_unknown_libcurl_option
     def test_ssh_knownhosts_setopt(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.SSH_KNOWNHOSTS, '/hello/world')
         curl.close()
 
     # CURLOPT_MAIL_FROM was introduced in libcurl-7.20.0
     @util.min_libcurl(7, 20, 0)
     def test_mail_from(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.MAIL_FROM, 'hello@world.com')
         curl.close()
 
     # CURLOPT_MAIL_RCPT was introduced in libcurl-7.20.0
     @util.min_libcurl(7, 20, 0)
     def test_mail_rcpt(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.MAIL_RCPT, ['hello@world.com', 'foo@bar.com'])
         curl.close()
 
     # CURLOPT_MAIL_AUTH was introduced in libcurl-7.25.0
     @util.min_libcurl(7, 25, 0)
     def test_mail_auth(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.MAIL_AUTH, 'hello@world.com')
         curl.close()
 
     @util.min_libcurl(7, 22, 0)
     @nose.plugins.attrib.attr('gssapi')
     def test_gssapi_delegation_options(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.GSSAPI_DELEGATION, curl.GSSAPI_DELEGATION_FLAG)
         curl.setopt(curl.GSSAPI_DELEGATION, curl.GSSAPI_DELEGATION_NONE)
         curl.setopt(curl.GSSAPI_DELEGATION, curl.GSSAPI_DELEGATION_POLICY_FLAG)
@@ -161,7 +161,7 @@ class OptionConstantsTest(unittest.TestCase):
     # SSLVERSION_DEFAULT causes CURLE_UNKNOWN_OPTION without SSL
     @util.only_ssl
     def test_sslversion_options(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.SSLVERSION, curl.SSLVERSION_DEFAULT)
         curl.setopt(curl.SSLVERSION, curl.SSLVERSION_SSLv2)
         curl.setopt(curl.SSLVERSION, curl.SSLVERSION_SSLv3)
@@ -172,7 +172,7 @@ class OptionConstantsTest(unittest.TestCase):
     # SSLVERSION_TLSv1_0 causes CURLE_UNKNOWN_OPTION without SSL
     @util.only_ssl
     def test_sslversion_7_34_0(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.SSLVERSION, curl.SSLVERSION_TLSv1_0)
         curl.setopt(curl.SSLVERSION, curl.SSLVERSION_TLSv1_1)
         curl.setopt(curl.SSLVERSION, curl.SSLVERSION_TLSv1_2)
@@ -181,140 +181,140 @@ class OptionConstantsTest(unittest.TestCase):
     @util.min_libcurl(7, 41, 0)
     @util.only_ssl_backends('openssl', 'nss')
     def test_ssl_verifystatus(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.SSL_VERIFYSTATUS, True)
         curl.close()
 
     @util.min_libcurl(7, 43, 0)
     @nose.plugins.attrib.attr('gssapi')
     def test_proxy_service_name(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.PROXY_SERVICE_NAME, 'fakehttp')
         curl.close()
 
     @util.min_libcurl(7, 43, 0)
     @nose.plugins.attrib.attr('gssapi')
     def test_service_name(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.SERVICE_NAME, 'fakehttp')
         curl.close()
 
     @util.min_libcurl(7, 39, 0)
     def test_pinnedpublickey(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.PINNEDPUBLICKEY, '/etc/publickey.der')
         curl.close()
 
     @util.min_libcurl(7, 21, 0)
     def test_wildcardmatch(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.WILDCARDMATCH, '*')
         curl.close()
 
     @util.min_libcurl(7, 40, 0)
     def test_unix_socket_path(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.UNIX_SOCKET_PATH, '/tmp/socket.sock')
         curl.close()
 
     @util.min_libcurl(7, 36, 0)
     def test_ssl_enable_alpn(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.SSL_ENABLE_ALPN, 1)
         curl.close()
 
     @util.min_libcurl(7, 36, 0)
     def test_ssl_enable_npn(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.SSL_ENABLE_NPN, 1)
         curl.close()
 
     @util.min_libcurl(7, 42, 0)
     @util.only_ssl_backends('nss')
     def test_ssl_falsestart(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.SSL_FALSESTART, 1)
         curl.close()
 
     def test_ssl_verifyhost(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.SSL_VERIFYHOST, 2)
         curl.close()
 
     def test_cainfo(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.CAINFO, '/bogus-cainfo')
         curl.close()
 
     @util.only_ssl
     def test_issuercert(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.ISSUERCERT, '/bogus-issuercert')
         curl.close()
 
     @util.only_ssl
     def test_capath(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.CAPATH, '/bogus-capath')
         curl.close()
 
     @util.only_ssl
     def test_crlfile(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.CRLFILE, '/bogus-crlfile')
         curl.close()
 
     @util.only_ssl
     def test_random_file(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.RANDOM_FILE, '/bogus-random')
         curl.close()
 
     @util.only_ssl_backends('openssl', 'gnutls')
     def test_egdsocket(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.EGDSOCKET, '/bogus-egdsocket')
         curl.close()
 
     @util.only_ssl
     def test_ssl_cipher_list(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.SSL_CIPHER_LIST, 'RC4-SHA:SHA1+DES')
         curl.close()
 
     @util.only_ssl
     def test_ssl_sessionid_cache(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.SSL_SESSIONID_CACHE, True)
         curl.close()
 
     def test_krblevel(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.KRBLEVEL, 'clear')
         curl.close()
 
     def test_krb4level(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.KRB4LEVEL, 'clear')
         curl.close()
 
     @util.min_libcurl(7, 25, 0)
     @util.only_ssl
     def test_ssl_options(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.SSL_OPTIONS, curl.SSLOPT_ALLOW_BEAST)
         curl.close()
 
     @util.min_libcurl(7, 44, 0)
     @util.only_ssl
     def test_ssl_option_no_revoke(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         curl.setopt(curl.SSL_OPTIONS, curl.SSLOPT_NO_REVOKE)
         curl.close()
 
 class OptionConstantsSettingTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
+        self.curl = util.default_test_curl()
 
     def tearDown(self):
         self.curl.close()

--- a/tests/pause_test.py
+++ b/tests/pause_test.py
@@ -15,17 +15,17 @@ setup_module, teardown_module = appmanager.setup(('app', 8380))
 @flaky.flaky(max_runs=3)
 class PauseTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
-    
+        self.curl = util.default_test_curl()
+
     def tearDown(self):
         self.curl.close()
-    
+
     def test_pause_via_call(self):
         self.check_pause(True)
-    
+
     def test_pause_via_return(self):
         self.check_pause(False)
-    
+
     def check_pause(self, call):
         # the app sleeps for 0.5 seconds
         self.curl.setopt(pycurl.URL, 'http://localhost:8380/pause')
@@ -57,7 +57,7 @@ class PauseTest(unittest.TestCase):
         signal.alarm(1)
         start = _time.time()
         self.curl.setopt(pycurl.WRITEFUNCTION, writefunc)
-        
+
         m = pycurl.CurlMulti()
         m.add_handle(self.curl)
 
@@ -82,14 +82,14 @@ class PauseTest(unittest.TestCase):
                 ret, num_handles = m.perform()
                 if ret != pycurl.E_CALL_MULTI_PERFORM:
                     break
-        
+
         # Cleanup
         m.remove_handle(self.curl)
         m.close()
-        
+
         self.assertEqual('part1part2', sio.getvalue().decode())
         end = _time.time()
         # check that client side waited
         self.assertTrue(end-start > 1)
-        
+
         assert state['resumed']

--- a/tests/post_test.py
+++ b/tests/post_test.py
@@ -23,7 +23,7 @@ setup_module, teardown_module = appmanager.setup(('app', 8380))
 @flaky.flaky(max_runs=3)
 class PostTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
+        self.curl = util.default_test_curl()
 
     def tearDown(self):
         self.curl.close()
@@ -82,7 +82,7 @@ class PostTest(unittest.TestCase):
             'field3': 'this is wei\000rd, but null-bytes are okay',
         }
         self.check_post(send, expect, 'http://localhost:8380/postfields')
-    
+
     def test_post_file(self):
         path = os.path.join(os.path.dirname(__file__), '..', 'README.rst')
         f = open(path)

--- a/tests/pycurl_object_test.py
+++ b/tests/pycurl_object_test.py
@@ -5,58 +5,60 @@
 import pycurl
 import unittest
 
+from . import util
+
 class PycurlObjectTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
-    
+        self.curl = util.default_test_curl()
+
     def tearDown(self):
         self.curl.close()
-    
+
     def test_set_attribute_curl(self):
         self.instantiate_and_check(self.check_set_attribute, 'Curl')
-    
+
     def test_get_attribute_curl(self):
         self.instantiate_and_check(self.check_get_attribute, 'Curl')
-    
+
     def test_get_missing_attribute_curl(self):
         self.instantiate_and_check(self.check_get_missing_attribute, 'Curl')
-    
+
     def test_delete_attribute_curl(self):
         self.instantiate_and_check(self.check_delete_attribute, 'Curl')
-    
+
     def test_delete_missing_attribute_curl(self):
         self.instantiate_and_check(self.check_delete_missing_attribute, 'Curl')
-    
+
     def test_set_attribute_multi(self):
         self.instantiate_and_check(self.check_set_attribute, 'CurlMulti')
-    
+
     def test_get_attribute_multi(self):
         self.instantiate_and_check(self.check_get_attribute, 'CurlMulti')
-    
+
     def test_get_missing_attribute_curl_multi(self):
         self.instantiate_and_check(self.check_get_missing_attribute, 'CurlMulti')
-    
+
     def test_delete_attribute_multi(self):
         self.instantiate_and_check(self.check_delete_attribute, 'CurlMulti')
-    
+
     def test_delete_missing_attribute_curl_multi(self):
         self.instantiate_and_check(self.check_delete_missing_attribute, 'CurlMulti')
-    
+
     def test_set_attribute_share(self):
         self.instantiate_and_check(self.check_set_attribute, 'CurlShare')
-    
+
     def test_get_attribute_share(self):
         self.instantiate_and_check(self.check_get_attribute, 'CurlShare')
-    
+
     def test_get_missing_attribute_curl_share(self):
         self.instantiate_and_check(self.check_get_missing_attribute, 'CurlShare')
-    
+
     def test_delete_attribute_share(self):
         self.instantiate_and_check(self.check_delete_attribute, 'CurlShare')
-    
+
     def test_delete_missing_attribute_curl_share(self):
         self.instantiate_and_check(self.check_delete_missing_attribute, 'CurlShare')
-    
+
     def instantiate_and_check(self, fn, cls_name):
         cls = getattr(pycurl, cls_name)
         instance = cls()
@@ -64,24 +66,24 @@ class PycurlObjectTest(unittest.TestCase):
             fn(instance)
         finally:
             instance.close()
-    
+
     def check_set_attribute(self, pycurl_obj):
         assert not hasattr(pycurl_obj, 'attr')
         pycurl_obj.attr = 1
         assert hasattr(pycurl_obj, 'attr')
-    
+
     def check_get_attribute(self, pycurl_obj):
         assert not hasattr(pycurl_obj, 'attr')
         pycurl_obj.attr = 1
         self.assertEqual(1, pycurl_obj.attr)
-    
+
     def check_get_missing_attribute(self, pycurl_obj):
         try:
             getattr(pycurl_obj, 'doesnotexist')
             self.fail('Expected an AttributeError exception to be raised')
         except AttributeError:
             pass
-    
+
     def check_delete_attribute(self, pycurl_obj):
         assert not hasattr(pycurl_obj, 'attr')
         pycurl_obj.attr = 1
@@ -89,23 +91,23 @@ class PycurlObjectTest(unittest.TestCase):
         assert hasattr(pycurl_obj, 'attr')
         del pycurl_obj.attr
         assert not hasattr(pycurl_obj, 'attr')
-    
+
     def check_delete_missing_attribute(self, pycurl_obj):
         try:
             del pycurl_obj.doesnotexist
             self.fail('Expected an AttributeError exception to be raised')
         except AttributeError:
             pass
-    
+
     def test_modify_attribute_curl(self):
         self.check_modify_attribute(pycurl.Curl, 'READFUNC_PAUSE')
-    
+
     def test_modify_attribute_multi(self):
         self.check_modify_attribute(pycurl.CurlMulti, 'E_MULTI_OK')
-    
+
     def test_modify_attribute_share(self):
         self.check_modify_attribute(pycurl.CurlShare, 'SH_SHARE')
-    
+
     def check_modify_attribute(self, cls, name):
         obj1 = cls()
         obj2 = cls()
@@ -115,10 +117,10 @@ class PycurlObjectTest(unittest.TestCase):
         self.assertEqual(old_value, getattr(pycurl, name))
         setattr(obj1, name, 'helloworld')
         self.assertEqual('helloworld', getattr(obj1, name))
-        
+
         # change does not affect other existing objects
         self.assertEqual(old_value, getattr(obj2, name))
-        
+
         # change does not affect objects created later
         obj3 = cls()
         self.assertEqual(old_value, getattr(obj3, name))

--- a/tests/read_cb_test.py
+++ b/tests/read_cb_test.py
@@ -42,7 +42,7 @@ class DataProvider(object):
 
 class ReadCbTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
+        self.curl = util.default_test_curl()
 
     def tearDown(self):
         self.curl.close()

--- a/tests/readdata_test.py
+++ b/tests/readdata_test.py
@@ -43,11 +43,11 @@ class DataProvider(object):
 
 class ReaddataTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
-    
+        self.curl = util.default_test_curl()
+
     def tearDown(self):
         self.curl.close()
-    
+
     def test_readdata_object(self):
         d = DataProvider(POSTSTRING)
         self.curl.setopt(self.curl.URL, 'http://localhost:8380/postfields')
@@ -57,24 +57,24 @@ class ReaddataTest(unittest.TestCase):
         sio = util.BytesIO()
         self.curl.setopt(pycurl.WRITEFUNCTION, sio.write)
         self.curl.perform()
-        
+
         actual = json.loads(sio.getvalue().decode())
         self.assertEqual(POSTFIELDS, actual)
-    
+
     def test_post_with_read_returning_bytes(self):
         self.check_bytes('world')
-    
+
     def test_post_with_read_returning_bytes_with_nulls(self):
         self.check_bytes("wor\0ld")
-    
+
     def test_post_with_read_returning_bytes_with_multibyte(self):
         self.check_bytes(util.u("Пушкин"))
-    
+
     def check_bytes(self, poststring):
         data = poststring.encode('utf8')
         assert type(data) == util.binary_type
         d = DataProvider(data)
-        
+
         self.curl.setopt(self.curl.URL, 'http://localhost:8380/raw_utf8')
         self.curl.setopt(self.curl.POST, 1)
         self.curl.setopt(self.curl.HTTPHEADER, ['Content-Type: application/octet-stream'])
@@ -84,17 +84,17 @@ class ReaddataTest(unittest.TestCase):
         sio = util.BytesIO()
         self.curl.setopt(pycurl.WRITEFUNCTION, sio.write)
         self.curl.perform()
-        
+
         # json should be ascii
         actual = json.loads(sio.getvalue().decode('ascii'))
         self.assertEqual(poststring, actual)
-    
+
     def test_post_with_read_callback_returning_unicode(self):
         self.check_unicode(util.u('world'))
-    
+
     def test_post_with_read_callback_returning_unicode_with_nulls(self):
         self.check_unicode(util.u("wor\0ld"))
-    
+
     def test_post_with_read_callback_returning_unicode_with_multibyte(self):
         try:
             self.check_unicode(util.u("Пушкин"))
@@ -105,11 +105,11 @@ class ReaddataTest(unittest.TestCase):
             # we expect pycurl.E_WRITE_ERROR as the response
             self.assertEqual(pycurl.E_ABORTED_BY_CALLBACK, err)
             self.assertEqual('operation aborted by callback', msg)
-    
+
     def check_unicode(self, poststring):
         assert type(poststring) == util.text_type
         d = DataProvider(poststring)
-        
+
         self.curl.setopt(self.curl.URL, 'http://localhost:8380/raw_utf8')
         self.curl.setopt(self.curl.POST, 1)
         self.curl.setopt(self.curl.HTTPHEADER, ['Content-Type: application/octet-stream'])
@@ -118,11 +118,11 @@ class ReaddataTest(unittest.TestCase):
         sio = util.BytesIO()
         self.curl.setopt(pycurl.WRITEFUNCTION, sio.write)
         self.curl.perform()
-        
+
         # json should be ascii
         actual = json.loads(sio.getvalue().decode('ascii'))
         self.assertEqual(poststring, actual)
-    
+
     def test_readdata_file_binary(self):
         path = os.path.join(os.path.dirname(__file__), 'fixtures', 'form_submission.txt')
         # file opened in binary mode
@@ -135,12 +135,12 @@ class ReaddataTest(unittest.TestCase):
             sio = util.BytesIO()
             self.curl.setopt(pycurl.WRITEDATA, sio)
             self.curl.perform()
-            
+
             actual = json.loads(sio.getvalue().decode())
             self.assertEqual({'foo': 'bar'}, actual)
         finally:
             f.close()
-    
+
     def test_readdata_file_text(self):
         path = os.path.join(os.path.dirname(__file__), 'fixtures', 'form_submission.txt')
         # file opened in text mode
@@ -153,7 +153,7 @@ class ReaddataTest(unittest.TestCase):
             sio = util.BytesIO()
             self.curl.setopt(pycurl.WRITEDATA, sio)
             self.curl.perform()
-            
+
             actual = json.loads(sio.getvalue().decode())
             self.assertEqual({'foo': 'bar'}, actual)
         finally:

--- a/tests/reset_test.py
+++ b/tests/reset_test.py
@@ -12,7 +12,7 @@ setup_module, teardown_module = appmanager.setup(('app', 8380))
 
 class ResetTest(unittest.TestCase):
     def test_reset(self):
-        c = pycurl.Curl()
+        c = util.default_test_curl()
         c.setopt(pycurl.USERAGENT, 'Phony/42')
         c.setopt(pycurl.URL, 'http://localhost:8380/header?h=user-agent')
         sio = util.BytesIO()
@@ -20,7 +20,7 @@ class ResetTest(unittest.TestCase):
         c.perform()
         user_agent = sio.getvalue().decode()
         assert user_agent == 'Phony/42'
-        
+
         c.reset()
         c.setopt(pycurl.URL, 'http://localhost:8380/header?h=user-agent')
         sio = util.BytesIO()
@@ -30,13 +30,13 @@ class ResetTest(unittest.TestCase):
         # we also check that the request succeeded after curl
         # object has been reset
         assert user_agent.startswith('PycURL')
-    
+
     # XXX this test was broken when it was test_reset.py
     def skip_reset_with_multi(self):
         outf = util.BytesIO()
         cm = pycurl.CurlMulti()
 
-        eh = pycurl.Curl()
+        eh = util.default_test_curl()
 
         for x in range(1, 20):
             eh.setopt(pycurl.WRITEFUNCTION, outf.write)

--- a/tests/resolve_test.py
+++ b/tests/resolve_test.py
@@ -11,15 +11,15 @@ setup_module, teardown_module = appmanager.setup(('app', 8380))
 
 class ResolveTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
-    
+        self.curl = util.default_test_curl()
+
     def tearDown(self):
         self.curl.close()
-    
+
     def test_resolve(self):
         if util.pycurl_version_less_than(7, 21, 3) and not hasattr(pycurl, 'RESOLVE'):
             raise nose.plugins.skip.SkipTest('libcurl < 7.21.3 or no RESOLVE')
-        
+
         self.curl.setopt(pycurl.URL, 'http://p.localhost:8380/success')
         self.curl.setopt(pycurl.RESOLVE, ['p.localhost:8380:127.0.0.1'])
         self.curl.perform()

--- a/tests/seek_cb_constants_test.py
+++ b/tests/seek_cb_constants_test.py
@@ -12,7 +12,7 @@ class SeekCbConstantsTest(unittest.TestCase):
     # the constant is only defined in 7.19.5+
     @util.min_libcurl(7, 19, 5)
     def test_ok(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         self.assertEqual(0, curl.SEEKFUNC_OK)
         curl.close()
 
@@ -20,12 +20,12 @@ class SeekCbConstantsTest(unittest.TestCase):
     # the constant is only defined in 7.19.5+
     @util.min_libcurl(7, 19, 5)
     def test_fail(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         self.assertEqual(1, curl.SEEKFUNC_FAIL)
         curl.close()
 
     @util.min_libcurl(7, 19, 5)
     def test_cantseek(self):
-        curl = pycurl.Curl()
+        curl = util.default_test_curl()
         self.assertEqual(2, curl.SEEKFUNC_CANTSEEK)
         curl.close()

--- a/tests/seek_cb_test.py
+++ b/tests/seek_cb_test.py
@@ -9,6 +9,7 @@ import unittest
 import os.path
 
 from . import procmgr, localhost
+from . import util
 
 setup_module, teardown_module = procmgr.vsftpd_setup()
 
@@ -37,7 +38,7 @@ class PartialFileSource:
 
 class SeekCbTest(unittest.TestCase):
     def test_seek_function(self):
-        c = pycurl.Curl()
+        c = util.default_test_curl()
         c.setopt(pycurl.UPLOAD, 1)
         c.setopt(pycurl.URL, "ftp://%s:8321/tests/tmp/upload.txt" % localhost)
         c.setopt(pycurl.RESUME_FROM, 0)
@@ -58,7 +59,7 @@ class SeekCbTest(unittest.TestCase):
         del c
         del upload_file
 
-        c = pycurl.Curl()
+        c = util.default_test_curl()
         c.setopt(pycurl.URL, "ftp://%s:8321/tests/tmp/upload.txt" % localhost)
         c.setopt(pycurl.RESUME_FROM, -1)
         c.setopt(pycurl.UPLOAD, 1)

--- a/tests/setopt_lifecycle_test.py
+++ b/tests/setopt_lifecycle_test.py
@@ -28,18 +28,18 @@ class SetoptLifecycleTest(unittest.TestCase):
         pf = TestString('&'.join(50*['field=value%d' % (index,)]))
         curl.setopt(pycurl.URL, 'http://localhost:8380/postfields')
         curl.setopt(pycurl.POSTFIELDS, pf)
-    
+
     # This test takes 6+ seconds to run.
     # It seems to pass with broken pycurl code when run by itself,
     # but fails when run as part of the entire test suite.
     def test_postfields_lifecycle(self):
         requests = []
         for i in range(1000):
-            curl = pycurl.Curl()
+            curl = util.default_test_curl()
             self.do_setopt(curl, i)
             gc.collect()
             requests.append(curl)
-        
+
         # send requests here to permit maximum garbage recycling
         for i in range(100):
             curl = requests[i]
@@ -51,7 +51,7 @@ class SetoptLifecycleTest(unittest.TestCase):
             body = sio.getvalue().decode()
             returned_fields = json.loads(body)
             self.assertEqual(dict(field='value%d' % i), returned_fields)
-        
+
         for i in range(100):
             curl = requests[i]
             curl.close()

--- a/tests/setopt_string_test.py
+++ b/tests/setopt_string_test.py
@@ -13,7 +13,7 @@ setup_module, teardown_module = appmanager.setup(('app', 8380))
 
 class SetoptTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
+        self.curl = util.default_test_curl()
 
     def tearDown(self):
         self.curl.close()

--- a/tests/setopt_test.py
+++ b/tests/setopt_test.py
@@ -13,7 +13,7 @@ setup_module, teardown_module = appmanager.setup(('app', 8380))
 
 class SetoptTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
+        self.curl = util.default_test_curl()
 
     def tearDown(self):
         self.curl.close()

--- a/tests/setopt_unicode_test.py
+++ b/tests/setopt_unicode_test.py
@@ -13,21 +13,21 @@ setup_module, teardown_module = appmanager.setup(('app', 8380))
 
 class SetoptUnicodeTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
-    
+        self.curl = util.default_test_curl()
+
     def tearDown(self):
         self.curl.close()
-    
+
     def test_ascii_string(self):
         self.check('p=test', 'test')
-    
+
     @nose.tools.raises(UnicodeEncodeError)
     def test_unicode_string(self):
         self.check(util.u('p=Москва'), util.u('Москва'))
-    
+
     def test_unicode_encoded(self):
         self.check(util.u('p=Москва').encode('utf8'), util.u('Москва'))
-    
+
     def check(self, send, expected):
         self.curl.setopt(pycurl.URL, 'http://localhost:8380/param_utf8_hack')
         sio = util.BytesIO()

--- a/tests/share_test.py
+++ b/tests/share_test.py
@@ -16,7 +16,7 @@ class WorkerThread(threading.Thread):
 
     def __init__(self, share):
         threading.Thread.__init__(self)
-        self.curl = pycurl.Curl()
+        self.curl = util.default_test_curl()
         self.curl.setopt(pycurl.URL, 'http://localhost:8380/success')
         self.curl.setopt(pycurl.SHARE, share)
         self.sio = util.BytesIO()
@@ -38,29 +38,29 @@ class ShareTest(unittest.TestCase):
 
         t1.start()
         t2.start()
-        
+
         t1.join()
         t2.join()
-        
+
         del s
-        
+
         self.assertEqual('success', t1.sio.getvalue().decode())
         self.assertEqual('success', t2.sio.getvalue().decode())
-    
+
     def test_share_close(self):
         s = pycurl.CurlShare()
         s.close()
-    
+
     def test_share_close_twice(self):
         s = pycurl.CurlShare()
         s.close()
         s.close()
-    
+
     # positional arguments are rejected
     @nose.tools.raises(TypeError)
     def test_positional_arguments(self):
         pycurl.CurlShare(1)
-    
+
     # keyword arguments are rejected
     @nose.tools.raises(TypeError)
     def test_keyword_arguments(self):

--- a/tests/sockopt_cb_test.py
+++ b/tests/sockopt_cb_test.py
@@ -12,7 +12,7 @@ setup_module, teardown_module = appmanager.setup(('app', 8380))
 
 class SockoptCbTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
+        self.curl = util.default_test_curl()
         self.curl.setopt(self.curl.URL, 'http://localhost:8380/success')
 
     def tearDown(self):
@@ -75,7 +75,7 @@ class SockoptCbTest(unittest.TestCase):
 
 class SockoptCbUnsetTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
+        self.curl = util.default_test_curl()
 
     def test_sockoptfunction_none(self):
         self.curl.setopt(pycurl.SOCKOPTFUNCTION, None)

--- a/tests/ssh_key_cb_test.py
+++ b/tests/ssh_key_cb_test.py
@@ -16,7 +16,7 @@ class SshKeyCbTest(unittest.TestCase):
     '''This test requires Internet access.'''
 
     def setUp(self):
-        self.curl = pycurl.Curl()
+        self.curl = util.default_test_curl()
         self.curl.setopt(pycurl.URL, sftp_server)
         self.curl.setopt(pycurl.VERBOSE, True)
 
@@ -71,7 +71,7 @@ class SshKeyCbTest(unittest.TestCase):
 @nose.plugins.attrib.attr('ssh')
 class SshKeyCbUnsetTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
+        self.curl = util.default_test_curl()
         self.curl.setopt(pycurl.URL, sftp_server)
         self.curl.setopt(pycurl.VERBOSE, True)
 

--- a/tests/unset_range_test.py
+++ b/tests/unset_range_test.py
@@ -7,9 +7,11 @@ import pycurl
 import sys
 import unittest
 
+from . import util
+
 class UnsetRangeTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
+        self.curl = util.default_test_curl()
 
     def tearDown(self):
         self.curl.close()

--- a/tests/user_agent_string_test.py
+++ b/tests/user_agent_string_test.py
@@ -12,11 +12,11 @@ setup_module, teardown_module = appmanager.setup(('app', 8380))
 
 class UserAgentStringTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
-    
+        self.curl = util.default_test_curl()
+
     def tearDown(self):
         self.curl.close()
-    
+
     def test_pycurl_user_agent_string(self):
         self.curl.setopt(pycurl.URL, 'http://localhost:8380/header?h=user-agent')
         sio = util.BytesIO()

--- a/tests/util.py
+++ b/tests/util.py
@@ -238,3 +238,12 @@ def get_sys_path(p=None):
     return p
 
 
+def default_test_curl():
+    import pycurl
+
+    curl = pycurl.Curl()
+    # the test servers are run in process and if libcurl keeps the connections
+    # open, the servers are shut down before libcurl closes the connections.
+    # avoid connection reuse by default
+    curl.setopt(curl.FORBID_REUSE, True)
+    return curl

--- a/tests/write_abort_test.py
+++ b/tests/write_abort_test.py
@@ -7,9 +7,11 @@ import pycurl
 import sys
 import unittest
 
+from . import util
+
 class WriteAbortTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
+        self.curl = util.default_test_curl()
 
     def tearDown(self):
         self.curl.close()

--- a/tests/write_cb_bogus_test.py
+++ b/tests/write_cb_bogus_test.py
@@ -7,9 +7,11 @@ import pycurl
 import sys
 import unittest
 
+from . import util
+
 class WriteAbortTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
+        self.curl = util.default_test_curl()
 
     def tearDown(self):
         self.curl.close()
@@ -22,17 +24,17 @@ class WriteAbortTest(unittest.TestCase):
 
     def test_write_cb_returning_string(self):
         self.check(self.write_cb_returning_string)
-    
+
     def test_write_cb_returning_float(self):
         self.check(self.write_cb_returning_float)
-    
+
     def check(self, write_cb):
         # download the script itself through the file:// protocol into write_cb
         self.curl.setopt(pycurl.URL, 'file://' + os.path.abspath(sys.argv[0]))
         self.curl.setopt(pycurl.WRITEFUNCTION, write_cb)
         try:
             self.curl.perform()
-            
+
             self.fail('Should not get here')
         except pycurl.error:
             err, msg = sys.exc_info()[1].args

--- a/tests/write_test.py
+++ b/tests/write_test.py
@@ -16,17 +16,17 @@ setup_module, teardown_module = appmanager.setup(('app', 8380))
 class Acceptor(object):
     def __init__(self):
         self.buffer = ''
-    
+
     def write(self, chunk):
         self.buffer += chunk.decode()
 
 class WriteTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
-    
+        self.curl = util.default_test_curl()
+
     def tearDown(self):
         self.curl.close()
-    
+
     def test_write_to_tempfile_via_function(self):
         self.curl.setopt(pycurl.URL, 'http://localhost:8380/success')
         f = tempfile.NamedTemporaryFile()
@@ -38,7 +38,7 @@ class WriteTest(unittest.TestCase):
         finally:
             f.close()
         self.assertEqual('success', body.decode())
-    
+
     @util.only_python3
     def test_write_to_tempfile_via_object(self):
         self.curl.setopt(pycurl.URL, 'http://localhost:8380/success')
@@ -51,7 +51,7 @@ class WriteTest(unittest.TestCase):
         finally:
             f.close()
         self.assertEqual('success', body.decode())
-    
+
     def test_write_to_file_via_function(self):
         self.curl.setopt(pycurl.URL, 'http://localhost:8380/success')
         dir = tempfile.mkdtemp()
@@ -68,7 +68,7 @@ class WriteTest(unittest.TestCase):
         finally:
             shutil.rmtree(dir)
         self.assertEqual('success', body.decode())
-    
+
     def test_write_to_file_via_object(self):
         self.curl.setopt(pycurl.URL, 'http://localhost:8380/success')
         dir = tempfile.mkdtemp()
@@ -85,7 +85,7 @@ class WriteTest(unittest.TestCase):
         finally:
             shutil.rmtree(dir)
         self.assertEqual('success', body.decode())
-    
+
     def test_write_to_file_like(self):
         self.curl.setopt(pycurl.URL, 'http://localhost:8380/success')
         acceptor = Acceptor()

--- a/tests/write_to_stringio_test.py
+++ b/tests/write_to_stringio_test.py
@@ -13,18 +13,18 @@ setup_module, teardown_module = appmanager.setup(('app', 8380))
 
 class WriteToStringioTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
-    
+        self.curl = util.default_test_curl()
+
     def tearDown(self):
         self.curl.close()
-    
+
     def test_write_to_bytesio(self):
         self.curl.setopt(pycurl.URL, 'http://localhost:8380/success')
         sio = util.BytesIO()
         self.curl.setopt(pycurl.WRITEFUNCTION, sio.write)
         self.curl.perform()
         self.assertEqual('success', sio.getvalue().decode())
-    
+
     @util.only_python3
     def test_write_to_stringio(self):
         self.curl.setopt(pycurl.URL, 'http://localhost:8380/success')
@@ -33,7 +33,7 @@ class WriteToStringioTest(unittest.TestCase):
         self.curl.setopt(pycurl.WRITEFUNCTION, sio.write)
         try:
             self.curl.perform()
-            
+
             self.fail('Should have received a write error')
         except pycurl.error:
             err, msg = sys.exc_info()[1].args

--- a/tests/xferinfo_cb_test.py
+++ b/tests/xferinfo_cb_test.py
@@ -12,7 +12,7 @@ setup_module, teardown_module = appmanager.setup(('app', 8380))
 
 class XferinfoCbTest(unittest.TestCase):
     def setUp(self):
-        self.curl = pycurl.Curl()
+        self.curl = util.default_test_curl()
         self.curl.setopt(self.curl.URL, 'http://localhost:8380/long_pause')
 
     def tearDown(self):


### PR DESCRIPTION
Hopefully this stops spurious errors about aborted connections.

Alternate fix to #16