### PR TITLE
Make the test suite pass on curl without nghttp2

### DIFF
--- a/tests/option_constants_test.py
+++ b/tests/option_constants_test.py
@@ -220,12 +220,14 @@ class OptionConstantsTest(unittest.TestCase):
         curl.setopt(curl.UNIX_SOCKET_PATH, '/tmp/socket.sock')
         curl.close()
 
+    @nose.plugins.attrib.attr('http2')
     @util.min_libcurl(7, 36, 0)
     def test_ssl_enable_alpn(self):
         curl = pycurl.Curl()
         curl.setopt(curl.SSL_ENABLE_ALPN, 1)
         curl.close()
 
+    @nose.plugins.attrib.attr('http2')
     @util.min_libcurl(7, 36, 0)
     def test_ssl_enable_npn(self):
         curl = pycurl.Curl()


### PR DESCRIPTION
Since curl 7.65.0, CURLOPT_SSL_ENABLE_NPN and CURLOPT_SSL_ENABLE_ALPN
are available only if libcurl is built with nghttp2 [1].

Closes: #570

[1] https://github.com/curl/curl/commit/e91e48161235272ff485ff32bd048c53af731f43#diff-72ee0eef31d053c9e6d4fb22e81d2407R2618