### PR TITLE
fix and standardize ignoring of SIGPIPE in examples

### DIFF
--- a/examples/retriever-multi.py
+++ b/examples/retriever-multi.py
@@ -14,9 +14,12 @@ import pycurl
 # the libcurl tutorial for more info.
 try:
     import signal
-    signal.signal(signal.SIGPIPE, signal.SIG_IGN)
+    from signal import SIGPIPE, SIG_IGN
 except ImportError:
     pass
+else:
+    signal.signal(SIGPIPE, SIG_IGN)
+
 
 
 # Get args

--- a/examples/retriever.py
+++ b/examples/retriever.py
@@ -18,9 +18,11 @@ import pycurl
 # the libcurl tutorial for more info.
 try:
     import signal
-    signal.signal(signal.SIGPIPE, signal.SIG_IGN)
+    from signal import SIGPIPE, SIG_IGN
 except ImportError:
     pass
+else:
+    signal.signal(SIGPIPE, SIG_IGN)
 
 
 # Get args

--- a/examples/tests/test_gtk.py
+++ b/examples/tests/test_gtk.py
@@ -12,9 +12,11 @@ import gtk
 # the libcurl tutorial for more info.
 try:
     import signal
-    signal.signal(signal.SIGPIPE, signal.SIG_IGN)
+    from signal import SIGPIPE, SIG_IGN
 except ImportError:
     pass
+else:
+    signal.signal(SIGPIPE, SIG_IGN)
 
 
 class ProgressBar:

--- a/examples/xmlrpc_curl.py
+++ b/examples/xmlrpc_curl.py
@@ -6,9 +6,12 @@
 # the libcurl tutorial for more info.
 try:
     import signal
-    signal.signal(signal.SIGPIPE, signal.SIG_IGN)
+    from signal import SIGPIPE, SIG_IGN
 except ImportError:
     pass
+else:
+    signal.signal(SIGPIPE, SIG_IGN)
+
 try:
     from cStringIO import StringIO
 except ImportError:

--- a/python/curl/__init__.py
+++ b/python/curl/__init__.py
@@ -21,12 +21,15 @@ else:
     except ImportError:
         from StringIO import StringIO as BytesIO
 
+# We should ignore SIGPIPE when using pycurl.NOSIGNAL - see
+# the libcurl tutorial for more info.
 try:
     import signal
     from signal import SIGPIPE, SIG_IGN
-    signal.signal(SIGPIPE, SIG_IGN)
 except ImportError:
     pass
+else:
+    signal.signal(SIGPIPE, SIG_IGN)
 
 
 class Curl:


### PR DESCRIPTION
The current code in some examples would crash on systems without `SIGPIPE`, since it would raise an AttributeError instead of ImportError, which was not being caught in the `except` statement.

I also moved the `signal.signal()` call to an `else:` clause, to make the exception handling more specific.

Finally I made the code and comments identical in all examples, for consistency.