### PR TITLE
Winbuild refactoring

### DIFF
--- a/winbuild.py
+++ b/winbuild.py
@@ -433,15 +433,15 @@ class StandardBuilder(Builder):
 
     @property
     def bin_path(self):
-        return os.path.join(config.archives_path, self.output_dir_path, 'bin')
+        return os.path.join(config.archives_path, self.output_dir_path, 'dist', 'bin')
 
     @property
     def include_path(self):
-        return os.path.join(config.archives_path, self.output_dir_path, 'include')
+        return os.path.join(config.archives_path, self.output_dir_path, 'dist', 'include')
 
     @property
     def lib_path(self):
-        return os.path.join(config.archives_path, self.output_dir_path, 'lib')
+        return os.path.join(config.archives_path, self.output_dir_path, 'dist', 'lib')
 
     @property
     def dll_paths(self):
@@ -597,11 +597,7 @@ class CaresBuilder(StandardBuilder):
     def output_dir_path(self):
         return 'c-ares-%s-%s' % (self.config.cares_version, self.vc_tag)
 
-class Libssh2Builder(Builder):
-    @property
-    def state_tag(self):
-        return 'libssh2-%s-%s' % (self.config.libssh2_version, self.vc_tag)
-
+class Libssh2Builder(StandardBuilder):
     def build(self):
         fetch('http://www.libssh2.org/download/libssh2-%s.tar.gz' % (self.config.libssh2_version))
         untar('libssh2-%s' % self.config.libssh2_version)
@@ -634,23 +630,15 @@ BUILD_STATIC_LIB=1
                 b.add("nmake -f NMakefile")
                 # libcurl loves its _a suffixes on static library names
                 b.add("cp Release\\src\\libssh2.lib Release\\src\\libssh2_a.lib")
+                
+                # assemble dist
+                b.add('mkdir dist dist\\include dist\\lib')
+                b.add('cp Release/src/*.lib dist/lib')
+                b.add('cp -r include dist')
 
     @property
     def output_dir_path(self):
         return 'libssh2-%s-%s' % (self.config.libssh2_version, self.vc_tag)
-
-    @property
-    def dll_paths(self):
-        raise NotImplementedError
-
-    @property
-    def include_path(self):
-        return os.path.join(config.archives_path, self.output_dir_path, 'include')
-
-    @property
-    def lib_path(self):
-        return os.path.join(config.archives_path, self.output_dir_path,
-            'Release', 'src')
 
 class LibcurlBuilder(Builder):
     @property

--- a/winbuild.py
+++ b/winbuild.py
@@ -273,7 +273,7 @@ class Batch(object):
             # I don't know why vcvars doesn't configure this under vc14
             windows_sdk_path = 'c:\\program files (x86)\\microsoft sdks\\windows\\v7.1a'
             self.add('set include=%s\\include;%%include%%' % windows_sdk_path)
-            if self.bitness == 32:
+            if self.bc.bitness == 32:
                 self.add('set lib=%s\\lib;%%lib%%' % windows_sdk_path)
                 self.add('set path=%s\\bin;%%path%%' % windows_sdk_path)
             else:
@@ -759,7 +759,7 @@ def build_dependencies(bitnesses=(32, 64)):
     mkdir_p(config.archives_path)
     with in_dir(config.archives_path):
         for bitness in bitnesses:
-            for vc_version in needed_vc_versions(python_versions):
+            for vc_version in needed_vc_versions(config.python_versions):
                 if opts.verbose:
                     print('Builddep for %s, %s-bit' % (vc_version, bitness))
                 if config.use_zlib:
@@ -919,7 +919,7 @@ if opts.python:
         if not ok:
             print('Invalid python %s' % python)
             exit(2)
-    python_versions = chosen_python_versions
+    config.python_versions = chosen_python_versions
 
 # https://stackoverflow.com/questions/35569042/python-3-ssl-certificate-verify-failed
 import ssl

--- a/winbuild.py
+++ b/winbuild.py
@@ -42,7 +42,9 @@ class Config:
     # where ActiveState Perl is installed, for building 64-bit OpenSSL
     activestate_perl_path = ('c:/perl64', r'c:\dev\perl64')
     # which versions of python to build against
