### PR TITLE
Support the CURLOPT_HAPROXYPROTOCOL option in pycurl

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,8 @@ VERSION = "7.43.0.5"
 
 import glob, os, re, sys, subprocess
 import distutils
-
 try:
     import wheel
-
     if wheel:
         from setuptools import setup
 except ImportError:
@@ -30,8 +28,6 @@ try:
 except NameError:
     # python 3
     exception_base = Exception
-
-
 class ConfigurationError(exception_base):
     pass
 
@@ -46,11 +42,11 @@ def scan_argv(argv, s, default=None):
     i = 1
     while i < len(argv):
         arg = argv[i]
-        if s.endswith("="):
+        if s.endswith('='):
             if str.find(arg, s) == 0:
                 # --option=value
-                p = arg[len(s) :]
-                if s != "--openssl-lib-name=":
+                p = arg[len(s):]
+                if s != '--openssl-lib-name=':
                     assert p, arg
                 del argv[i]
             else:
@@ -68,16 +64,16 @@ def scan_argv(argv, s, default=None):
 
 
 def scan_argvs(argv, s):
-    if not s.endswith("="):
-        raise Exception("specification must end with =")
+    if not s.endswith('='):
+        raise Exception('specification must end with =')
     p = []
     i = 1
     while i < len(argv):
         arg = argv[i]
         if str.find(arg, s) == 0:
             # --option=value
-            p.append(arg[len(s) :])
-            if s != "--openssl-lib-name=":
+            p.append(arg[len(s):])
+            if s != '--openssl-lib-name=':
                 assert p[-1], arg
             del argv[i]
         else:
@@ -122,16 +118,11 @@ class ExtensionConfiguration(object):
                 if not dir in self.library_dirs:
                     self.library_dirs.append(dir)
             elif fatal:
-                fail(
-                    "FATAL: bad directory %s in environment variable %s" % (dir, envvar)
-                )
+                fail("FATAL: bad directory %s in environment variable %s" % (dir, envvar))
 
     def detect_features(self):
