### PR TITLE
Fix runtime error on no-SSL builds

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -378,7 +378,8 @@ initpycurl(void)
                 }
             }
         }
-        if (runtime_supported_backend_found == COMPILE_SUPPORTED_SSL_BACKEND_FOUND) {
+        /* Don't error if both the curl library and pycurl itself is compiled without SSL */
+        if (runtime_supported_backend_found || COMPILE_SUPPORTED_SSL_BACKEND_FOUND) {
             PyErr_Format(PyExc_ImportError, "pycurl: libcurl link-time ssl backends (%s) do not include compile-time ssl backend (%s)", backends, COMPILE_SSL_LIB);
             goto error;
         }


### PR DESCRIPTION
Small logic error in the check - we want to error if either a valid SSL library is found at runtime or at compile time. We don't want to error when a SSL library is found in neither.

I'm very sorry for the error - I did try to cover this scenario when testing locally but must have made a mistake when doing so.