### PR TITLE
Add --enable-runtime-libs to ensure RUNPATH is set correctly. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -215,10 +215,13 @@ class ExtensionConfiguration(object):
             return curl_config
 
     def configure_unix(self):
+        ENABLE_RUNTIME_LIBS = scan_argv(self.argv, "--enable-runtime-libs")
         OPENSSL_DIR = scan_argv(self.argv, "--openssl-dir=")
         if OPENSSL_DIR is not None:
             self.include_dirs.append(os.path.join(OPENSSL_DIR, "include"))
             self.library_dirs.append(os.path.join(OPENSSL_DIR, "lib"))
+            if ENABLE_RUNTIME_LIBS:
+                self.runtime_library_dirs.append(os.path.join(OPENSSL_DIR, "lib"))
         try:
             p = subprocess.Popen((self.curl_config(), '--version'),
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -328,6 +331,8 @@ manually. For other SSL backends please ignore this message.''')
                 self.libraries.append(arg[2:])
             elif arg[:2] == "-L":
                 self.library_dirs.append(arg[2:])
+                if ENABLE_RUNTIME_LIBS:
+                    self.runtime_library_dirs.append(arg[2:])
             else:
                 self.extra_link_args.append(arg)
             


### PR DESCRIPTION
Add --enable-runtime-libs to ensure RUNPATH is set correctly. This means it is no longer necessary to set LD_LIBRARY_PATH to find dependencies in custom locations.

We build all our python modules and dependencies in custom locations for an enterprise. Setting LD_LIBRARY_PATH is not a viable solution, and PyCurl is unusual in not having an ability to set RUNPATH/RPATH.

This fixes 
https://github.com/pycurl/pycurl/issues/207
https://github.com/pycurl/pycurl/issues/402
which have been closed with a complete fix. 