### PR TITLE
docs(quickstart): only show Python 3 code

### DIFF
--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -12,24 +12,29 @@ PycURL, the following steps are required:
     2. Use ``setopt`` to set options.
     3. Call ``perform`` to perform the operation.
 
-Here is how we can retrieve a network resource in Python 2::
+Here is how we can retrieve a network resource in Python 3::
 
     import pycurl
-    from StringIO import StringIO
+    import certifi
+    from io import BytesIO
 
-    buffer = StringIO()
+    buffer = BytesIO()
     c = pycurl.Curl()
     c.setopt(c.URL, 'http://pycurl.io/')
     c.setopt(c.WRITEDATA, buffer)
+    c.setopt(c.CAINFO, certifi.where())
     c.perform()
     c.close()
 
     body = buffer.getvalue()
-    # Body is a string in some encoding.
-    # In Python 2, we can print it without knowing what the encoding is.
-    print(body)
+    # Body is a byte string.
+    # We have to know the encoding in order to print it to a text file
+    # such as standard output.
+    print(body.decode('iso-8859-1'))
 
-This code is available as ``examples/quickstart/get_python2.py``.
+This code is available as ``examples/quickstart/get_python3.py``.
+For a Python 2 only example, see ``examples/quickstart/get_python2.py``.
+For an example targeting Python 2 and 3, see ``examples/quickstart/get.py``.
 
 PycURL does not provide storage for the network response - that is the
 application's job. Therefore we must setup a buffer (in the form of a
@@ -44,36 +49,6 @@ While the WRITEFUNCTION idiom continues to work, it is now unnecessary.
 As of PycURL 7.19.3 WRITEDATA accepts any Python object with a ``write``
 method.
 
-Python 3 version is slightly more complicated::
-
-    import pycurl
-    from io import BytesIO
-
-    buffer = BytesIO()
-    c = pycurl.Curl()
-    c.setopt(c.URL, 'http://pycurl.io/')
-    c.setopt(c.WRITEDATA, buffer)
-    c.perform()
-    c.close()
-
-    body = buffer.getvalue()
-    # Body is a byte string.
-    # We have to know the encoding in order to print it to a text file
-    # such as standard output.
-    print(body.decode('iso-8859-1'))
-
-This code is available as ``examples/quickstart/get_python3.py``.
-
-In Python 3, PycURL returns the response body as a byte string.
-This is handy if we are downloading a binary file, but for text documents
-we must decode the byte string. In the above example, we assume that the
-body is encoded in iso-8859-1.
-
-Python 2 and Python 3 versions can be combined. Doing so requires decoding
-the response body as in Python 3 version. The code for the combined
-example can be found in ``examples/quickstart/get.py``.
-
-
 Working With HTTPS
 ------------------
 
@@ -85,9 +60,9 @@ if not, consider using the `certifi`_ Python package::
 
     import pycurl
     import certifi
-    from StringIO import StringIO
+    from io import BytesIO
 
-    buffer = StringIO()
+    buffer = BytesIO()
     c = pycurl.Curl()
     c.setopt(c.URL, 'https://python.org/')
     c.setopt(c.WRITEDATA, buffer)
@@ -96,10 +71,13 @@ if not, consider using the `certifi`_ Python package::
     c.close()
 
     body = buffer.getvalue()
-    print(body)
+    # Body is a byte string.
+    # We have to know the encoding in order to print it to a text file
+    # such as standard output.
+    print(body.decode('iso-8859-1'))
 
-This code is available as ``examples/quickstart/get_python2_https.py`` and
-``examples/quickstart/get_python3_https.py``.
+This code is available as ``examples/quickstart/get_python3_https.py``.
+For a Python 2 example, see ``examples/quickstart/get_python2_https.py``.
 
 
 Troubleshooting


### PR DESCRIPTION
Python 2 is end-of-life. Show only code snippets targeting Python 3.