### PR TITLE
Use make -C for building fake-curl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ build-release: $(RELEASE_SOURCES)
 	PYCURL_RELEASE=1 $(PYTHON) setup.py build
 
 do-test:
-	cd tests/fake-curl/libcurl && make
+	make -C tests/fake-curl/libcurl
 	./tests/run.sh
 	./tests/ext/test-suite.sh
 	$(PYFLAKES) python examples tests setup.py

--- a/tests/travis/run.sh
+++ b/tests/travis/run.sh
@@ -45,7 +45,7 @@ fi
 make gen
 python setup.py build $setup_args
 
-(cd tests/fake-curl/libcurl && make)
+make -C tests/fake-curl/libcurl
 
 ldd build/lib*/pycurl*.so
 


### PR DESCRIPTION
Both the Makefile and the Travis setup use a subshell with cd to build
fake-curl, whereas make everywhere supports -C, so make use of that
instead.