### PR TITLE
Mnt py310 compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /www/htdocs/download/*.exe
 /www/htdocs/download/*.gz
 /www/upload/*
+pycurl.egg-info

--- a/src/module.c
+++ b/src/module.c
@@ -13,7 +13,7 @@
 
 /* Introduced in https://github.com/python/cpython/commit/d2ec81a8c99796b51fb8c49b77a7fe369863226f */
 #if PY_VERSION_HEX < 0x030900a4
-    #define Py_SET_TYPE(obj, typ) (Py_TYPE(obj) = typ)
+    #define Py_SET_TYPE(obj, new_type) do { Py_TYPE(obj) = (new_type); } while (0)
 #endif
 
 

--- a/src/module.c
+++ b/src/module.c
@@ -11,6 +11,12 @@
 
 #define PYCURL_VERSION_PREFIX "PycURL/" PYCURL_VERSION_STRING
 
+/* Introduced in https://github.com/python/cpython/commit/d2ec81a8c99796b51fb8c49b77a7fe369863226f */
+#if PY_VERSION_HEX < 0x030900a4
+    #define Py_SET_TYPE(obj, typ) (Py_TYPE(obj) = typ)
+#endif
+
+
 PYCURL_INTERNAL char *empty_keywords[] = { NULL };
 
 PYCURL_INTERNAL PyObject *bytesio = NULL;
@@ -372,9 +378,9 @@ initpycurl(void)
     p_Curl_Type = &Curl_Type;
     p_CurlMulti_Type = &CurlMulti_Type;
     p_CurlShare_Type = &CurlShare_Type;
-    Py_TYPE(&Curl_Type) = &PyType_Type;
-    Py_TYPE(&CurlMulti_Type) = &PyType_Type;
-    Py_TYPE(&CurlShare_Type) = &PyType_Type;
+    Py_SET_TYPE(&Curl_Type, &PyType_Type);
+    Py_SET_TYPE(&CurlMulti_Type,  &PyType_Type);
+    Py_SET_TYPE(&CurlShare_Type,  &PyType_Type);
 
     /* Create the module and add the functions */
     if (PyType_Ready(&Curl_Type) < 0)


### PR DESCRIPTION
There was a change in the CPython c-api to change `Py_TYPE` from a macro to an inline function (python/cpython#20290).  This requires a change to using `Py_SET_TYPE` which was introduced on py39a4.