### PR TITLE
Fix link order for when OpenSSL is static

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -501,14 +501,14 @@ manually. For other SSL backends please ignore this message.''')
             # for openssl < 1.1.0; it is a noop for openssl >= 1.1.0
             self.extra_link_args.append(self.openssl_lib_name)
         else:
+            # we also need ssl for the certificate functions
+            # (SSL_CTX_get_cert_store)
+            self.libraries.append('ssl')
             # the actual library that defines CRYPTO_num_locks etc.
             # is crypto, and on cygwin linking against ssl does not
             # link against crypto as of May 2014.
             # http://stackoverflow.com/questions/23687488/cant-get-pycurl-to-install-on-cygwin-missing-openssl-symbols-crypto-num-locks
             self.libraries.append('crypto')
-            # we also need ssl for the certificate functions
-            # (SSL_CTX_get_cert_store)
-            self.libraries.append('ssl')
         self.define_macros.append(('HAVE_CURL_SSL', 1))
 
     def using_wolfssl(self):


### PR DESCRIPTION
When OpenSSL is a static library, the order of linking is important because the "ssl" library depends on the "crypto" library.

```
$ ldd /usr/lib/libssl.so
        ...
	libcrypto.so.1.1 => /usr/lib/libcrypto.so.1.1 (0x00007f5028b50000)
        ...
```

Without this change, I get the following error when importing pycurl:

```
/usr/bin/python -c "import curl"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python2.7/site-packages/curl/__init__.py", line 7, in <module>
    import sys, pycurl
ImportError: /usr/lib/python2.7/site-packages/pycurl.so: undefined symbol: COMP_expand_block
```