### PR TITLE
Exclude fake-curl binaries from distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -51,3 +51,4 @@ include tests/run-quickstart.sh
 include tests/vsftpd.conf
 include winbuild.py
 include winbuild/*
+exclude tests/fake-curl/libcurl/*.so


### PR DESCRIPTION
This is a problem mainly when trying to run the tests on non-x86_64 platforms.
'make test' will not recompile the .so files and thus they will be the wrong
architecture.