### PR TITLE
Update tests to work with curl compiled with libssh

### DIFF
--- a/tests/ssh_key_cb_test.py
+++ b/tests/ssh_key_cb_test.py
@@ -24,6 +24,9 @@ class SshKeyCbTest(unittest.TestCase):
         self.curl.close()
 
     @util.min_libcurl(7, 19, 6)
+    # curl compiled with libssh doesn't support
+    # CURLOPT_SSH_KNOWNHOSTS and CURLOPT_SSH_KEYFUNCTION
+    @util.guard_unknown_libcurl_option
     def test_keyfunction(self):
         # with keyfunction returning ok
 
@@ -54,6 +57,7 @@ class SshKeyCbTest(unittest.TestCase):
             self.assertEqual(pycurl.E_PEER_FAILED_VERIFICATION, e.args[0])
 
     @util.min_libcurl(7, 19, 6)
+    @util.guard_unknown_libcurl_option
     def test_keyfunction_bogus_return(self):
         def keyfunction(known_key, found_key, match):
             return 'bogus'
@@ -76,9 +80,11 @@ class SshKeyCbUnsetTest(unittest.TestCase):
         self.curl.setopt(pycurl.VERBOSE, True)
 
     @util.min_libcurl(7, 19, 6)
+    @util.guard_unknown_libcurl_option
     def test_keyfunction_none(self):
         self.curl.setopt(pycurl.SSH_KEYFUNCTION, None)
 
     @util.min_libcurl(7, 19, 6)
+    @util.guard_unknown_libcurl_option
     def test_keyfunction_unset(self):
         self.curl.unsetopt(pycurl.SSH_KEYFUNCTION)


### PR DESCRIPTION
Since version 7.58.0, curl may be compiled with libssh
instead of libssh2 which differs in the supported functionality.
For example CURLOPT_SSH_KNOWNHOSTS and CURLOPT_SSH_KEYFUNCTION
are unknown options to curl in such setup.