-        p = subprocess.Popen(
-            (self.curl_config(), "--features"),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
+        p = subprocess.Popen((self.curl_config(), '--features'),
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = p.communicate()
         if p.wait() != 0:
             msg = "Problem running `%s' --features" % self.curl_config()
@@ -140,22 +131,22 @@ class ExtensionConfiguration(object):
             raise ConfigurationError(msg)
         curl_has_ssl = False
         for feature in split_quoted(stdout.decode()):
-            if feature == "SSL":
+            if feature == 'SSL':
                 # this means any ssl library, not just openssl.
                 # we set the ssl flag to check for ssl library mismatch
                 # at link time and run time
-                self.define_macros.append(("HAVE_CURL_SSL", 1))
+                self.define_macros.append(('HAVE_CURL_SSL', 1))
                 curl_has_ssl = True
         self.curl_has_ssl = curl_has_ssl
 
     def ssl_options(self):
         return {
-            "--with-openssl": self.using_openssl,
-            "--with-ssl": self.using_openssl,
-            "--with-wolfssl": self.using_wolfssl,
-            "--with-gnutls": self.using_gnutls,
-            "--with-nss": self.using_nss,
-            "--with-mbedtls": self.using_mbedtls,
+            '--with-openssl': self.using_openssl,
+            '--with-ssl': self.using_openssl,
+            '--with-wolfssl': self.using_wolfssl,
+            '--with-gnutls': self.using_gnutls,
+            '--with-nss': self.using_nss,
+            '--with-mbedtls': self.using_mbedtls,
         }
 
     def detect_ssl_option(self):
@@ -164,69 +155,60 @@ class ExtensionConfiguration(object):
                 for other_option in self.ssl_options():
                     if option != other_option:
                         if scan_argv(self.argv, other_option) is not None:
-                            raise ConfigurationError(
-                                "Cannot give both %s and %s" % (option, other_option)
-                            )
+                            raise ConfigurationError('Cannot give both %s and %s' % (option, other_option))
 
                 return option
 
     def detect_ssl_backend(self):
         ssl_lib_detected = None
 
-        if "PYCURL_SSL_LIBRARY" in os.environ:
-            ssl_lib = os.environ["PYCURL_SSL_LIBRARY"]
-            if ssl_lib in ["openssl", "wolfssl", "gnutls", "nss", "mbedtls"]:
+        if 'PYCURL_SSL_LIBRARY' in os.environ:
+            ssl_lib = os.environ['PYCURL_SSL_LIBRARY']
+            if ssl_lib in ['openssl', 'wolfssl', 'gnutls', 'nss', 'mbedtls']:
                 ssl_lib_detected = ssl_lib
-                getattr(self, "using_%s" % ssl_lib)()
+                getattr(self, 'using_%s' % ssl_lib)()
             else:
-                raise ConfigurationError(
-                    'Invalid value "%s" for PYCURL_SSL_LIBRARY' % ssl_lib
-                )
+                raise ConfigurationError('Invalid value "%s" for PYCURL_SSL_LIBRARY' % ssl_lib)
 
         option = self.detect_ssl_option()
         if option:
-            ssl_lib_detected = option.replace("--with-", "")
+            ssl_lib_detected = option.replace('--with-', '')
             self.ssl_options()[option]()
 
         # ssl detection - ssl libraries are added
         if not ssl_lib_detected:
             libcurl_dll_path = scan_argv(self.argv, "--libcurl-dll=")
             if libcurl_dll_path is not None:
-                ssl_lib_detected = self.detect_ssl_lib_from_libcurl_dll(
-                    libcurl_dll_path
-                )
+                ssl_lib_detected = self.detect_ssl_lib_from_libcurl_dll(libcurl_dll_path)
 
         if not ssl_lib_detected:
             # self.sslhintbuf is a hack
             for arg in split_quoted(self.sslhintbuf):
                 if arg[:2] == "-l":
-                    if arg[2:] == "ssl":
+                    if arg[2:] == 'ssl':
                         self.using_openssl()
-                        ssl_lib_detected = "openssl"
+                        ssl_lib_detected = 'openssl'
                         break
-                    if arg[2:] == "wolfssl":
+                    if arg[2:] == 'wolfssl':
                         self.using_wolfssl()
-                        ssl_lib_detected = "wolfssl"
+                        ssl_lib_detected = 'wolfssl'
                         break
-                    if arg[2:] == "gnutls":
+                    if arg[2:] == 'gnutls':
                         self.using_gnutls()
-                        ssl_lib_detected = "gnutls"
+                        ssl_lib_detected = 'gnutls'
                         break
-                    if arg[2:] == "ssl3":
+                    if arg[2:] == 'ssl3':
                         self.using_nss()
-                        ssl_lib_detected = "nss"
+                        ssl_lib_detected = 'nss'
                         break
-                    if arg[2:] == "mbedtls":
+                    if arg[2:] == 'mbedtls':
                         self.using_mbedtls()
-                        ssl_lib_detected = "mbedtls"
+                        ssl_lib_detected = 'mbedtls'
                         break
 
-        if (
-            not ssl_lib_detected
-            and len(self.argv) == len(self.original_argv)
-            and not os.environ.get("PYCURL_CURL_CONFIG")
-            and not os.environ.get("PYCURL_SSL_LIBRARY")
-        ):
+        if not ssl_lib_detected and len(self.argv) == len(self.original_argv) \
+                and not os.environ.get('PYCURL_CURL_CONFIG') \
+                and not os.environ.get('PYCURL_SSL_LIBRARY'):
             # this path should only be taken when no options or
             # configuration environment variables are given to setup.py
             ssl_lib_detected = self.detect_ssl_lib_on_centos6_plus()
@@ -237,7 +219,7 @@ class ExtensionConfiguration(object):
         try:
             return self._curl_config
         except AttributeError:
-            curl_config = os.environ.get("PYCURL_CURL_CONFIG", "curl-config")
+            curl_config = os.environ.get('PYCURL_CURL_CONFIG', "curl-config")
             curl_config = scan_argv(self.argv, "--curl-config=", curl_config)
             self._curl_config = curl_config
             return curl_config
@@ -248,31 +230,22 @@ class ExtensionConfiguration(object):
             self.include_dirs.append(os.path.join(OPENSSL_DIR, "include"))
             self.library_dirs.append(os.path.join(OPENSSL_DIR, "lib"))
         try:
-            p = subprocess.Popen(
-                (self.curl_config(), "--version"),
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )
+            p = subprocess.Popen((self.curl_config(), '--version'),
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         except OSError:
             exc = sys.exc_info()[1]
-            msg = "Could not run curl-config: %s" % str(exc)
+            msg = 'Could not run curl-config: %s' % str(exc)
             raise ConfigurationError(msg)
         stdout, stderr = p.communicate()
         if p.wait() != 0:
-            msg = (
-                "`%s' not found -- please install the libcurl development files or specify --curl-config=/path/to/curl-config"
-                % self.curl_config()
-            )
+            msg = "`%s' not found -- please install the libcurl development files or specify --curl-config=/path/to/curl-config" % self.curl_config()
             if stderr:
                 msg += ":\n" + stderr.decode()
             raise ConfigurationError(msg)
         libcurl_version = stdout.decode().strip()
         print("Using %s (%s)" % (self.curl_config(), libcurl_version))
-        p = subprocess.Popen(
-            (self.curl_config(), "--cflags"),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
+        p = subprocess.Popen((self.curl_config(), '--cflags'),
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = p.communicate()
         if p.wait() != 0:
             msg = "Problem running `%s' --cflags" % self.curl_config()
@@ -309,18 +282,15 @@ class ExtensionConfiguration(object):
         # even if libcurl does not tell us to, because *we* invoke functions
         # in that SSL library. This means any SSL libraries found in
         # --static-libs are forwarded to our libraries.
-        optbuf = ""
-        sslhintbuf = ""
-        errtext = ""
+        optbuf = ''
+        sslhintbuf = ''
+        errtext = ''
         for option in ["--libs", "--static-libs"]:
-            p = subprocess.Popen(
-                (self.curl_config(), option),
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )
+            p = subprocess.Popen((self.curl_config(), option),
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             stdout, stderr = p.communicate()
             if p.wait() == 0:
-                if optbuf == "":
+                if optbuf == '':
                     # first successful call
                     optbuf = stdout.decode()
                     # optbuf only has output from this call
@@ -329,7 +299,7 @@ class ExtensionConfiguration(object):
                     # second successful call
                     sslhintbuf += stdout.decode()
             else:
-                if optbuf == "":
+                if optbuf == '':
                     # no successful call yet
                     errtext += stderr.decode()
                 else:
@@ -337,10 +307,8 @@ class ExtensionConfiguration(object):
                     # ignore stderr and the error exit
                     pass
         if optbuf == "":
-            msg = (
-                "Neither curl-config --libs nor curl-config --static-libs"
-                + " succeeded and produced output"
-            )
+            msg = "Neither curl-config --libs nor curl-config --static-libs" +\
+                " succeeded and produced output"
             if errtext:
                 msg += ":\n" + errtext
             raise ConfigurationError(msg)
@@ -354,18 +322,14 @@ class ExtensionConfiguration(object):
             self.detect_ssl_backend()
 
             if not self.ssl_lib_detected:
-                sys.stderr.write(
-                    """\
+                sys.stderr.write('''\
 Warning: libcurl is configured to use SSL, but we have not been able to \
 determine which SSL backend it is using. If your Curl is built against \
 OpenSSL, LibreSSL, BoringSSL, GnuTLS, NSS or mbedTLS please specify the SSL backend \
-manually. For other SSL backends please ignore this message."""
-                )
+manually. For other SSL backends please ignore this message.''')
         else:
             if self.detect_ssl_option():
-                sys.stderr.write(
-                    "Warning: SSL backend specified manually but libcurl does not use SSL\n"
-                )
+                sys.stderr.write("Warning: SSL backend specified manually but libcurl does not use SSL\n")
 
         # libraries and options - all libraries and options are forwarded
         # but if --libs succeeded, --static-libs output is ignored
@@ -381,7 +345,7 @@ manually. For other SSL backends please ignore this message."""
             self.libraries.append("curl")
 
         # Add extra compile flag for MacOS X
-        if sys.platform.startswith("darwin"):
+        if sys.platform.startswith('darwin'):
             self.extra_link_args.append("-flat_namespace")
 
         # Recognize --avoid-stdio on Unix so that it can be tested
@@ -393,33 +357,32 @@ manually. For other SSL backends please ignore this message."""
         ssl_version = curl_version_info.ssl_version
         if py3:
             # ssl_version is bytes on python 3
-            ssl_version = ssl_version.decode("ascii")
-        if ssl_version.startswith("OpenSSL/") or ssl_version.startswith("LibreSSL/"):
+            ssl_version = ssl_version.decode('ascii')
+        if ssl_version.startswith('OpenSSL/') or ssl_version.startswith('LibreSSL/'):
             self.using_openssl()
-            ssl_lib_detected = "openssl"
-        elif ssl_version.startswith("GnuTLS/"):
+            ssl_lib_detected = 'openssl'
+        elif ssl_version.startswith('GnuTLS/'):
             self.using_gnutls()
-            ssl_lib_detected = "gnutls"
-        elif ssl_version.startswith("NSS/"):
+            ssl_lib_detected = 'gnutls'
+        elif ssl_version.startswith('NSS/'):
             self.using_nss()
-            ssl_lib_detected = "nss"
-        elif ssl_version.startswith("mbedTLS/"):
+            ssl_lib_detected = 'nss'
+        elif ssl_version.startswith('mbedTLS/'):
             self.using_mbedtls()
-            ssl_lib_detected = "mbedtls"
+            ssl_lib_detected = 'mbedtls'
         return ssl_lib_detected
 
     def detect_ssl_lib_on_centos6_plus(self):
         import platform
         from ctypes.util import find_library
-
         os_name = platform.system()
-        if os_name != "Linux" or not hasattr(platform, "dist"):
+        if os_name != 'Linux' or not hasattr(platform, 'dist'):
             return False
         dist_name, dist_version, _ = platform.dist()
-        dist_version = dist_version.split(".")[0]
-        if dist_name != "centos" or int(dist_version) < 6:
+        dist_version = dist_version.split('.')[0]
+        if dist_name != 'centos' or int(dist_version) < 6:
             return False
-        libcurl_dll_path = find_library("curl")
+        libcurl_dll_path = find_library('curl')
         print('libcurl_dll_path = "%s"' % libcurl_dll_path)
         return self.detect_ssl_lib_from_libcurl_dll(libcurl_dll_path)
 
@@ -441,17 +404,15 @@ manually. For other SSL backends please ignore this message."""
         # For libcurl 7.46.0, the library name is libcurl.lib.
         # And static library name is libcurl_a.lib by default as of libcurl 7.46.0.
         # override with: --libcurl-lib-name=libcurl_imp.lib
-        curl_lib_name = scan_argv(self.argv, "--libcurl-lib-name=", "libcurl.lib")
+        curl_lib_name = scan_argv(self.argv, '--libcurl-lib-name=', 'libcurl.lib')
 
         # openssl 1.1.0 changed its library names
         # from libeay32.lib/ssleay32.lib to libcrypto.lib/libssl.lib.
         # at the same time they dropped thread locking callback interface,
         # meaning the correct usage of this option is --openssl-lib-name=""
-        self.openssl_lib_name = scan_argv(
-            self.argv, "--openssl-lib-name=", "libeay32.lib"
-        )
+        self.openssl_lib_name = scan_argv(self.argv, '--openssl-lib-name=', 'libeay32.lib')
 
-        for lib in scan_argvs(self.argv, "--link-arg="):
+        for lib in scan_argvs(self.argv, '--link-arg='):
             self.extra_link_args.append(lib)
 
         if scan_argv(self.argv, "--use-libcurl-dll") is not None:
@@ -463,21 +424,13 @@ manually. For other SSL backends please ignore this message."""
         else:
             self.extra_compile_args.append("-DCURL_STATICLIB")
             libcurl_lib_path = os.path.join(curl_dir, "lib", curl_lib_name)
-            self.extra_link_args.extend(
-                ["gdi32.lib", "wldap32.lib", "winmm.lib", "ws2_32.lib",]
-            )
+            self.extra_link_args.extend(["gdi32.lib", "wldap32.lib", "winmm.lib", "ws2_32.lib",])
 
         if not os.path.exists(libcurl_lib_path):
-            fail(
-                "libcurl.lib does not exist at %s.\nCurl directory must point to compiled libcurl (bin/include/lib subdirectories): %s"
-                % (libcurl_lib_path, curl_dir)
-            )
+            fail("libcurl.lib does not exist at %s.\nCurl directory must point to compiled libcurl (bin/include/lib subdirectories): %s" %(libcurl_lib_path, curl_dir))
         self.extra_objects.append(libcurl_lib_path)
 
-        if (
-            scan_argv(self.argv, "--with-openssl") is not None
-            or scan_argv(self.argv, "--with-ssl") is not None
-        ):
+        if scan_argv(self.argv, '--with-openssl') is not None or scan_argv(self.argv, '--with-ssl') is not None:
             self.using_openssl()
 
         self.check_avoid_stdio()
@@ -491,32 +444,26 @@ manually. For other SSL backends please ignore this message."""
 
         if str.find(sys.version, "MSC") >= 0:
             self.extra_compile_args.append("-O2")
-            self.extra_compile_args.append("-GF")  # enable read-only string pooling
-            self.extra_compile_args.append("-WX")  # treat warnings as errors
-            p = subprocess.Popen(
-                ["cl.exe"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
-            )
+            self.extra_compile_args.append("-GF")        # enable read-only string pooling
+            self.extra_compile_args.append("-WX")        # treat warnings as errors
+            p = subprocess.Popen(['cl.exe'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             out, err = p.communicate()
-            match = re.search(r"Version (\d+)", err.decode().split("\n")[0])
+            match = re.search(r'Version (\d+)', err.decode().split("\n")[0])
             if match and int(match.group(1)) < 16:
                 # option removed in vs 2010:
                 # connect.microsoft.com/VisualStudio/feedback/details/475896/link-fatal-error-lnk1117-syntax-error-in-option-opt-nowin98/
-                self.extra_link_args.append(
-                    "/opt:nowin98"
-                )  # use small section alignment
+                self.extra_link_args.append("/opt:nowin98")  # use small section alignment
 
     if sys.platform == "win32":
         configure = configure_windows
     else:
         configure = configure_unix
 
+
     def check_avoid_stdio(self):
-        if (
-            "PYCURL_SETUP_OPTIONS" in os.environ
-            and "--avoid-stdio" in os.environ["PYCURL_SETUP_OPTIONS"]
-        ):
+        if 'PYCURL_SETUP_OPTIONS' in os.environ and '--avoid-stdio' in os.environ['PYCURL_SETUP_OPTIONS']:
             self.extra_compile_args.append("-DPYCURL_AVOID_STDIO")
-        if scan_argv(self.argv, "--avoid-stdio") is not None:
+        if scan_argv(self.argv, '--avoid-stdio') is not None:
             self.extra_compile_args.append("-DPYCURL_AVOID_STDIO")
 
     def get_curl_version_info(self, dll_path):
@@ -524,20 +471,20 @@ manually. For other SSL backends please ignore this message."""
 
         class curl_version_info_struct(ctypes.Structure):
             _fields_ = [
-                ("age", ctypes.c_int),
-                ("version", ctypes.c_char_p),
-                ("version_num", ctypes.c_uint),
-                ("host", ctypes.c_char_p),
-                ("features", ctypes.c_int),
-                ("ssl_version", ctypes.c_char_p),
-                ("ssl_version_num", ctypes.c_long),
-                ("libz_version", ctypes.c_char_p),
-                ("protocols", ctypes.c_void_p),
-                ("ares", ctypes.c_char_p),
-                ("ares_num", ctypes.c_int),
-                ("libidn", ctypes.c_char_p),
-                ("iconv_ver_num", ctypes.c_int),
-                ("libssh_version", ctypes.c_char_p),
+                ('age', ctypes.c_int),
+                ('version', ctypes.c_char_p),
+                ('version_num', ctypes.c_uint),
+                ('host', ctypes.c_char_p),
+                ('features', ctypes.c_int),
+                ('ssl_version', ctypes.c_char_p),
+                ('ssl_version_num', ctypes.c_long),
+                ('libz_version', ctypes.c_char_p),
+                ('protocols', ctypes.c_void_p),
+                ('ares', ctypes.c_char_p),
+                ('ares_num', ctypes.c_int),
+                ('libidn', ctypes.c_char_p),
+                ('iconv_ver_num', ctypes.c_int),
+                ('libssh_version', ctypes.c_char_p),
             ]
 
         dll = ctypes.CDLL(dll_path)
@@ -549,7 +496,7 @@ manually. For other SSL backends please ignore this message."""
         return fn(3)[0]
 
     def using_openssl(self):
-        self.define_macros.append(("HAVE_CURL_OPENSSL", 1))
+        self.define_macros.append(('HAVE_CURL_OPENSSL', 1))
         if sys.platform == "win32":
             # CRYPTO_num_locks is defined in libeay32.lib
             # for openssl < 1.1.0; it is a noop for openssl >= 1.1.0
@@ -557,39 +504,38 @@ manually. For other SSL backends please ignore this message."""
         else:
             # we also need ssl for the certificate functions
             # (SSL_CTX_get_cert_store)
-            self.libraries.append("ssl")
+            self.libraries.append('ssl')
             # the actual library that defines CRYPTO_num_locks etc.
             # is crypto, and on cygwin linking against ssl does not
             # link against crypto as of May 2014.
             # http://stackoverflow.com/questions/23687488/cant-get-pycurl-to-install-on-cygwin-missing-openssl-symbols-crypto-num-locks
-            self.libraries.append("crypto")
-        self.define_macros.append(("HAVE_CURL_SSL", 1))
-        self.ssl_lib_detected = "openssl"
+            self.libraries.append('crypto')
+        self.define_macros.append(('HAVE_CURL_SSL', 1))
+        self.ssl_lib_detected = 'openssl'
 
     def using_wolfssl(self):
-        self.define_macros.append(("HAVE_CURL_WOLFSSL", 1))
-        self.libraries.append("wolfssl")
-        self.define_macros.append(("HAVE_CURL_SSL", 1))
-        self.ssl_lib_detected = "wolfssl"
+        self.define_macros.append(('HAVE_CURL_WOLFSSL', 1))
+        self.libraries.append('wolfssl')
+        self.define_macros.append(('HAVE_CURL_SSL', 1))
+        self.ssl_lib_detected = 'wolfssl'
 
     def using_gnutls(self):
-        self.define_macros.append(("HAVE_CURL_GNUTLS", 1))
-        self.libraries.append("gnutls")
-        self.define_macros.append(("HAVE_CURL_SSL", 1))
-        self.ssl_lib_detected = "gnutls"
+        self.define_macros.append(('HAVE_CURL_GNUTLS', 1))
+        self.libraries.append('gnutls')
+        self.define_macros.append(('HAVE_CURL_SSL', 1))
+        self.ssl_lib_detected = 'gnutls'
 
     def using_nss(self):
-        self.define_macros.append(("HAVE_CURL_NSS", 1))
-        self.libraries.append("ssl3")
-        self.define_macros.append(("HAVE_CURL_SSL", 1))
-        self.ssl_lib_detected = "nss"
+        self.define_macros.append(('HAVE_CURL_NSS', 1))
+        self.libraries.append('ssl3')
+        self.define_macros.append(('HAVE_CURL_SSL', 1))
+        self.ssl_lib_detected = 'nss'
 
     def using_mbedtls(self):
-        self.define_macros.append(("HAVE_CURL_MBEDTLS", 1))
-        self.libraries.append("mbedtls")
-        self.define_macros.append(("HAVE_CURL_SSL", 1))
-        self.ssl_lib_detected = "mbedtls"
-
+        self.define_macros.append(('HAVE_CURL_MBEDTLS', 1))
+        self.libraries.append('mbedtls')
+        self.define_macros.append(('HAVE_CURL_SSL', 1))
+        self.ssl_lib_detected = 'mbedtls'
 
 def get_bdist_msi_version_hack():
     # workaround for distutils/msi version requirement per
@@ -603,41 +549,36 @@ def get_bdist_msi_version_hack():
 
     class bdist_msi_version_hack(bdist_msi):
         """ MSI builder requires version to be in the x.x.x format """
-
         def run(self):
             def monkey_get_version(self):
                 """ monkey patch replacement for metadata.get_version() that
                         returns MSI compatible version string for bdist_msi
                 """
                 # get filename of the calling function
-                if inspect.stack()[1][1].endswith("bdist_msi.py"):
+                if inspect.stack()[1][1].endswith('bdist_msi.py'):
                     # strip revision from version (if any), e.g. 11.0.0-r31546
-                    match = re.match(r"(\d+\.\d+\.\d+)", self.version)
+                    match = re.match(r'(\d+\.\d+\.\d+)', self.version)
                     assert match
                     return match.group(1)
                 else:
                     return self.version
 
             # monkeypatching get_version() call for DistributionMetadata
-            self.distribution.metadata.get_version = types.MethodType(
-                monkey_get_version, self.distribution.metadata
-            )
+            self.distribution.metadata.get_version = \
+                types.MethodType(monkey_get_version, self.distribution.metadata)
             bdist_msi.run(self)
 
     return bdist_msi_version_hack
 
 
 def strip_pycurl_options(argv):
-    if sys.platform == "win32":
+    if sys.platform == 'win32':
         options = [
-            "--curl-dir=",
-            "--libcurl-lib-name=",
-            "--use-libcurl-dll",
-            "--avoid-stdio",
-            "--with-openssl",
+            '--curl-dir=', '--libcurl-lib-name=', '--use-libcurl-dll',
+            '--avoid-stdio', '--with-openssl',
         ]
     else:
-        options = ["--openssl-dir=", "--curl-config=", "--avoid-stdio"]
+        options = ['--openssl-dir=', '--curl-config=', '--avoid-stdio']
     for option in options:
         scan_argv(argv, option)
 
@@ -646,13 +587,12 @@ def strip_pycurl_options(argv):
 
 PRETTY_SSL_LIBS = {
     # setup.py may be detecting BoringSSL properly, need to test
-    "openssl": "OpenSSL/LibreSSL/BoringSSL",
-    "wolfssl": "wolfSSL",
-    "gnutls": "GnuTLS",
-    "nss": "NSS",
-    "mbedtls": "mbedTLS",
+    'openssl': 'OpenSSL/LibreSSL/BoringSSL',
+    'wolfssl': 'wolfSSL',
+    'gnutls': 'GnuTLS',
+    'nss': 'NSS',
+    'mbedtls': 'mbedTLS',
 }
-
 
 def get_extension(argv, split_extension_source=False):
     if split_extension_source:
@@ -683,9 +623,9 @@ def get_extension(argv, split_extension_source=False):
     ext_config = ExtensionConfiguration(argv)
 
     if ext_config.ssl_lib_detected:
-        print("Using SSL library: %s" % PRETTY_SSL_LIBS[ext_config.ssl_lib_detected])
+        print('Using SSL library: %s' % PRETTY_SSL_LIBS[ext_config.ssl_lib_detected])
     else:
-        print("Not using an SSL library")
+        print('Not using an SSL library')
 
     ext = Extension(
         name=PACKAGE,
@@ -708,7 +648,6 @@ def get_extension(argv, split_extension_source=False):
 
 # prepare data_files
 
-
 def get_data_files():
     # a list of tuples with (path to install to, a list of local files)
     data_files = []
@@ -717,15 +656,8 @@ def get_data_files():
     else:
         datadir = os.path.join("share", "doc", PACKAGE)
     #
-    files = [
-        "AUTHORS",
-        "ChangeLog",
-        "COPYING-LGPL",
-        "COPYING-MIT",
-        "INSTALL.rst",
-        "README.rst",
-        "RELEASE-NOTES.rst",
-    ]
+    files = ["AUTHORS", "ChangeLog", "COPYING-LGPL", "COPYING-MIT",
+        "INSTALL.rst", "README.rst", "RELEASE-NOTES.rst"]
     if files:
         data_files.append((os.path.join(datadir), files))
     files = glob.glob(os.path.join("examples", "*.py"))
@@ -745,18 +677,17 @@ def get_data_files():
 
 ###############################################################################
 
-
 def check_manifest():
     import fnmatch
 
-    f = open("MANIFEST.in")
+    f = open('MANIFEST.in')
     globs = []
     try:
         for line in f.readlines():
             stripped = line.strip()
-            if stripped == "" or stripped.startswith("#"):
+            if stripped == '' or stripped.startswith('#'):
                 continue
-            assert stripped.startswith("include ")
+            assert stripped.startswith('include ')
             glob = stripped[8:]
             globs.append(glob)
     finally:
@@ -765,12 +696,12 @@ def check_manifest():
     paths = []
     start = os.path.abspath(os.path.dirname(__file__))
     for root, dirs, files in os.walk(start):
-        if ".git" in dirs:
-            dirs.remove(".git")
+        if '.git' in dirs:
+            dirs.remove('.git')
         for file in files:
-            if file.endswith(".pyc"):
+            if file.endswith('.pyc'):
                 continue
-            rel = os.path.join(root, file)[len(start) + 1 :]
+            rel = os.path.join(root, file)[len(start)+1:]
             paths.append(rel)
 
     for path in paths:
@@ -782,12 +713,10 @@ def check_manifest():
         if not included:
             print(path)
 
-
 AUTHORS_PARAGRAPH = 3
 
-
 def check_authors():
-    f = open("AUTHORS")
+    f = open('AUTHORS')
     try:
         contents = f.read()
     finally:
@@ -797,14 +726,14 @@ def check_authors():
     authors_para = paras[AUTHORS_PARAGRAPH]
     authors = [author for author in authors_para.strip().split("\n")]
 
-    log = subprocess.check_output(["git", "log", "--format=%an (%ae)"])
+    log = subprocess.check_output(['git', 'log', '--format=%an (%ae)'])
     for author in log.strip().split("\n"):
-        author = author.replace("@", " at ").replace("(", "<").replace(")", ">")
+        author = author.replace('@', ' at ').replace('(', '<').replace(')', '>')
         if author not in authors:
             authors.append(author)
     authors.sort()
     paras[AUTHORS_PARAGRAPH] = "\n".join(authors)
-    f = open("AUTHORS", "w")
+    f = open('AUTHORS', 'w')
     try:
         f.write("\n\n".join(paras))
     finally:
@@ -813,29 +742,29 @@ def check_authors():
 
 def convert_docstrings():
     docstrings = []
-    for entry in sorted(os.listdir("doc/docstrings")):
-        if not entry.endswith(".rst"):
+    for entry in sorted(os.listdir('doc/docstrings')):
+        if not entry.endswith('.rst'):
             continue
 
-        name = entry.replace(".rst", "")
-        f = open("doc/docstrings/%s" % entry)
+        name = entry.replace('.rst', '')
+        f = open('doc/docstrings/%s' % entry)
         try:
             text = f.read().strip()
         finally:
             f.close()
         docstrings.append((name, text))
-    f = open("src/docstrings.c", "w")
+    f = open('src/docstrings.c', 'w')
     try:
         f.write("/* Generated file - do not edit. */\n")
         # space to avoid having /* inside a C comment
         f.write("/* See doc/docstrings/ *.rst. */\n\n")
-        f.write('#include "pycurl.h"\n\n')
+        f.write("#include \"pycurl.h\"\n\n")
         for name, text in docstrings:
-            text = text.replace('"', '\\"').replace("\n", "\\n\\\n")
-            f.write('PYCURL_INTERNAL const char %s_doc[] = "%s";\n\n' % (name, text))
+            text = text.replace("\"", "\\\"").replace("\n", "\\n\\\n")
+            f.write("PYCURL_INTERNAL const char %s_doc[] = \"%s\";\n\n" % (name, text))
     finally:
         f.close()
-    f = open("src/docstrings.h", "w")
+    f = open('src/docstrings.h', 'w')
     try:
         f.write("/* Generated file - do not edit. */\n")
         # space to avoid having /* inside a C comment
@@ -847,20 +776,19 @@ def convert_docstrings():
 
 
 def gen_docstrings_sources():
-    sources = "DOCSTRINGS_SOURCES ="
-    for entry in sorted(os.listdir("doc/docstrings")):
-        if entry.endswith(".rst"):
+    sources = 'DOCSTRINGS_SOURCES ='
+    for entry in sorted(os.listdir('doc/docstrings')):
+        if entry.endswith('.rst'):
             sources += " \\\n\tdoc/docstrings/%s" % entry
     print(sources)
-
 
 ###############################################################################
 
 setup_args = dict(
     name=PACKAGE,
     version=VERSION,
-    description="PycURL -- A Python Interface To The cURL library",
-    long_description="""\
+    description='PycURL -- A Python Interface To The cURL library',
+    long_description='''\
 PycURL -- A Python Interface To The cURL library
 ================================================
 
@@ -942,46 +870,38 @@ in COPYING-LGPL_ and COPYING-MIT_ files in the source distribution.
 .. _urllib: http://docs.python.org/library/urllib.html
 .. _COPYING-LGPL: https://raw.githubusercontent.com/pycurl/pycurl/master/COPYING-LGPL
 .. _COPYING-MIT: https://raw.githubusercontent.com/pycurl/pycurl/master/COPYING-MIT
-""",
+''',
     author="Kjetil Jacobsen, Markus F.X.J. Oberhumer, Oleg Pudeyev",
     author_email="kjetilja@gmail.com, markus@oberhumer.com, oleg@bsdpower.com",
     maintainer="Oleg Pudeyev",
     maintainer_email="oleg@bsdpower.com",
     url="http://pycurl.io/",
     license="LGPL/MIT",
-    keywords=[
-        "curl",
-        "libcurl",
-        "urllib",
-        "wget",
-        "download",
-        "file transfer",
-        "http",
-        "www",
-    ],
+    keywords=['curl', 'libcurl', 'urllib', 'wget', 'download', 'file transfer',
+        'http', 'www'],
     classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Environment :: Web Environment",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: Microsoft :: Windows",
-        "Operating System :: POSIX",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Topic :: Internet :: File Transfer Protocol (FTP)",
-        "Topic :: Internet :: WWW/HTTP",
+        'Development Status :: 5 - Production/Stable',
+        'Environment :: Web Environment',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: Microsoft :: Windows',
+        'Operating System :: POSIX',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Topic :: Internet :: File Transfer Protocol (FTP)',
+        'Topic :: Internet :: WWW/HTTP',
     ],
     packages=[PY_PACKAGE],
-    package_dir={PY_PACKAGE: os.path.join("python", "curl")},
-    python_requires=">=3.5",
+    package_dir={ PY_PACKAGE: os.path.join('python', 'curl') },
+    python_requires='>=3.5',
 )
 
 if sys.platform == "win32":
-    setup_args["cmdclass"] = {"bdist_msi": get_bdist_msi_version_hack()}
+    setup_args['cmdclass'] = {'bdist_msi': get_bdist_msi_version_hack()}
 
 ##print distutils.__version__
 if LooseVersion(distutils.__version__) > LooseVersion("1.0.1"):
@@ -989,7 +909,7 @@ if LooseVersion(distutils.__version__) > LooseVersion("1.0.1"):
 if LooseVersion(distutils.__version__) < LooseVersion("1.0.3"):
     setup_args["licence"] = setup_args["license"]
 
-unix_help = """\
+unix_help = '''\
 PycURL Unix options:
  --curl-config=/path/to/curl-config  use specified curl-config binary
  --libcurl-dll=[/path/to/]libcurl.so obtain SSL library from libcurl.so
@@ -1000,9 +920,9 @@ PycURL Unix options:
  --with-nss                          libcurl is linked against NSS
  --with-mbedtls                      libcurl is linked against mbedTLS
  --with-wolfssl                      libcurl is linked against wolfSSL
-"""
+'''
 
-windows_help = """\
+windows_help = '''\
 PycURL Windows options:
  --curl-dir=/path/to/compiled/libcurl  path to libcurl headers and libraries
  --use-libcurl-dll                     link against libcurl DLL, if not given
@@ -1011,10 +931,10 @@ PycURL Windows options:
  --with-openssl                        libcurl is linked against OpenSSL/LibreSSL/BoringSSL
  --with-ssl                            legacy alias for --with-openssl
  --link-arg=foo.lib                    also link against specified library
-"""
+'''
 
 if __name__ == "__main__":
-    if "--help" in sys.argv or "-h" in sys.argv:
+    if '--help' in sys.argv or '-h' in sys.argv:
         # unfortunately this help precedes distutils help
         if sys.platform == "win32":
             print(windows_help)
@@ -1025,33 +945,28 @@ if __name__ == "__main__":
         # we need to remove our options because distutils complains about them
         strip_pycurl_options(sys.argv)
         setup(**setup_args)
-    elif len(sys.argv) > 1 and sys.argv[1] == "manifest":
+    elif len(sys.argv) > 1 and sys.argv[1] == 'manifest':
         check_manifest()
-    elif len(sys.argv) > 1 and sys.argv[1] == "docstrings":
+    elif len(sys.argv) > 1 and sys.argv[1] == 'docstrings':
         convert_docstrings()
-    elif len(sys.argv) > 1 and sys.argv[1] == "authors":
+    elif len(sys.argv) > 1 and sys.argv[1] == 'authors':
         check_authors()
-    elif len(sys.argv) > 1 and sys.argv[1] == "docstrings-sources":
+    elif len(sys.argv) > 1 and sys.argv[1] == 'docstrings-sources':
         gen_docstrings_sources()
     else:
-        setup_args["data_files"] = get_data_files()
-
         # Generate docstrings before installing if we're installing directly
         # from Git (eg. pip3 install git://github.com/repo/pycurl#egg=pycurl),
-        # otherwise we'll get an error because src/docstrings.c, .h do not
-        # exist yet
+        # otherwise we'll get a build error because src/docstrings.{c,h} do not
+        # exist
         convert_docstrings()
 
-        if "PYCURL_RELEASE" in os.environ and os.environ["PYCURL_RELEASE"].lower() in [
-            "1",
-            "yes",
-            "true",
-        ]:
+        setup_args['data_files'] = get_data_files()
+        if 'PYCURL_RELEASE' in os.environ and os.environ['PYCURL_RELEASE'].lower() in ['1', 'yes', 'true']:
             split_extension_source = False
         else:
             split_extension_source = True
         ext = get_extension(sys.argv, split_extension_source=split_extension_source)
-        setup_args["ext_modules"] = [ext]
+        setup_args['ext_modules'] = [ext]
 
         for o in ext.extra_objects:
             assert os.path.isfile(o), o

--- a/setup.py
+++ b/setup.py
@@ -954,12 +954,6 @@ if __name__ == "__main__":
     elif len(sys.argv) > 1 and sys.argv[1] == 'docstrings-sources':
         gen_docstrings_sources()
     else:
-        # Generate docstrings before installing if we're installing directly
-        # from Git (eg. pip3 install git://github.com/repo/pycurl#egg=pycurl),
-        # otherwise we'll get a build error because src/docstrings.{c,h} do not
-        # exist
-        convert_docstrings()
-
         setup_args['data_files'] = get_data_files()
         if 'PYCURL_RELEASE' in os.environ and os.environ['PYCURL_RELEASE'].lower() in ['1', 'yes', 'true']:
             split_extension_source = False

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,10 @@ VERSION = "7.43.0.5"
 
 import glob, os, re, sys, subprocess
 import distutils
+
 try:
     import wheel
+
     if wheel:
         from setuptools import setup
 except ImportError:
@@ -28,6 +30,8 @@ try:
 except NameError:
     # python 3
     exception_base = Exception
+
+
 class ConfigurationError(exception_base):
     pass
 
@@ -42,11 +46,11 @@ def scan_argv(argv, s, default=None):
     i = 1
     while i < len(argv):
         arg = argv[i]
-        if s.endswith('='):
+        if s.endswith("="):
             if str.find(arg, s) == 0:
                 # --option=value
-                p = arg[len(s):]
-                if s != '--openssl-lib-name=':
+                p = arg[len(s) :]
+                if s != "--openssl-lib-name=":
                     assert p, arg
                 del argv[i]
             else:
@@ -64,16 +68,16 @@ def scan_argv(argv, s, default=None):
 
 
 def scan_argvs(argv, s):
-    if not s.endswith('='):
-        raise Exception('specification must end with =')
+    if not s.endswith("="):
+        raise Exception("specification must end with =")
     p = []
     i = 1
     while i < len(argv):
         arg = argv[i]
         if str.find(arg, s) == 0:
             # --option=value
-            p.append(arg[len(s):])
-            if s != '--openssl-lib-name=':
+            p.append(arg[len(s) :])
+            if s != "--openssl-lib-name=":
                 assert p[-1], arg
             del argv[i]
         else:
@@ -118,11 +122,16 @@ class ExtensionConfiguration(object):
                 if not dir in self.library_dirs:
                     self.library_dirs.append(dir)
             elif fatal:
-                fail("FATAL: bad directory %s in environment variable %s" % (dir, envvar))
+                fail(
+                    "FATAL: bad directory %s in environment variable %s" % (dir, envvar)
+                )
 
     def detect_features(self):
-        p = subprocess.Popen((self.curl_config(), '--features'),
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p = subprocess.Popen(
+            (self.curl_config(), "--features"),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
         stdout, stderr = p.communicate()
         if p.wait() != 0:
             msg = "Problem running `%s' --features" % self.curl_config()
@@ -131,22 +140,22 @@ class ExtensionConfiguration(object):
             raise ConfigurationError(msg)
         curl_has_ssl = False
         for feature in split_quoted(stdout.decode()):
-            if feature == 'SSL':
+            if feature == "SSL":
                 # this means any ssl library, not just openssl.
                 # we set the ssl flag to check for ssl library mismatch
                 # at link time and run time
-                self.define_macros.append(('HAVE_CURL_SSL', 1))
+                self.define_macros.append(("HAVE_CURL_SSL", 1))
                 curl_has_ssl = True
         self.curl_has_ssl = curl_has_ssl
 
     def ssl_options(self):
         return {
-            '--with-openssl': self.using_openssl,
-            '--with-ssl': self.using_openssl,
-            '--with-wolfssl': self.using_wolfssl,
-            '--with-gnutls': self.using_gnutls,
-            '--with-nss': self.using_nss,
-            '--with-mbedtls': self.using_mbedtls,
+            "--with-openssl": self.using_openssl,
+            "--with-ssl": self.using_openssl,
+            "--with-wolfssl": self.using_wolfssl,
+            "--with-gnutls": self.using_gnutls,
+            "--with-nss": self.using_nss,
+            "--with-mbedtls": self.using_mbedtls,
         }
 
     def detect_ssl_option(self):
@@ -155,60 +164,69 @@ class ExtensionConfiguration(object):
                 for other_option in self.ssl_options():
                     if option != other_option:
                         if scan_argv(self.argv, other_option) is not None:
-                            raise ConfigurationError('Cannot give both %s and %s' % (option, other_option))
+                            raise ConfigurationError(
+                                "Cannot give both %s and %s" % (option, other_option)
+                            )
 
                 return option
 
     def detect_ssl_backend(self):
         ssl_lib_detected = None
 
-        if 'PYCURL_SSL_LIBRARY' in os.environ:
-            ssl_lib = os.environ['PYCURL_SSL_LIBRARY']
-            if ssl_lib in ['openssl', 'wolfssl', 'gnutls', 'nss', 'mbedtls']:
+        if "PYCURL_SSL_LIBRARY" in os.environ:
+            ssl_lib = os.environ["PYCURL_SSL_LIBRARY"]
+            if ssl_lib in ["openssl", "wolfssl", "gnutls", "nss", "mbedtls"]:
                 ssl_lib_detected = ssl_lib
-                getattr(self, 'using_%s' % ssl_lib)()
+                getattr(self, "using_%s" % ssl_lib)()
             else:
-                raise ConfigurationError('Invalid value "%s" for PYCURL_SSL_LIBRARY' % ssl_lib)
+                raise ConfigurationError(
+                    'Invalid value "%s" for PYCURL_SSL_LIBRARY' % ssl_lib
+                )
 
         option = self.detect_ssl_option()
         if option:
-            ssl_lib_detected = option.replace('--with-', '')
+            ssl_lib_detected = option.replace("--with-", "")
             self.ssl_options()[option]()
 
         # ssl detection - ssl libraries are added
         if not ssl_lib_detected:
             libcurl_dll_path = scan_argv(self.argv, "--libcurl-dll=")
             if libcurl_dll_path is not None:
-                ssl_lib_detected = self.detect_ssl_lib_from_libcurl_dll(libcurl_dll_path)
+                ssl_lib_detected = self.detect_ssl_lib_from_libcurl_dll(
+                    libcurl_dll_path
+                )
 
         if not ssl_lib_detected:
             # self.sslhintbuf is a hack
             for arg in split_quoted(self.sslhintbuf):
                 if arg[:2] == "-l":
-                    if arg[2:] == 'ssl':
+                    if arg[2:] == "ssl":
                         self.using_openssl()
-                        ssl_lib_detected = 'openssl'
+                        ssl_lib_detected = "openssl"
                         break
-                    if arg[2:] == 'wolfssl':
+                    if arg[2:] == "wolfssl":
                         self.using_wolfssl()
-                        ssl_lib_detected = 'wolfssl'
+                        ssl_lib_detected = "wolfssl"
                         break
-                    if arg[2:] == 'gnutls':
+                    if arg[2:] == "gnutls":
                         self.using_gnutls()
-                        ssl_lib_detected = 'gnutls'
+                        ssl_lib_detected = "gnutls"
                         break
-                    if arg[2:] == 'ssl3':
+                    if arg[2:] == "ssl3":
                         self.using_nss()
-                        ssl_lib_detected = 'nss'
+                        ssl_lib_detected = "nss"
                         break
-                    if arg[2:] == 'mbedtls':
+                    if arg[2:] == "mbedtls":
                         self.using_mbedtls()
-                        ssl_lib_detected = 'mbedtls'
+                        ssl_lib_detected = "mbedtls"
                         break
 
-        if not ssl_lib_detected and len(self.argv) == len(self.original_argv) \
-                and not os.environ.get('PYCURL_CURL_CONFIG') \
-                and not os.environ.get('PYCURL_SSL_LIBRARY'):
+        if (
+            not ssl_lib_detected
+            and len(self.argv) == len(self.original_argv)
+            and not os.environ.get("PYCURL_CURL_CONFIG")
+            and not os.environ.get("PYCURL_SSL_LIBRARY")
+        ):
             # this path should only be taken when no options or
             # configuration environment variables are given to setup.py
             ssl_lib_detected = self.detect_ssl_lib_on_centos6_plus()
@@ -219,7 +237,7 @@ class ExtensionConfiguration(object):
         try:
             return self._curl_config
         except AttributeError:
-            curl_config = os.environ.get('PYCURL_CURL_CONFIG', "curl-config")
+            curl_config = os.environ.get("PYCURL_CURL_CONFIG", "curl-config")
             curl_config = scan_argv(self.argv, "--curl-config=", curl_config)
             self._curl_config = curl_config
             return curl_config
@@ -230,22 +248,31 @@ class ExtensionConfiguration(object):
             self.include_dirs.append(os.path.join(OPENSSL_DIR, "include"))
             self.library_dirs.append(os.path.join(OPENSSL_DIR, "lib"))
         try:
-            p = subprocess.Popen((self.curl_config(), '--version'),
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            p = subprocess.Popen(
+                (self.curl_config(), "--version"),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
         except OSError:
             exc = sys.exc_info()[1]
-            msg = 'Could not run curl-config: %s' % str(exc)
+            msg = "Could not run curl-config: %s" % str(exc)
             raise ConfigurationError(msg)
         stdout, stderr = p.communicate()
         if p.wait() != 0:
-            msg = "`%s' not found -- please install the libcurl development files or specify --curl-config=/path/to/curl-config" % self.curl_config()
+            msg = (
+                "`%s' not found -- please install the libcurl development files or specify --curl-config=/path/to/curl-config"
+                % self.curl_config()
+            )
             if stderr:
                 msg += ":\n" + stderr.decode()
             raise ConfigurationError(msg)
         libcurl_version = stdout.decode().strip()
         print("Using %s (%s)" % (self.curl_config(), libcurl_version))
-        p = subprocess.Popen((self.curl_config(), '--cflags'),
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p = subprocess.Popen(
+            (self.curl_config(), "--cflags"),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
         stdout, stderr = p.communicate()
         if p.wait() != 0:
             msg = "Problem running `%s' --cflags" % self.curl_config()
@@ -282,15 +309,18 @@ class ExtensionConfiguration(object):
         # even if libcurl does not tell us to, because *we* invoke functions
         # in that SSL library. This means any SSL libraries found in
         # --static-libs are forwarded to our libraries.
-        optbuf = ''
-        sslhintbuf = ''
-        errtext = ''
+        optbuf = ""
+        sslhintbuf = ""
+        errtext = ""
         for option in ["--libs", "--static-libs"]:
-            p = subprocess.Popen((self.curl_config(), option),
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            p = subprocess.Popen(
+                (self.curl_config(), option),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
             stdout, stderr = p.communicate()
             if p.wait() == 0:
-                if optbuf == '':
+                if optbuf == "":
                     # first successful call
                     optbuf = stdout.decode()
                     # optbuf only has output from this call
@@ -299,7 +329,7 @@ class ExtensionConfiguration(object):
                     # second successful call
                     sslhintbuf += stdout.decode()
             else:
-                if optbuf == '':
+                if optbuf == "":
                     # no successful call yet
                     errtext += stderr.decode()
                 else:
@@ -307,8 +337,10 @@ class ExtensionConfiguration(object):
                     # ignore stderr and the error exit
                     pass
         if optbuf == "":
-            msg = "Neither curl-config --libs nor curl-config --static-libs" +\
-                " succeeded and produced output"
+            msg = (
+                "Neither curl-config --libs nor curl-config --static-libs"
+                + " succeeded and produced output"
+            )
             if errtext:
                 msg += ":\n" + errtext
             raise ConfigurationError(msg)
@@ -322,14 +354,18 @@ class ExtensionConfiguration(object):
             self.detect_ssl_backend()
 
             if not self.ssl_lib_detected:
-                sys.stderr.write('''\
+                sys.stderr.write(
+                    """\
 Warning: libcurl is configured to use SSL, but we have not been able to \
 determine which SSL backend it is using. If your Curl is built against \
 OpenSSL, LibreSSL, BoringSSL, GnuTLS, NSS or mbedTLS please specify the SSL backend \
-manually. For other SSL backends please ignore this message.''')
+manually. For other SSL backends please ignore this message."""
+                )
         else:
             if self.detect_ssl_option():
-                sys.stderr.write("Warning: SSL backend specified manually but libcurl does not use SSL\n")
+                sys.stderr.write(
+                    "Warning: SSL backend specified manually but libcurl does not use SSL\n"
+                )
 
         # libraries and options - all libraries and options are forwarded
         # but if --libs succeeded, --static-libs output is ignored
@@ -345,7 +381,7 @@ manually. For other SSL backends please ignore this message.''')
             self.libraries.append("curl")
 
         # Add extra compile flag for MacOS X
-        if sys.platform.startswith('darwin'):
+        if sys.platform.startswith("darwin"):
             self.extra_link_args.append("-flat_namespace")
 
         # Recognize --avoid-stdio on Unix so that it can be tested
@@ -357,32 +393,33 @@ manually. For other SSL backends please ignore this message.''')
         ssl_version = curl_version_info.ssl_version
         if py3:
             # ssl_version is bytes on python 3
-            ssl_version = ssl_version.decode('ascii')
-        if ssl_version.startswith('OpenSSL/') or ssl_version.startswith('LibreSSL/'):
+            ssl_version = ssl_version.decode("ascii")
+        if ssl_version.startswith("OpenSSL/") or ssl_version.startswith("LibreSSL/"):
             self.using_openssl()
-            ssl_lib_detected = 'openssl'
-        elif ssl_version.startswith('GnuTLS/'):
+            ssl_lib_detected = "openssl"
+        elif ssl_version.startswith("GnuTLS/"):
             self.using_gnutls()
-            ssl_lib_detected = 'gnutls'
-        elif ssl_version.startswith('NSS/'):
+            ssl_lib_detected = "gnutls"
+        elif ssl_version.startswith("NSS/"):
             self.using_nss()
-            ssl_lib_detected = 'nss'
-        elif ssl_version.startswith('mbedTLS/'):
+            ssl_lib_detected = "nss"
+        elif ssl_version.startswith("mbedTLS/"):
             self.using_mbedtls()
-            ssl_lib_detected = 'mbedtls'
+            ssl_lib_detected = "mbedtls"
         return ssl_lib_detected
 
     def detect_ssl_lib_on_centos6_plus(self):
         import platform
         from ctypes.util import find_library
+
         os_name = platform.system()
-        if os_name != 'Linux' or not hasattr(platform, 'dist'):
+        if os_name != "Linux" or not hasattr(platform, "dist"):
             return False
         dist_name, dist_version, _ = platform.dist()
-        dist_version = dist_version.split('.')[0]
-        if dist_name != 'centos' or int(dist_version) < 6:
+        dist_version = dist_version.split(".")[0]
+        if dist_name != "centos" or int(dist_version) < 6:
             return False
-        libcurl_dll_path = find_library('curl')
+        libcurl_dll_path = find_library("curl")
         print('libcurl_dll_path = "%s"' % libcurl_dll_path)
         return self.detect_ssl_lib_from_libcurl_dll(libcurl_dll_path)
 
@@ -404,15 +441,17 @@ manually. For other SSL backends please ignore this message.''')
         # For libcurl 7.46.0, the library name is libcurl.lib.
         # And static library name is libcurl_a.lib by default as of libcurl 7.46.0.
         # override with: --libcurl-lib-name=libcurl_imp.lib
-        curl_lib_name = scan_argv(self.argv, '--libcurl-lib-name=', 'libcurl.lib')
+        curl_lib_name = scan_argv(self.argv, "--libcurl-lib-name=", "libcurl.lib")
 
         # openssl 1.1.0 changed its library names
         # from libeay32.lib/ssleay32.lib to libcrypto.lib/libssl.lib.
         # at the same time they dropped thread locking callback interface,
         # meaning the correct usage of this option is --openssl-lib-name=""
-        self.openssl_lib_name = scan_argv(self.argv, '--openssl-lib-name=', 'libeay32.lib')
+        self.openssl_lib_name = scan_argv(
+            self.argv, "--openssl-lib-name=", "libeay32.lib"
+        )
 
-        for lib in scan_argvs(self.argv, '--link-arg='):
+        for lib in scan_argvs(self.argv, "--link-arg="):
             self.extra_link_args.append(lib)
 
         if scan_argv(self.argv, "--use-libcurl-dll") is not None:
@@ -424,13 +463,21 @@ manually. For other SSL backends please ignore this message.''')
         else:
             self.extra_compile_args.append("-DCURL_STATICLIB")
             libcurl_lib_path = os.path.join(curl_dir, "lib", curl_lib_name)
-            self.extra_link_args.extend(["gdi32.lib", "wldap32.lib", "winmm.lib", "ws2_32.lib",])
+            self.extra_link_args.extend(
+                ["gdi32.lib", "wldap32.lib", "winmm.lib", "ws2_32.lib",]
+            )
 
         if not os.path.exists(libcurl_lib_path):
-            fail("libcurl.lib does not exist at %s.\nCurl directory must point to compiled libcurl (bin/include/lib subdirectories): %s" %(libcurl_lib_path, curl_dir))
+            fail(
+                "libcurl.lib does not exist at %s.\nCurl directory must point to compiled libcurl (bin/include/lib subdirectories): %s"
+                % (libcurl_lib_path, curl_dir)
+            )
         self.extra_objects.append(libcurl_lib_path)
 
-        if scan_argv(self.argv, '--with-openssl') is not None or scan_argv(self.argv, '--with-ssl') is not None:
+        if (
+            scan_argv(self.argv, "--with-openssl") is not None
+            or scan_argv(self.argv, "--with-ssl") is not None
+        ):
             self.using_openssl()
 
         self.check_avoid_stdio()
@@ -444,26 +491,32 @@ manually. For other SSL backends please ignore this message.''')
 
         if str.find(sys.version, "MSC") >= 0:
             self.extra_compile_args.append("-O2")
-            self.extra_compile_args.append("-GF")        # enable read-only string pooling
-            self.extra_compile_args.append("-WX")        # treat warnings as errors
-            p = subprocess.Popen(['cl.exe'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            self.extra_compile_args.append("-GF")  # enable read-only string pooling
+            self.extra_compile_args.append("-WX")  # treat warnings as errors
+            p = subprocess.Popen(
+                ["cl.exe"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
             out, err = p.communicate()
-            match = re.search(r'Version (\d+)', err.decode().split("\n")[0])
+            match = re.search(r"Version (\d+)", err.decode().split("\n")[0])
             if match and int(match.group(1)) < 16:
                 # option removed in vs 2010:
                 # connect.microsoft.com/VisualStudio/feedback/details/475896/link-fatal-error-lnk1117-syntax-error-in-option-opt-nowin98/
-                self.extra_link_args.append("/opt:nowin98")  # use small section alignment
+                self.extra_link_args.append(
+                    "/opt:nowin98"
+                )  # use small section alignment
 
     if sys.platform == "win32":
         configure = configure_windows
     else:
         configure = configure_unix
 
-
     def check_avoid_stdio(self):
-        if 'PYCURL_SETUP_OPTIONS' in os.environ and '--avoid-stdio' in os.environ['PYCURL_SETUP_OPTIONS']:
+        if (
+            "PYCURL_SETUP_OPTIONS" in os.environ
+            and "--avoid-stdio" in os.environ["PYCURL_SETUP_OPTIONS"]
+        ):
             self.extra_compile_args.append("-DPYCURL_AVOID_STDIO")
-        if scan_argv(self.argv, '--avoid-stdio') is not None:
+        if scan_argv(self.argv, "--avoid-stdio") is not None:
             self.extra_compile_args.append("-DPYCURL_AVOID_STDIO")
 
     def get_curl_version_info(self, dll_path):
@@ -471,20 +524,20 @@ manually. For other SSL backends please ignore this message.''')
 
         class curl_version_info_struct(ctypes.Structure):
             _fields_ = [
-                ('age', ctypes.c_int),
-                ('version', ctypes.c_char_p),
-                ('version_num', ctypes.c_uint),
-                ('host', ctypes.c_char_p),
-                ('features', ctypes.c_int),
-                ('ssl_version', ctypes.c_char_p),
-                ('ssl_version_num', ctypes.c_long),
-                ('libz_version', ctypes.c_char_p),
-                ('protocols', ctypes.c_void_p),
-                ('ares', ctypes.c_char_p),
-                ('ares_num', ctypes.c_int),
-                ('libidn', ctypes.c_char_p),
-                ('iconv_ver_num', ctypes.c_int),
-                ('libssh_version', ctypes.c_char_p),
+                ("age", ctypes.c_int),
+                ("version", ctypes.c_char_p),
+                ("version_num", ctypes.c_uint),
+                ("host", ctypes.c_char_p),
+                ("features", ctypes.c_int),
+                ("ssl_version", ctypes.c_char_p),
+                ("ssl_version_num", ctypes.c_long),
+                ("libz_version", ctypes.c_char_p),
+                ("protocols", ctypes.c_void_p),
+                ("ares", ctypes.c_char_p),
+                ("ares_num", ctypes.c_int),
+                ("libidn", ctypes.c_char_p),
+                ("iconv_ver_num", ctypes.c_int),
+                ("libssh_version", ctypes.c_char_p),
             ]
 
         dll = ctypes.CDLL(dll_path)
@@ -496,7 +549,7 @@ manually. For other SSL backends please ignore this message.''')
         return fn(3)[0]
 
     def using_openssl(self):
-        self.define_macros.append(('HAVE_CURL_OPENSSL', 1))
+        self.define_macros.append(("HAVE_CURL_OPENSSL", 1))
         if sys.platform == "win32":
             # CRYPTO_num_locks is defined in libeay32.lib
             # for openssl < 1.1.0; it is a noop for openssl >= 1.1.0
@@ -504,38 +557,39 @@ manually. For other SSL backends please ignore this message.''')
         else:
             # we also need ssl for the certificate functions
             # (SSL_CTX_get_cert_store)
-            self.libraries.append('ssl')
+            self.libraries.append("ssl")
             # the actual library that defines CRYPTO_num_locks etc.
             # is crypto, and on cygwin linking against ssl does not
             # link against crypto as of May 2014.
             # http://stackoverflow.com/questions/23687488/cant-get-pycurl-to-install-on-cygwin-missing-openssl-symbols-crypto-num-locks
-            self.libraries.append('crypto')
-        self.define_macros.append(('HAVE_CURL_SSL', 1))
-        self.ssl_lib_detected = 'openssl'
+            self.libraries.append("crypto")
+        self.define_macros.append(("HAVE_CURL_SSL", 1))
+        self.ssl_lib_detected = "openssl"
 
     def using_wolfssl(self):
-        self.define_macros.append(('HAVE_CURL_WOLFSSL', 1))
-        self.libraries.append('wolfssl')
-        self.define_macros.append(('HAVE_CURL_SSL', 1))
-        self.ssl_lib_detected = 'wolfssl'
+        self.define_macros.append(("HAVE_CURL_WOLFSSL", 1))
+        self.libraries.append("wolfssl")
+        self.define_macros.append(("HAVE_CURL_SSL", 1))
+        self.ssl_lib_detected = "wolfssl"
 
     def using_gnutls(self):
-        self.define_macros.append(('HAVE_CURL_GNUTLS', 1))
-        self.libraries.append('gnutls')
-        self.define_macros.append(('HAVE_CURL_SSL', 1))
-        self.ssl_lib_detected = 'gnutls'
+        self.define_macros.append(("HAVE_CURL_GNUTLS", 1))
+        self.libraries.append("gnutls")
+        self.define_macros.append(("HAVE_CURL_SSL", 1))
+        self.ssl_lib_detected = "gnutls"
 
     def using_nss(self):
-        self.define_macros.append(('HAVE_CURL_NSS', 1))
-        self.libraries.append('ssl3')
-        self.define_macros.append(('HAVE_CURL_SSL', 1))
-        self.ssl_lib_detected = 'nss'
+        self.define_macros.append(("HAVE_CURL_NSS", 1))
+        self.libraries.append("ssl3")
+        self.define_macros.append(("HAVE_CURL_SSL", 1))
+        self.ssl_lib_detected = "nss"
 
     def using_mbedtls(self):
-        self.define_macros.append(('HAVE_CURL_MBEDTLS', 1))
-        self.libraries.append('mbedtls')
-        self.define_macros.append(('HAVE_CURL_SSL', 1))
-        self.ssl_lib_detected = 'mbedtls'
+        self.define_macros.append(("HAVE_CURL_MBEDTLS", 1))
+        self.libraries.append("mbedtls")
+        self.define_macros.append(("HAVE_CURL_SSL", 1))
+        self.ssl_lib_detected = "mbedtls"
+
 
 def get_bdist_msi_version_hack():
     # workaround for distutils/msi version requirement per
@@ -549,36 +603,41 @@ def get_bdist_msi_version_hack():
 
     class bdist_msi_version_hack(bdist_msi):
         """ MSI builder requires version to be in the x.x.x format """
+
         def run(self):
             def monkey_get_version(self):
                 """ monkey patch replacement for metadata.get_version() that
                         returns MSI compatible version string for bdist_msi
                 """
                 # get filename of the calling function
-                if inspect.stack()[1][1].endswith('bdist_msi.py'):
+                if inspect.stack()[1][1].endswith("bdist_msi.py"):
                     # strip revision from version (if any), e.g. 11.0.0-r31546
-                    match = re.match(r'(\d+\.\d+\.\d+)', self.version)
+                    match = re.match(r"(\d+\.\d+\.\d+)", self.version)
                     assert match
                     return match.group(1)
                 else:
                     return self.version
 
             # monkeypatching get_version() call for DistributionMetadata
-            self.distribution.metadata.get_version = \
-                types.MethodType(monkey_get_version, self.distribution.metadata)
+            self.distribution.metadata.get_version = types.MethodType(
+                monkey_get_version, self.distribution.metadata
+            )
             bdist_msi.run(self)
 
     return bdist_msi_version_hack
 
 
 def strip_pycurl_options(argv):
-    if sys.platform == 'win32':
+    if sys.platform == "win32":
         options = [
-            '--curl-dir=', '--libcurl-lib-name=', '--use-libcurl-dll',
-            '--avoid-stdio', '--with-openssl',
+            "--curl-dir=",
+            "--libcurl-lib-name=",
+            "--use-libcurl-dll",
+            "--avoid-stdio",
+            "--with-openssl",
         ]
     else:
-        options = ['--openssl-dir=', '--curl-config=', '--avoid-stdio']
+        options = ["--openssl-dir=", "--curl-config=", "--avoid-stdio"]
     for option in options:
         scan_argv(argv, option)
 
@@ -587,12 +646,13 @@ def strip_pycurl_options(argv):
 
 PRETTY_SSL_LIBS = {
     # setup.py may be detecting BoringSSL properly, need to test
-    'openssl': 'OpenSSL/LibreSSL/BoringSSL',
-    'wolfssl': 'wolfSSL',
-    'gnutls': 'GnuTLS',
-    'nss': 'NSS',
-    'mbedtls': 'mbedTLS',
+    "openssl": "OpenSSL/LibreSSL/BoringSSL",
+    "wolfssl": "wolfSSL",
+    "gnutls": "GnuTLS",
+    "nss": "NSS",
+    "mbedtls": "mbedTLS",
 }
+
 
 def get_extension(argv, split_extension_source=False):
     if split_extension_source:
@@ -623,9 +683,9 @@ def get_extension(argv, split_extension_source=False):
     ext_config = ExtensionConfiguration(argv)
 
     if ext_config.ssl_lib_detected:
-        print('Using SSL library: %s' % PRETTY_SSL_LIBS[ext_config.ssl_lib_detected])
+        print("Using SSL library: %s" % PRETTY_SSL_LIBS[ext_config.ssl_lib_detected])
     else:
-        print('Not using an SSL library')
+        print("Not using an SSL library")
 
     ext = Extension(
         name=PACKAGE,
@@ -648,6 +708,7 @@ def get_extension(argv, split_extension_source=False):
 
 # prepare data_files
 
+
 def get_data_files():
     # a list of tuples with (path to install to, a list of local files)
     data_files = []
@@ -656,8 +717,15 @@ def get_data_files():
     else:
         datadir = os.path.join("share", "doc", PACKAGE)
     #
-    files = ["AUTHORS", "ChangeLog", "COPYING-LGPL", "COPYING-MIT",
-        "INSTALL.rst", "README.rst", "RELEASE-NOTES.rst"]
+    files = [
+        "AUTHORS",
+        "ChangeLog",
+        "COPYING-LGPL",
+        "COPYING-MIT",
+        "INSTALL.rst",
+        "README.rst",
+        "RELEASE-NOTES.rst",
+    ]
     if files:
         data_files.append((os.path.join(datadir), files))
     files = glob.glob(os.path.join("examples", "*.py"))
@@ -677,17 +745,18 @@ def get_data_files():
 
 ###############################################################################
 
+
 def check_manifest():
     import fnmatch
 
-    f = open('MANIFEST.in')
+    f = open("MANIFEST.in")
     globs = []
     try:
         for line in f.readlines():
             stripped = line.strip()
-            if stripped == '' or stripped.startswith('#'):
+            if stripped == "" or stripped.startswith("#"):
                 continue
-            assert stripped.startswith('include ')
+            assert stripped.startswith("include ")
             glob = stripped[8:]
             globs.append(glob)
     finally:
@@ -696,12 +765,12 @@ def check_manifest():
     paths = []
     start = os.path.abspath(os.path.dirname(__file__))
     for root, dirs, files in os.walk(start):
-        if '.git' in dirs:
-            dirs.remove('.git')
+        if ".git" in dirs:
+            dirs.remove(".git")
         for file in files:
-            if file.endswith('.pyc'):
+            if file.endswith(".pyc"):
                 continue
-            rel = os.path.join(root, file)[len(start)+1:]
+            rel = os.path.join(root, file)[len(start) + 1 :]
             paths.append(rel)
 
     for path in paths:
@@ -713,10 +782,12 @@ def check_manifest():
         if not included:
             print(path)
 
+
 AUTHORS_PARAGRAPH = 3
 
+
 def check_authors():
-    f = open('AUTHORS')
+    f = open("AUTHORS")
     try:
         contents = f.read()
     finally:
@@ -726,14 +797,14 @@ def check_authors():
     authors_para = paras[AUTHORS_PARAGRAPH]
     authors = [author for author in authors_para.strip().split("\n")]
 
-    log = subprocess.check_output(['git', 'log', '--format=%an (%ae)'])
+    log = subprocess.check_output(["git", "log", "--format=%an (%ae)"])
     for author in log.strip().split("\n"):
-        author = author.replace('@', ' at ').replace('(', '<').replace(')', '>')
+        author = author.replace("@", " at ").replace("(", "<").replace(")", ">")
         if author not in authors:
             authors.append(author)
     authors.sort()
     paras[AUTHORS_PARAGRAPH] = "\n".join(authors)
-    f = open('AUTHORS', 'w')
+    f = open("AUTHORS", "w")
     try:
         f.write("\n\n".join(paras))
     finally:
@@ -742,29 +813,29 @@ def check_authors():
 
 def convert_docstrings():
     docstrings = []
-    for entry in sorted(os.listdir('doc/docstrings')):
-        if not entry.endswith('.rst'):
+    for entry in sorted(os.listdir("doc/docstrings")):
+        if not entry.endswith(".rst"):
             continue
 
-        name = entry.replace('.rst', '')
-        f = open('doc/docstrings/%s' % entry)
+        name = entry.replace(".rst", "")
+        f = open("doc/docstrings/%s" % entry)
         try:
             text = f.read().strip()
         finally:
             f.close()
         docstrings.append((name, text))
-    f = open('src/docstrings.c', 'w')
+    f = open("src/docstrings.c", "w")
     try:
         f.write("/* Generated file - do not edit. */\n")
         # space to avoid having /* inside a C comment
         f.write("/* See doc/docstrings/ *.rst. */\n\n")
-        f.write("#include \"pycurl.h\"\n\n")
+        f.write('#include "pycurl.h"\n\n')
         for name, text in docstrings:
-            text = text.replace("\"", "\\\"").replace("\n", "\\n\\\n")
-            f.write("PYCURL_INTERNAL const char %s_doc[] = \"%s\";\n\n" % (name, text))
+            text = text.replace('"', '\\"').replace("\n", "\\n\\\n")
+            f.write('PYCURL_INTERNAL const char %s_doc[] = "%s";\n\n' % (name, text))
     finally:
         f.close()
-    f = open('src/docstrings.h', 'w')
+    f = open("src/docstrings.h", "w")
     try:
         f.write("/* Generated file - do not edit. */\n")
         # space to avoid having /* inside a C comment
@@ -776,19 +847,20 @@ def convert_docstrings():
 
 
 def gen_docstrings_sources():
-    sources = 'DOCSTRINGS_SOURCES ='
-    for entry in sorted(os.listdir('doc/docstrings')):
-        if entry.endswith('.rst'):
+    sources = "DOCSTRINGS_SOURCES ="
+    for entry in sorted(os.listdir("doc/docstrings")):
+        if entry.endswith(".rst"):
             sources += " \\\n\tdoc/docstrings/%s" % entry
     print(sources)
+
 
 ###############################################################################
 
 setup_args = dict(
     name=PACKAGE,
     version=VERSION,
-    description='PycURL -- A Python Interface To The cURL library',
-    long_description='''\
+    description="PycURL -- A Python Interface To The cURL library",
+    long_description="""\
 PycURL -- A Python Interface To The cURL library
 ================================================
 
@@ -870,38 +942,46 @@ in COPYING-LGPL_ and COPYING-MIT_ files in the source distribution.
 .. _urllib: http://docs.python.org/library/urllib.html
 .. _COPYING-LGPL: https://raw.githubusercontent.com/pycurl/pycurl/master/COPYING-LGPL
 .. _COPYING-MIT: https://raw.githubusercontent.com/pycurl/pycurl/master/COPYING-MIT
-''',
+""",
     author="Kjetil Jacobsen, Markus F.X.J. Oberhumer, Oleg Pudeyev",
     author_email="kjetilja@gmail.com, markus@oberhumer.com, oleg@bsdpower.com",
     maintainer="Oleg Pudeyev",
     maintainer_email="oleg@bsdpower.com",
     url="http://pycurl.io/",
     license="LGPL/MIT",
-    keywords=['curl', 'libcurl', 'urllib', 'wget', 'download', 'file transfer',
-        'http', 'www'],
+    keywords=[
+        "curl",
+        "libcurl",
+        "urllib",
+        "wget",
+        "download",
+        "file transfer",
+        "http",
+        "www",
+    ],
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: Web Environment',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: Microsoft :: Windows',
-        'Operating System :: POSIX',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Topic :: Internet :: File Transfer Protocol (FTP)',
-        'Topic :: Internet :: WWW/HTTP',
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Web Environment",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: Microsoft :: Windows",
+        "Operating System :: POSIX",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Topic :: Internet :: File Transfer Protocol (FTP)",
+        "Topic :: Internet :: WWW/HTTP",
     ],
     packages=[PY_PACKAGE],
-    package_dir={ PY_PACKAGE: os.path.join('python', 'curl') },
-    python_requires='>=3.5',
+    package_dir={PY_PACKAGE: os.path.join("python", "curl")},
+    python_requires=">=3.5",
 )
 
 if sys.platform == "win32":
-    setup_args['cmdclass'] = {'bdist_msi': get_bdist_msi_version_hack()}
+    setup_args["cmdclass"] = {"bdist_msi": get_bdist_msi_version_hack()}
 
 ##print distutils.__version__
 if LooseVersion(distutils.__version__) > LooseVersion("1.0.1"):
@@ -909,7 +989,7 @@ if LooseVersion(distutils.__version__) > LooseVersion("1.0.1"):
 if LooseVersion(distutils.__version__) < LooseVersion("1.0.3"):
     setup_args["licence"] = setup_args["license"]
 
-unix_help = '''\
+unix_help = """\
 PycURL Unix options:
  --curl-config=/path/to/curl-config  use specified curl-config binary
  --libcurl-dll=[/path/to/]libcurl.so obtain SSL library from libcurl.so
@@ -920,9 +1000,9 @@ PycURL Unix options:
  --with-nss                          libcurl is linked against NSS
  --with-mbedtls                      libcurl is linked against mbedTLS
  --with-wolfssl                      libcurl is linked against wolfSSL
-'''
+"""
 
-windows_help = '''\
+windows_help = """\
 PycURL Windows options:
  --curl-dir=/path/to/compiled/libcurl  path to libcurl headers and libraries
  --use-libcurl-dll                     link against libcurl DLL, if not given
@@ -931,10 +1011,10 @@ PycURL Windows options:
  --with-openssl                        libcurl is linked against OpenSSL/LibreSSL/BoringSSL
  --with-ssl                            legacy alias for --with-openssl
  --link-arg=foo.lib                    also link against specified library
-'''
+"""
 
 if __name__ == "__main__":
-    if '--help' in sys.argv or '-h' in sys.argv:
+    if "--help" in sys.argv or "-h" in sys.argv:
         # unfortunately this help precedes distutils help
         if sys.platform == "win32":
             print(windows_help)
@@ -945,22 +1025,33 @@ if __name__ == "__main__":
         # we need to remove our options because distutils complains about them
         strip_pycurl_options(sys.argv)
         setup(**setup_args)
-    elif len(sys.argv) > 1 and sys.argv[1] == 'manifest':
+    elif len(sys.argv) > 1 and sys.argv[1] == "manifest":
         check_manifest()
-    elif len(sys.argv) > 1 and sys.argv[1] == 'docstrings':
+    elif len(sys.argv) > 1 and sys.argv[1] == "docstrings":
         convert_docstrings()
-    elif len(sys.argv) > 1 and sys.argv[1] == 'authors':
+    elif len(sys.argv) > 1 and sys.argv[1] == "authors":
         check_authors()
-    elif len(sys.argv) > 1 and sys.argv[1] == 'docstrings-sources':
+    elif len(sys.argv) > 1 and sys.argv[1] == "docstrings-sources":
         gen_docstrings_sources()
     else:
-        setup_args['data_files'] = get_data_files()
-        if 'PYCURL_RELEASE' in os.environ and os.environ['PYCURL_RELEASE'].lower() in ['1', 'yes', 'true']:
+        setup_args["data_files"] = get_data_files()
+
+        # Generate docstrings before installing if we're installing directly
+        # from Git (eg. pip3 install git://github.com/repo/pycurl#egg=pycurl),
+        # otherwise we'll get an error because src/docstrings.c, .h do not
+        # exist yet
+        convert_docstrings()
+
+        if "PYCURL_RELEASE" in os.environ and os.environ["PYCURL_RELEASE"].lower() in [
+            "1",
+            "yes",
+            "true",
+        ]:
             split_extension_source = False
         else:
             split_extension_source = True
         ext = get_extension(sys.argv, split_extension_source=split_extension_source)
-        setup_args['ext_modules'] = [ext]
+        setup_args["ext_modules"] = [ext]
 
         for o in ext.extra_objects:
             assert os.path.isfile(o), o

--- a/src/module.c
+++ b/src/module.c
@@ -1075,6 +1075,9 @@ initpycurl(void)
     insint_c(d, "SSLVERSION_MAX_TLSv1_2", CURL_SSLVERSION_MAX_TLSv1_2);
     insint_c(d, "SSLVERSION_MAX_TLSv1_3", CURL_SSLVERSION_MAX_TLSv1_3);
 #endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 60, 0)
+    insint_c(d, "HAPROXYPROTOCOL", CURLOPT_HAPROXYPROTOCOL);
+#endif
 
     /* curl_TimeCond: constants for setopt(TIMECONDITION, x) */
     insint_c(d, "TIMECONDITION_NONE", CURL_TIMECOND_NONE);

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -154,6 +154,10 @@ pycurl_inet_ntop (int family, void *addr, char *string, size_t string_size);
 #define HAVE_CURLINFO_HTTP_VERSION
 #endif
 
+#if LIBCURL_VERSION_NUM >= 0x073C00 /* check for 7.60.0 or greater */
+#define HAVE_CURLOPT_HAPROXYPROTOCOL
+#endif
+
 #undef UNUSED
 #define UNUSED(var)     ((void)&var)
 


### PR DESCRIPTION
Support the CURLOPT_HAPROXYPROTOCOL option in pycurl.  Before this change, the option was rejected and haproxy protocol support was unusable.