### PR TITLE
Winbuild updates & fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,13 @@
 master
 ------
 
+        * Official Python 3.x Windows builds now include international
+          domain name support via WINIDN. Official Python 2.x builds
+          do not have international domain name support at this time.
+
+        * Official Windows builds now include HTTP 2 support via
+          libnghttp2.
+
         * Added perform_rb and perform_rs methods to Curl objects to
           return response body as byte string and string, respectively.
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,28 @@ def scan_argv(argv, s, default=None):
     return p
 
 
+def scan_argvs(argv, s):
+    p = []
+    i = 1
+    while i < len(argv):
+        arg = argv[i]
+        if str.find(arg, s) == 0:
+            if s.endswith('='):
+                # --option=value
+                p.append(arg[len(s):])
+                if s != '--openssl-lib-name=':
+                    assert p[-1], arg
+            else:
+                # --option
+                # set value to True
+                raise Exception('specification must end with =')
+            del argv[i]
+        else:
+            i = i + 1
+    ##print argv
+    return p
+
+
 class ExtensionConfiguration(object):
     def __init__(self, argv=[]):
         # we mutate argv, this is necessary because
@@ -367,6 +389,9 @@ specify the SSL backend manually.''')
         # at the same time they dropped thread locking callback interface,
         # meaning the correct usage of this option is --openssl-lib-name=""
         self.openssl_lib_name = scan_argv(self.argv, '--openssl-lib-name=', 'libeay32.lib')
+
+        for lib in scan_argvs(self.argv, '--link-arg='):
+            self.extra_link_args.append(lib)
 
         if scan_argv(self.argv, "--use-libcurl-dll") is not None:
             libcurl_lib_path = os.path.join(curl_dir, "lib", curl_lib_name)
@@ -851,6 +876,7 @@ PycURL Windows options:
  --libcurl-lib-name=libcurl_imp.lib    override libcurl import library name
  --with-openssl                        libcurl is linked against OpenSSL
  --with-ssl                            legacy alias for --with-openssl
+ --link-arg=foo.lib                    also link against specified library
 '''
 
 if __name__ == "__main__":

--- a/winbuild.py
+++ b/winbuild.py
@@ -753,7 +753,15 @@ class LibcurlBuilder(StandardBuilder):
                     # https://github.com/curl/curl/issues/984
                     # crypt32.lib: http://stackoverflow.com/questions/37522654/linking-with-openssl-lib-statically
                     extra_options += ' MAKE="NMAKE /e" SSL_LIBS="libssl.lib libcrypto.lib crypt32.lib"'
-                b.add("nmake /f Makefile.vc ENABLE_IDN=no%s" % extra_options)
+                # https://github.com/curl/curl/issues/1863
+                extra_options += ' VC=%s' % self.vc_version[2:]
+                if self.vc_version == 'vc9':
+                    # curl uses winidn APIs that do not exist in msvc9:
+                    # https://github.com/curl/curl/issues/1863
+                    extra_options += ' ENABLE_IDN=no'
+                else:
+                    extra_options += ' ENABLE_IDN=yes'
+                b.add("nmake /f Makefile.vc %s" % extra_options)
         
         # assemble dist - figure out where libcurl put its files
         # and move them to a more reasonable location

--- a/winbuild.py
+++ b/winbuild.py
@@ -666,6 +666,13 @@ class Nghttp2Builder(StandardBuilder):
                 shutil.copy('../stdint.h', 'lib/includes/stdint.h')
         
         with in_dir(nghttp2_dir):
+            generator = self.CMAKE_GENERATORS[self.vc_version]
+            # Cmake also couldn't care less about the bitness I have configured in the
+            # environment since it ignores the environment entirely.
+            # Educate it on the required bitness by hand.
+            # https://stackoverflow.com/questions/28350214/how-to-build-x86-and-or-x64-on-windows-from-command-line-with-cmake#28370892
+            if self.bitness == 64:
+                generator += ' Win64'
             with self.execute_batch() as b:
                 cmd = ' '.join([
                     '"%s"' % config.cmake_path,
@@ -687,7 +694,7 @@ class Nghttp2Builder(StandardBuilder):
                     # and uses the newest compiler by default, which is great
                     # if one doesn't care what compiler their code is compiled with.
                     # https://stackoverflow.com/questions/6430251/what-is-the-default-generator-for-cmake-in-windows
-                    '-G', '"%s"' % self.CMAKE_GENERATORS[self.vc_version],
+                    '-G', '"%s"' % generator,
                 ])
                 b.add('%s .' % cmd)
                 # --config Release here is what produces a release build

