### PR TITLE
end trashcan sections after calling free

### DIFF
--- a/src/easy.c
+++ b/src/easy.c
@@ -416,8 +416,8 @@ do_curl_dealloc(CurlObject *self)
     Py_CLEAR(self->dict);
     util_curl_close(self);
 
-    Py_TRASHCAN_SAFE_END(self);
     Curl_Type.tp_free(self);
+    Py_TRASHCAN_SAFE_END(self);
 }
 
 

--- a/src/multi.c
+++ b/src/multi.c
@@ -110,8 +110,8 @@ do_multi_dealloc(CurlMultiObject *self)
     util_multi_xdecref(self);
     util_multi_close(self);
 
-    Py_TRASHCAN_SAFE_END(self);
     CurlMulti_Type.tp_free(self);
+    Py_TRASHCAN_SAFE_END(self);
 }
 
 

--- a/src/share.c
+++ b/src/share.c
@@ -127,8 +127,8 @@ do_share_dealloc(CurlShareObject *self)
     share_lock_destroy(self->lock);
 #endif
 
-    Py_TRASHCAN_SAFE_END(self);
     CurlShare_Type.tp_free(self);
+    Py_TRASHCAN_SAFE_END(self);
 }
 
 


### PR DESCRIPTION
The Py_TRASHCAN_SAFE_* macros create a lexical block that may or may
not be executed depending on the stack depth. If it's not executed,
the deallocator is called again when the stack is not so deeply
nested. The current curl deallocators have the problem that if the
block is not executed, the object is still freed because
Py_TYPE(self)->tp_free is called outside of the trashcan block. This
can lead to double-freeing.