### PR TITLE
Fix Python 3.8 related deprecation warning 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.gitignore
 *.pyc
 *.pyo
 /MANIFEST
@@ -9,7 +8,6 @@
 /src/docstrings.h
 /tests/tmp
 /tests/fake-curl/libcurl/*.so
-/.vscode
 /www/htdocs/download/*.bz2
 /www/htdocs/download/*.exe
 /www/htdocs/download/*.gz

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.gitignore
 *.pyc
 *.pyo
 /MANIFEST
@@ -8,6 +9,7 @@
 /src/docstrings.h
 /tests/tmp
 /tests/fake-curl/libcurl/*.so
+/.vscode
 /www/htdocs/download/*.bz2
 /www/htdocs/download/*.exe
 /www/htdocs/download/*.gz

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -1,6 +1,7 @@
 #if (defined(_WIN32) || defined(__WIN32__)) && !defined(WIN32)
 #  define WIN32 1
 #endif
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <pythread.h>
 #include <stddef.h>


### PR DESCRIPTION
#599 

added #define PY_SSIZE_T_CLEAN to src/pycurl.h per Python 3.8 documentation

#################################################################
TLDR: indexes should be typed as Py_ssize_t (signed) instead of int to allow the use of full address space (64bit vs. 32bit). The conversion codes 's#' and 't#' will output Py_ssize_t if the macro PY_SSIZE_T_CLEAN is defined before Python.h is included. Use PY_SSIZE_T_CLEAN and make sure all values are correctly converted.

**Documentation**:
This warning message is new in Python 3.8 and conversion must be complete before 3.10 ...

* Changelog: https://docs.python.org/3/whatsnew/3.8.html#changes-in-the-c-api
>Use of # variants of formats in parsing or building value (e.g. PyArg_ParseTuple(), Py_BuildValue(), PyObject_CallFunction(), etc.) without PY_SSIZE_T_CLEAN defined raises DeprecationWarning now. It will be removed in 3.10 or 4.0. Read Parsing arguments and building values for detail. (Contributed by Inada Naoki in bpo-36381.)

* Python Bug Tracker: https://bugs.python.org/issue36381
>Raise warning for # use without PY_SSIZE_T_CLEAN.
>* 3.8: PendingDeprecationWarning
>* 3.9: DeprecationWarning
>* 3.10 (or 4.0): Remove PY_SSIZE_T_CLEAN and use Py_ssize_t always

* PEP353: https://www.python.org/dev/peps/pep-0353/
>The conversion codes 's#' and 't#' will output Py_ssize_t if the macro PY_SSIZE_T_CLEAN is defined before Python.h is included, and continue to output int if that macro isn't defined.

```sh
# installed locally after changes
> pip list
pycurl            7.43.0.3  /Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages

> curl --version
curl 7.64.1 (x86_64-apple-darwin19.0) libcurl/7.64.1 (SecureTransport) LibreSSL/2.8.3 zlib/1.2.11 nghttp2/1.39.2

# running test script - no warning found when using pycurl.Curl.perform()
> ./ssm_pycurl.py
pycurl.VERBOSE = 1
pycurl.version = 'PycURL/7.43.0.3 libcurl/7.64.1 SecureTransport (LibreSSL/2.8.3) zlib/1.2.11 nghttp2/1.39.2'
pycurl.version_info() = (4, '7.64.1', 475137, 'x86_64-apple-darwin19.0', 5211037, 'SecureTransport (LibreSSL/2.8.3)', 0, '1.2.11', ('dict', 'file', 'ftp', 'ftps', 'gopher', 'http', 'https', 'imap', 'imaps', 'ldap', 'ldaps', 'pop3', 'pop3s', 'rtsp', 'smb', 'smbs', 'smtp', 'smtps', 'telnet', 'tftp'), None, 0, None)

```

* copy of relevant test script portions

```py
#*###################################################################################
class Curl_Wrapper():
    ''' ... [edited for content] ... '''
    def get(self):
        """
        Perform a file transfer and return
        """
        try:
            self.crl.perform()
        except pycurl.error as e:
            self.show_error(e)
            return e
        return self.b_obj.getvalue().decode(self.encoding)
    ''' ... [edited for content] ... '''
#*###################################################################################
test_url: bytes = b'https://wiki.python.org/moin/BeginnersGuide'
crl = Curl_Wrapper(test_url) # per documentation: initializing a Curl object sets VERBOSE = 0
crl.set_verbose() # explicitly set VERBOSE = 1, as requested
response = crl.get()
print(f"{pycurl.VERBOSE = }")
print(f"{pycurl.version = }")
print(f"{pycurl.version_info() = }")
# print(f'Output of GET request:\n{response}') # prints html from url
crl.close()
#*###################################################################################
```