-    python_versions = ['2.7.10', '3.2.5', '3.3.5', '3.4.3', '3.5.4', '3.6.2']
+    #python_versions = ['2.7.10', '3.2.5', '3.3.5', '3.4.3', '3.5.4', '3.6.2']
+    # these require only vc9 and vc14
+    python_versions = ['2.7.10', '3.5.4', '3.6.2']
     # where pythons are installed
     python_path_template = 'c:/dev/%(bitness)s/python%(python_release)s/python'
     vc_paths = {

--- a/winbuild.py
+++ b/winbuild.py
@@ -215,6 +215,10 @@ class ExtendedConfig(Config):
         )
 
     @property
+    def libssh2_version_tuple(self):
+        return tuple(int(part) for part in self.libssh2_version.split('.'))
+
+    @property
     def python_releases(self):
         return [PythonRelease('.'.join(version.split('.')[:2]))
             for version in self.python_versions]
@@ -592,7 +596,7 @@ class Libssh2Builder(StandardBuilder):
         libssh2_dir = rename_for_vc('libssh2-%s' % self.config.libssh2_version, self.vc_tag)
         with in_dir(libssh2_dir):
             with self.execute_batch() as b:
-                if self.vc_version == 'vc14':
+                if self.config.libssh2_version_tuple < (1, 8, 0) and self.vc_version == 'vc14':
                     b.add("patch -p0 < %s" %
                         require_file_exists(os.path.join(config.winbuild_patch_root, 'libssh2-vs2015.patch')))
                 zlib_builder = ZlibBuilder(bitness=self.bitness, vc_version=self.vc_version, config=self.config)

--- a/winbuild.py
+++ b/winbuild.py
@@ -60,15 +60,15 @@ class Config:
     # whether to use openssl instead of winssl
     use_openssl = True
     # which version of openssl to use, will be downloaded from internet
-    openssl_version = '1.1.0g'
+    openssl_version = '1.1.0h'
     # whether to use c-ares
     use_cares = True
-    cares_version = '1.13.0'
+    cares_version = '1.14.0'
     # whether to use libssh2
     use_libssh2 = True
     libssh2_version = '1.8.0'
     # which version of libcurl to use, will be downloaded from internet
-    libcurl_version = '7.57.0'
+    libcurl_version = '7.59.0'
     # virtualenv version
     virtualenv_version = '15.1.0'
     # whether to build binary wheels
@@ -557,8 +557,12 @@ class CaresBuilder(Builder):
 
     @property
     def lib_path(self):
+        if map(int, self.config.cares_version.split('.')) < [1, 14]:
+            subdir = 'ms%s0' % self.vc_version
+        else:
+            subdir = 'msvc'
         return os.path.join(config.archives_path, self.output_dir_path,
-            'ms%s0' % self.vc_version, 'cares', 'lib-release')
+            subdir, 'cares', 'lib-release')
 
 class Libssh2Builder(Builder):
     @property

--- a/winbuild.py
+++ b/winbuild.py
@@ -955,9 +955,9 @@ if opts.python:
 # https://stackoverflow.com/questions/35569042/python-3-ssl-certificate-verify-failed
 import ssl
 try:
-	ssl._create_default_https_context = ssl._create_unverified_context
+    ssl._create_default_https_context = ssl._create_unverified_context
 except AttributeError:
-	pass
+    pass
 
 if len(args) > 0:
     if args[0] == 'download':

--- a/winbuild.py
+++ b/winbuild.py
@@ -28,6 +28,13 @@
 # http://www.activestate.com/activeperl/downloads
 
 class Config:
+    '''User-adjustable configuration.
+    
+    This class contains version numbers for dependencies,
+    which dependencies to use,
+    and where various binaries, headers and libraries are located in the filesystem.
+    '''
+    
     # work directory for downloading dependencies and building everything
     root = 'c:/dev/build-pycurl'
     # where msysgit is installed
@@ -145,6 +152,12 @@ def check_call(cmd):
         raise Exception('Failed to execute ' + str(cmd) + ': ' + str(type(e)) + ': ' +str(e))
 
 class ExtendedConfig(Config):
+    '''Global configuration that specifies what the entire process will do.
+    
+    Unlike Config, this class contains also various derived properties
+    for convenience.
+    '''
+    
     def __init__(self, **kwargs):
         for k in kwargs:
             setattr(self, k, kwargs[k])