--- a/winbuild.py
+++ b/winbuild.py
@@ -700,8 +700,9 @@ class Nghttp2Builder(StandardBuilder):
                 b.add('mkdir dist dist\\include dist\\include\\nghttp2 dist\\lib')
                 b.add('cp lib/Release/*.lib dist/lib')
                 b.add('cp lib/includes/nghttp2/*.h dist/include/nghttp2')
-                # stdint.h
-                b.add('cp lib/includes/*.h dist/include')
+                if self.vc_version == 'vc9':
+                    # stdint.h
+                    b.add('cp lib/includes/*.h dist/include')
 
     @property
     def output_dir_path(self):

--- a/winbuild/vcvars-vc14-32.sh
+++ b/winbuild/vcvars-vc14-32.sh
@@ -1,0 +1,25 @@
+# Courtesy of libiconv 1.15
+
+# Set environment variables for using MSVC 14,
+# for creating native 32-bit Windows executables.
+
+# Windows C library headers and libraries.
+WindowsCrtIncludeDir='C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt'
+WindowsCrtLibDir='C:\Program Files (x86)\Windows Kits\10\Lib\10.0.10240.0\ucrt\'
+INCLUDE="${WindowsCrtIncludeDir};$INCLUDE"
+LIB="${WindowsCrtLibDir}x86;$LIB"
+
+# Windows API headers and libraries.
+WindowsSdkIncludeDir='C:\Program Files (x86)\Windows Kits\8.1\Include\'
+WindowsSdkLibDir='C:\Program Files (x86)\Windows Kits\8.1\Lib\winv6.3\um\'
+INCLUDE="${WindowsSdkIncludeDir}um;${WindowsSdkIncludeDir}shared;$INCLUDE"
+LIB="${WindowsSdkLibDir}x86;$LIB"
+
+# Visual C++ tools, headers and libraries.
+VSINSTALLDIR='C:\Program Files (x86)\Microsoft Visual Studio 14.0'
+VCINSTALLDIR="${VSINSTALLDIR}"'\VC'
+PATH=`cygpath -u "${VCINSTALLDIR}"`/bin:"$PATH"
+INCLUDE="${VCINSTALLDIR}"'\include;'"${INCLUDE}"
+LIB="${VCINSTALLDIR}"'\lib;'"${LIB}"
+
+export INCLUDE LIB

--- a/winbuild/vcvars-vc14-64.sh
+++ b/winbuild/vcvars-vc14-64.sh
@@ -1,0 +1,25 @@
+# Courtesy of libiconv 1.15
+
+# Set environment variables for using MSVC 14,
+# for creating native 64-bit Windows executables.
+
+# Windows C library headers and libraries.
+WindowsCrtIncludeDir='C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt'
+WindowsCrtLibDir='C:\Program Files (x86)\Windows Kits\10\Lib\10.0.10240.0\ucrt\'
+INCLUDE="${WindowsCrtIncludeDir};$INCLUDE"
+LIB="${WindowsCrtLibDir}x64;$LIB"
+
+# Windows API headers and libraries.
+WindowsSdkIncludeDir='C:\Program Files (x86)\Windows Kits\8.1\Include\'
+WindowsSdkLibDir='C:\Program Files (x86)\Windows Kits\8.1\Lib\winv6.3\um\'
+INCLUDE="${WindowsSdkIncludeDir}um;${WindowsSdkIncludeDir}shared;$INCLUDE"
+LIB="${WindowsSdkLibDir}x64;$LIB"
+
+# Visual C++ tools, headers and libraries.
+VSINSTALLDIR='C:\Program Files (x86)\Microsoft Visual Studio 14.0'
+VCINSTALLDIR="${VSINSTALLDIR}"'\VC'
+PATH=`cygpath -u "${VCINSTALLDIR}"`/bin/amd64:"$PATH"
+INCLUDE="${VCINSTALLDIR}"'\include;'"${INCLUDE}"
+LIB="${VCINSTALLDIR}"'\lib\amd64;'"${LIB}"
+
+export INCLUDE LIB 


### PR DESCRIPTION
- nghttp2-related code fixed
- idn support added to python 3 builds (msvc14) which can use winidn, python 2/msvc9 cannot
- worked around https://github.com/curl/curl/pull/2474 to support libcurl 7.60.0