### PR TITLE
Stop using legacy bdist_wininst

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -228,9 +228,6 @@ Additional Windows setup.py options:
 
     PYCURL_SETUP_OPTIONS=--avoid-stdio pip install pycurl
 
-A good ``setup.py`` target to use is ``bdist_wininst`` which produces an
-executable installer that you can run to install PycURL.
-
 You may find the following mailing list posts helpful:
 
 - https://curl.haxx.se/mail/curlpython-2009-11/0010.html

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,7 +88,7 @@ build_script:
   #-  call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
   # Build the compiled extension
   - "%CMD_IN_ENV% python setup.py docstrings"
-  - "%CMD_IN_ENV% python setup.py --with-openssl --libcurl-lib-name=libcurl_a.lib --openssl-lib-name=\"\" --curl-dir=deps bdist_wheel bdist_wininst bdist_msi bdist_egg --link-arg=/LIBPATH:deps/lib --link-arg=zlib.lib --link-arg=libcrypto.lib --link-arg=libssl.lib --link-arg=crypt32.lib --link-arg=advapi32.lib --link-arg=libcares.lib --link-arg=libssh2.lib --link-arg=nghttp2_static.lib --link-arg=normaliz.lib --link-arg=user32.lib"
+  - "%CMD_IN_ENV% python setup.py --with-openssl --libcurl-lib-name=libcurl_a.lib --openssl-lib-name=\"\" --curl-dir=deps bdist_wheel bdist_msi bdist_egg --link-arg=/LIBPATH:deps/lib --link-arg=zlib.lib --link-arg=libcrypto.lib --link-arg=libssl.lib --link-arg=crypt32.lib --link-arg=advapi32.lib --link-arg=libcares.lib --link-arg=libssh2.lib --link-arg=nghttp2_static.lib --link-arg=normaliz.lib --link-arg=user32.lib"
 
 test_script:
   # Run the project tests
@@ -99,7 +99,6 @@ test_script:
 after_test:
   # If tests are successful, create binary packages for the project.
   #- "%CMD_IN_ENV% python setup.py bdist_wheel"
-  #- "%CMD_IN_ENV% python setup.py bdist_wininst"
   #- "%CMD_IN_ENV% python setup.py bdist_msi"
   - ps: "ls dist"
 

--- a/winbuild.py
+++ b/winbuild.py
@@ -213,7 +213,7 @@ def build(config):
     with in_dir(config.archives_path):
         for bitness in config.bitnesses:
             for python_release in config.python_releases:
-                targets = ['bdist', 'bdist_wininst', 'bdist_msi']
+                targets = ['bdist', 'bdist_msi']
                 vc_version = PYTHON_VC_VERSIONS[python_release]
                 bconf = BuildConfig(config, bitness=bitness, vc_version=vc_version)
                 builder = PycurlBuilder(bconf=bconf, python_release=python_release)


### PR DESCRIPTION
The `bdist_wininst` file type is deprecated by PyPI:

* https://www.python.org/dev/peps/pep-0527/

It will probably be removed soon:

* https://github.com/pypa/warehouse/issues/6792
