### PR TITLE
Allow CC and CFLAGS to be overridden for  fake-curl Makefile

### DIFF
--- a/tests/fake-curl/libcurl/Makefile
+++ b/tests/fake-curl/libcurl/Makefile
@@ -1,9 +1,13 @@
-all: \
+ALL = \
 	with_gnutls.so \
 	with_nss.so \
 	with_openssl.so \
 	with_unknown_ssl.so \
 	without_ssl.so
+
+all: $(ALL)
+clean:
+	rm -f $(ALL)
 
 .SUFFIXES: .c .so
 

--- a/tests/fake-curl/libcurl/Makefile
+++ b/tests/fake-curl/libcurl/Makefile
@@ -7,8 +7,11 @@ all: \
 
 .SUFFIXES: .c .so
 
+CC = `curl-config --cc`
+CFLAGS += `curl-config --cflags`
+
 .c.so:
-	`curl-config --cc` `curl-config --cflags` -shared -fPIC \
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -shared -fPIC \
 		-Wl,-soname,$@ -o $@ $<
 
 show-targets:


### PR DESCRIPTION
Permit overriding `CC`, respect `*FLAGS` variables and add a `clean` target. This is needed to make it possible to build fake-curl correctly for different platforms.