### PR TITLE
Set python_requires='>=3.5'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -817,7 +817,7 @@ libcurl, including:
 Requirements
 ------------
 
-- Python 2.7 or 3.4 through 3.6.
+- Python 3.5-3.8.
 - libcurl 7.19.0 or better.
 
 
@@ -897,6 +897,7 @@ in COPYING-LGPL_ and COPYING-MIT_ files in the source distribution.
     ],
     packages=[PY_PACKAGE],
     package_dir={ PY_PACKAGE: os.path.join('python', 'curl') },
+    python_requires='>=3.5',
 )
 
 if sys.platform == "win32":


### PR DESCRIPTION
Will prevent users with Python 2.7 or 3.4 and older from downloading a sdist version they cannot build.
Also updated the description.

Note: supporting `python_requires` requires setuptools>=24.2.0 and pip>=9.0.0 to benefit from it.
Details here: https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires