### PR TITLE
Handle MultiSSL

### DIFF
--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -154,6 +154,10 @@ pycurl_inet_ntop (int family, void *addr, char *string, size_t string_size);
 #define HAVE_CURLINFO_HTTP_VERSION
 #endif
 
+#if LIBCURL_VERSION_NUM >= 0x073800 /* check for 7.56.0 or greater */
+#define HAVE_CURL_GLOBAL_SSLSET
+#endif
+
 #if LIBCURL_VERSION_NUM >= 0x073C00 /* check for 7.60.0 or greater */
 #define HAVE_CURLOPT_HAPROXYPROTOCOL
 #endif
@@ -169,6 +173,7 @@ pycurl_inet_ntop (int family, void *addr, char *string, size_t string_size);
 #   include <openssl/ssl.h>
 #   include <openssl/err.h>
 #   define COMPILE_SSL_LIB "openssl"
+#   define COMPILE_SUPPORTED_SSL_BACKEND_FOUND 1
 # elif defined(HAVE_CURL_WOLFSSL)
 #   include <wolfssl/options.h>
 #   if defined(OPENSSL_EXTRA)
@@ -191,6 +196,7 @@ pycurl_inet_ntop (int family, void *addr, char *string, size_t string_size);
 #    endif
 #   endif
 #   define COMPILE_SSL_LIB "wolfssl"
+#   define COMPILE_SUPPORTED_SSL_BACKEND_FOUND 1
 # elif defined(HAVE_CURL_GNUTLS)
 #   include <gnutls/gnutls.h>
 #   if GNUTLS_VERSION_NUMBER <= 0x020b00
@@ -199,13 +205,16 @@ pycurl_inet_ntop (int family, void *addr, char *string, size_t string_size);
 #     include <gcrypt.h>
 #   endif
 #   define COMPILE_SSL_LIB "gnutls"
+#   define COMPILE_SUPPORTED_SSL_BACKEND_FOUND 1
 # elif defined(HAVE_CURL_NSS)
 #   define COMPILE_SSL_LIB "nss"
+#   define COMPILE_SUPPORTED_SSL_BACKEND_FOUND 1
 # elif defined(HAVE_CURL_MBEDTLS)
 #   include <mbedtls/ssl.h>
 #   define PYCURL_NEED_SSL_TSL
 #   define PYCURL_NEED_MBEDTLS_TSL
 #   define COMPILE_SSL_LIB "mbedtls"
+#   define COMPILE_SUPPORTED_SSL_BACKEND_FOUND 1
 # else
 #  ifdef _MSC_VER
     /* sigh */
@@ -222,9 +231,11 @@ pycurl_inet_ntop (int family, void *addr, char *string, size_t string_size);
    /* since we have no crypto callbacks for other ssl backends,
     * no reason to require users match those */
 #  define COMPILE_SSL_LIB "none/other"
+#  define COMPILE_SUPPORTED_SSL_BACKEND_FOUND 0
 # endif /* HAVE_CURL_OPENSSL || HAVE_CURL_WOLFSSL || HAVE_CURL_GNUTLS || HAVE_CURL_NSS || HAVE_CURL_MBEDTLS */
 #else
 # define COMPILE_SSL_LIB "none/other"
+# define COMPILE_SUPPORTED_SSL_BACKEND_FOUND 0
 #endif /* HAVE_CURL_SSL */
 
 #if defined(PYCURL_NEED_SSL_TSL)


### PR DESCRIPTION
Since curl 7.56, multiple SSL backends can be used in the curl library. Currently, the SSL backend check only checks the first SSL library returned by `curl_version_info` which may not necessarily be the library used by pycurl, or even be the "default" curl SSL library (in which case the check always fails).

What this pull request does, is it tries to select the SSL library that pycurl uses (via `curl_global_sslset`). This allows pycurl to still work when the SSL backend desired is present but not the default.

The return value of `curl_global_sslset` is then used to detect whether that requested library is present. If not, it will go through the list of SSL backends returned and format that into the error message. Checks are there to cover the cases where there are no backends or there are backends, but just none that pycurl support.

This was tested with the following configuration:

```
curl 7.71.1 (x86_64-apple-darwin18.7.0) libcurl/7.71.1 (SecureTransport) OpenSSL/1.1.1g zlib/1.2.11 brotli/1.0.7 c-ares/1.16.1 libidn2/2.3.0 libssh2/1.9.0 nghttp2/1.41.0 librtmp/2.3
Release-Date: 2020-07-01
Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtmp rtsp scp sftp smb smbs smtp smtps telnet tftp 
Features: AsynchDNS brotli GSS-API HTTP2 HTTPS-proxy IDN IPv6 Kerberos Largefile libz Metalink MultiSSL NTLM NTLM_WB SPNEGO SSL TLS-SRP UnixSockets
```

Prior to this patch, the above configuration would have resulted in:

```
ImportError: pycurl: libcurl link-time ssl backend (none/other) is different from compile-time ssl backend (openssl)
```
