### PR TITLE
Disable pip version check by environment variable on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,8 @@ environment:
     # /E:ON and /V:ON options are not enabled in the batch script intepreter
     # See: http://stackoverflow.com/a/13751649/163740
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\.appveyor\\run_with_env.cmd"
+    # The pip version upgrade message on stderr causes appveyor to fail steps.
+    PIP_DISABLE_PIP_VERSION_CHECK: "1"
 
   matrix:
 
@@ -62,10 +64,6 @@ install:
   # Check that we have the expected version and architecture for Python
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
-
-  # Upgrade to the latest version of pip to avoid it displaying warnings
-  # about it being out of date.
-  #- "python -m pip install --upgrade pip"
 
   # Install the build dependencies of the project. If some dependencies contain
   # compiled extensions and are not provided as pre-built wheel packages,


### PR DESCRIPTION
This removes the stderr message that causes Appveyor to fail pip callin'
commands.