@@ -371,7 +384,13 @@ class Batch(object):
         return "set path=%s;%%path%%\n" % config.nasm_path
 
 class BuildConfig(ExtendedConfig):
+    '''Parameters for a particular build configuration.
+    
+    Unlike ExtendedConfig, this class fixes bitness and Python version.
+    '''
+    
     def __init__(self, **kwargs):
+        ExtendedConfig.__init__(self, **kwargs)
         for k in kwargs:
             setattr(self, k, kwargs[k])
 

--- a/winbuild.py
+++ b/winbuild.py
@@ -374,6 +374,8 @@ class ZlibBuilder(Builder):
         with in_dir(zlib_dir):
             with self.execute_batch() as b:
                 b.add("nmake /f win32/Makefile.msc")
+                # libcurl loves its _a suffixes on static library names
+                b.add("cp zlib.lib zlib_a.lib")
 
     @property
     def output_dir_path(self):

--- a/winbuild.py
+++ b/winbuild.py
@@ -426,11 +426,24 @@ class Builder(object):
     def vc_tag(self):
         return '%s-%s' % (self.vc_version, self.bitness)
 
-class ZlibBuilder(Builder):
+class StandardBuilder(Builder):
     @property
     def state_tag(self):
-        return 'zlib-%s-%s' % (self.config.zlib_version, self.vc_tag)
+        return self.output_dir_path
 
+    @property
+    def bin_path(self):
+        return os.path.join(config.archives_path, self.output_dir_path, 'bin')
+
+    @property
+    def include_path(self):
+        return os.path.join(config.archives_path, self.output_dir_path, 'include')
+
+    @property
+    def lib_path(self):
+        return os.path.join(config.archives_path, self.output_dir_path, 'lib')
+
+class ZlibBuilder(StandardBuilder):
     def build(self):
         fetch('http://downloads.sourceforge.net/project/libpng/zlib/%s/zlib-%s.tar.gz' % (self.config.zlib_version, self.config.zlib_version))
         untar('zlib-%s' % self.config.zlib_version)
@@ -440,6 +453,12 @@ class ZlibBuilder(Builder):
                 b.add("nmake /f win32/Makefile.msc")
                 # libcurl loves its _a suffixes on static library names
                 b.add("cp zlib.lib zlib_a.lib")
+                
+                # assemble dist
+                b.add('mkdir dist dist\\include dist\\lib dist\\bin')
+                b.add('cp *.lib *.exp dist/lib')
+                b.add('cp *.dll dist/bin')
+                b.add('cp *.h dist/include')
 
     @property
     def output_dir_path(self):
@@ -448,16 +467,8 @@ class ZlibBuilder(Builder):
     @property
     def dll_paths(self):
         return [
-            os.path.join(self.output_dir_path, 'zlib1.dll'),
+            os.path.join(self.bin_path, 'zlib1.dll'),
         ]
-
-    @property
-    def include_path(self):
-        return os.path.join(config.archives_path, self.output_dir_path)
-
-    @property
-    def lib_path(self):
-        return os.path.join(config.archives_path, self.output_dir_path)
 
 class OpensslBuilder(Builder):
     @property

--- a/winbuild/libcurl-fix-zlib-references.patch
+++ b/winbuild/libcurl-fix-zlib-references.patch
@@ -1,19 +1,5 @@
 --- winbuild/MakefileBuild.vc.orig	2015-11-27 07:00:14.000000000 -0800
 +++ winbuild/MakefileBuild.vc	2016-01-01 21:33:44.263840800 -0800
-@@ -144,11 +144,11 @@
- !ENDIF
- 
- !IF "$(WITH_ZLIB)"=="dll"
--ZLIB_LIBS   = zlib.lib
-+ZLIB_LIBS   = zdll.lib
- USE_ZLIB    = true
- ZLIB        = dll
- !ELSEIF "$(WITH_ZLIB)"=="static"
--ZLIB_LIBS   = zlib_a.lib
-+ZLIB_LIBS   = zlib.lib
- USE_ZLIB    = true
- ZLIB        = static
- !ENDIF
 @@ -238,7 +238,7 @@
  
  # Runtime library configuration


### PR DESCRIPTION
This is intended to support adding nghttp2 later, as well as fixes to build against current dependencies (c-ares 1.14.0 and libcurl 7.60.0 in particular break current winbuild).

7.60.0 breakage: https://github.com/curl/curl/pull/2474