### PR TITLE
decode_string_list: fix populating list of decoded strings

### DIFF
--- a/src/easyinfo.c
+++ b/src/easyinfo.c
@@ -277,6 +277,7 @@ decode_string_list(PyObject *list)
         if (decoded_item == NULL) {
             goto err;
         }
+	PyList_SetItem(decoded_list, i, decoded_item);
     }
     
     return decoded_list;


### PR DESCRIPTION
Under Python3 the call curl.getinfo(pycurl.INFO_COOKIELIST) returns
invalid list (for example `[<NULL>]`), which cases segmentation fault.
The cause is in function decode_string_list() (Python3 only) which
creates new list without populating it with elements. This commit
adds the setting of elements fixing the behaviour.