### PR TITLE
Fix seek callback's use of offset parameter

### DIFF
--- a/src/easycb.c
+++ b/src/easycb.c
@@ -485,7 +485,7 @@ seek_callback(void *stream, curl_off_t offset, int origin)
     cb = self->seek_cb;
     if (cb == NULL)
         goto silent_error;
-    arglist = Py_BuildValue("(i,i)", offset, source);
+    arglist = Py_BuildValue("(L,i)", (PY_LONG_LONG) offset, source);
     if (arglist == NULL)
         goto verbose_error;
     result = PyEval_CallObject(cb, arglist);


### PR DESCRIPTION
This was discovered by the seek_cb_test which was failing on certain
architectures (e.g., armhf):

FAIL: test_seek_function (tests.seek_cb_test.SeekCbTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/<<PKGBUILDDIR>>/tests/seek_cb_test.py", line 77, in test_seek_function
    self.assertEqual('1234567890.1234567890', content)
AssertionError: '1234567890.1234567890' != '12345678901234567890.1234567890'
- 1234567890.1234567890
+ 12345678901234567890.1234567890
? ++++++++++