### PR TITLE
Add support for mbedTLS

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,8 @@ master
           is configured to use SSL, added in 7.43.0.2, has been changed
           to a warning to allow this.
 
+        * Added support for mbedTLS
+
 
 Version 7.43.0.2 [requires libcurl-7.19.0 or better] - 2018-06-02
 -----------------------------------------------------------------

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -53,7 +53,7 @@ It will then fail at runtime as follows::
 
 To fix this, you need to tell ``setup.py`` what SSL backend is used::
 
-    python setup.py --with-[openssl|gnutls|nss] install
+    python setup.py --with-[openssl|gnutls|nss|mbedtls] install
 
 Note: as of PycURL 7.21.5, setup.py accepts ``--with-openssl`` option to
 indicate that libcurl is built against OpenSSL. ``--with-ssl`` is an alias
@@ -85,7 +85,7 @@ environment variable::
 The same applies to the SSL backend, if you need to specify it (see the SSL
 note above)::
 
-    export PYCURL_SSL_LIBRARY=[openssl|gnutls|nss]
+    export PYCURL_SSL_LIBRARY=[openssl|gnutls|nss|mbedtls]
     easy_install pycurl
 
 

--- a/doc/thread-safety.rst
+++ b/doc/thread-safety.rst
@@ -21,7 +21,7 @@ For Python programs using PycURL, this means:
   Python code *outside of a libcurl callback for the PycURL object in question*
   is unsafe.
 
-PycURL handles the necessary SSL locks for OpenSSL/LibreSSL, GnuTLS and NSS.
+PycURL handles the necessary SSL locks for OpenSSL/LibreSSL, GnuTLS, NSS and mbedTLS.
 
 A special situation exists when libcurl uses the standard C library
 name resolver (i.e., not threaded nor c-ares resolver). By default libcurl

--- a/src/module.c
+++ b/src/module.c
@@ -328,7 +328,7 @@ initpycurl(void)
     PyObject *collections_module = NULL;
     PyObject *named_tuple = NULL;
     PyObject *arglist = NULL;
-    
+
     assert(Curl_Type.tp_weaklistoffset > 0);
     assert(CurlMulti_Type.tp_weaklistoffset > 0);
     assert(CurlShare_Type.tp_weaklistoffset > 0);
@@ -355,6 +355,8 @@ initpycurl(void)
         runtime_ssl_lib = "gnutls";
     } else if (!strncmp(vi->ssl_version, "NSS/", 4)) {
         runtime_ssl_lib = "nss";
+    } else if (!strncmp(vi->ssl_version, "mbedTLS/", 2)) {
+        runtime_ssl_lib = "mbedtls";
     } else {
         runtime_ssl_lib = "none/other";
     }
@@ -461,7 +463,7 @@ initpycurl(void)
     /* constants for ioctl callback argument values */
     insint_c(d, "IOCMD_NOP", CURLIOCMD_NOP);
     insint_c(d, "IOCMD_RESTARTREAD", CURLIOCMD_RESTARTREAD);
-    
+
     /* opensocketfunction return value */
     insint_c(d, "SOCKET_BAD", CURL_SOCKET_BAD);
 

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -174,6 +174,11 @@ pycurl_inet_ntop (int family, void *addr, char *string, size_t string_size);
 #   define COMPILE_SSL_LIB "gnutls"
 # elif defined(HAVE_CURL_NSS)
 #   define COMPILE_SSL_LIB "nss"
+# elif defined(HAVE_CURL_MBEDTLS)
+#   include <mbedtls/ssl.h>
+#   define PYCURL_NEED_SSL_TSL
+#   define PYCURL_NEED_MBEDTLS_TSL
+#   define COMPILE_SSL_LIB "mbedtls"
 # else
 #  ifdef _MSC_VER
     /* sigh */
@@ -190,7 +195,7 @@ pycurl_inet_ntop (int family, void *addr, char *string, size_t string_size);
    /* since we have no crypto callbacks for other ssl backends,
     * no reason to require users match those */
 #  define COMPILE_SSL_LIB "none/other"
-# endif /* HAVE_CURL_OPENSSL || HAVE_CURL_GNUTLS || HAVE_CURL_NSS */
+# endif /* HAVE_CURL_OPENSSL || HAVE_CURL_GNUTLS || HAVE_CURL_NSS || HAVE_CURL_MBEDTLS */
 #else
 # define COMPILE_SSL_LIB "none/other"
 #endif /* HAVE_CURL_SSL */

--- a/src/threadsupport.c
+++ b/src/threadsupport.c
@@ -232,6 +232,45 @@ pycurl_ssl_cleanup(void)
 }
 #endif
 
+/* mbedTLS */
+
+#ifdef PYCURL_NEED_MBEDTLS_TSL
+static int
+pycurl_ssl_mutex_create(void **m)
+{
+    if ((*((PyThread_type_lock *) m) = PyThread_allocate_lock()) == NULL) {
+        return -1;
+    } else {
+        return 0;
+    }
+}
+
+static int
+pycurl_ssl_mutex_destroy(void **m)
+{
+    PyThread_free_lock(*((PyThread_type_lock *) m));
+    return 0;
+}
+
+static int
+pycurl_ssl_mutex_lock(void **m)
+{
+    return !PyThread_acquire_lock(*((PyThread_type_lock *) m), 1);
+}
+
+PYCURL_INTERNAL int
+pycurl_ssl_init(void)
+{
+    return 0;
+}
+
+PYCURL_INTERNAL void
+pycurl_ssl_cleanup(void)
+{
+    return;
+}
+#endif
+
 /*************************************************************************
 // CurlShareObject
 **************************************************************************/


### PR DESCRIPTION
This pull request adds [mbedTLS](https://tls.mbed.org/) support for pycurl. mbedTLS is by default used in OpenWrt routers and without it, I can use OpenSSL or other SSL libraries, which are in OpenWrt, but I will need to compile libcurl with OpenSSL by myself, which is not so hard for me, but I can imagine for other users that it will be a little hard.

What I'm not sure is about file threadsupport.c in folder src.

I have been able to test it with mbedTLS version 2.16.0 and run the following tests, which are documented on [your website](http://pycurl.io/docs/latest/quickstart.html). 

- Following Redirects
- Working With HTTPS

Any feedback regarding it, will be **highly** appreciated as it will help me in for https://github.com/openwrt/packages/pull/8325