### PR TITLE
tests: Don't use proxy when testing connection to ::1

### DIFF
--- a/tests/open_socket_cb_test.py
+++ b/tests/open_socket_cb_test.py
@@ -77,6 +77,7 @@ class OpenSocketCbTest(unittest.TestCase):
     def test_socket_open_ipv6(self):
         self.curl.setopt(pycurl.OPENSOCKETFUNCTION, socket_open_ipv6)
         self.curl.setopt(self.curl.URL, 'http://[::1]:8380/success')
+        self.curl.setopt(self.curl.NOPROXY, '::1')
         sio = util.BytesIO()
         self.curl.setopt(pycurl.WRITEFUNCTION, sio.write)
         try:


### PR DESCRIPTION
The environment where the test is run may not disable proxy for ::1,
which is the case in Ubuntu CI due to older releases not handling ::1
in no_proxy properly.

https://bugs.launchpad.net/ubuntu/+source/curl/+bug/1908136