### PR TITLE
Add convert_docstring() call to setup.py to ensure that src/docstring…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -954,6 +954,8 @@ if __name__ == "__main__":
     elif len(sys.argv) > 1 and sys.argv[1] == 'docstrings-sources':
         gen_docstrings_sources()
     else:
+        convert_docstrings()
+
         setup_args['data_files'] = get_data_files()
         if 'PYCURL_RELEASE' in os.environ and os.environ['PYCURL_RELEASE'].lower() in ['1', 'yes', 'true']:
             split_extension_source = False


### PR DESCRIPTION
Add `convert_docstring()` call to `./setup.py` to ensure that the two files (`src/docstring.c` and `src/docstrings.h`) are both created at compile time so that Python installations with pip (setuptools) are successful.