### PR TITLE
Remove bintray links from docs

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -128,9 +128,6 @@ install PycURL by running:
 
     pip install pycurl
 
-If you are not using pip, EXE and MSI installers are available in the
-`download area`_.
-
 Both 32-bit and 64-bit builds of PycURL are available for Windows.
 
 
@@ -264,8 +261,6 @@ Prerequisites:
 ``winbuild.py`` assumes all programs are installed in their default locations,
 if this is not the case edit it as needed. ``winbuild.py`` itself can be run
 with any Python it supports.
-
-.. _`download area`: https://dl.bintray.com/pycurl/pycurl/
 
 
 Git Checkout

--- a/README.kr.rst
+++ b/README.kr.rst
@@ -34,13 +34,12 @@ urllib_ Python 모듈과 마찬가지로, PycURL 을 사용하여 Python프로�
 설치
 ----
 
-`PyPI`_ 또는 `Bintray`_ 에서 소스 및 바이너리 배포판을 다운로드 하십시오.
+`PyPI`_ 에서 소스 및 바이너리 배포판을 다운로드 하십시오.
 이제 바이너리 휘을 32 비트 및 64 비트 Windows 버전에서 사용할 수 있습니다.
 
 설치 지침은 `INSTALL.rst`_ 를 참조하십시오. Git checkout에서 설치하는 경우, INSTALL.rst 의 `Git Checkout`_ 섹션의 지침을 따르십시오.
 
 .. _PyPI: https://pypi.python.org/pypi/pycurl
-.. _Bintray: https://dl.bintray.com/pycurl/pycurl/
 .. _INSTALL.rst: http://pycurl.io/docs/latest/install.html
 .. _Git Checkout: http://pycurl.io/docs/latest/install.html#git-checkout
 

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Requirements
 Installation
 ------------
 
-Download source and binary distributions from `PyPI`_ or `Bintray`_.
+Download source and binary distributions from `PyPI`_.
 Binary wheels are now available for 32 and 64 bit Windows versions.
 
 Please see `INSTALL.rst`_ for installation instructions. If installing from
@@ -47,7 +47,6 @@ a Git checkout, please follow instruction in the `Git Checkout`_ section
 of INSTALL.rst.
 
 .. _PyPI: https://pypi.python.org/pypi/pycurl
-.. _Bintray: https://dl.bintray.com/pycurl/pycurl/
 .. _INSTALL.rst: http://pycurl.io/docs/latest/install.html
 .. _Git Checkout: http://pycurl.io/docs/latest/install.html#git-checkout
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -78,11 +78,6 @@ On Windows, use pip to install a binary wheel for Python 2.7, 3.5 or 3.6::
 
     pip install pycurl
 
-If not using pip, binary distributions in other formats are available
-`on Bintray`_.
-
-.. _on Bintray: https://dl.bintray.com/pycurl/pycurl/
-
 
 Support
 -------

--- a/setup.py
+++ b/setup.py
@@ -850,13 +850,12 @@ Requirements
 Installation
 ------------
 
-Download source and binary distributions from `PyPI`_ or `Bintray`_.
+Download source and binary distributions from `PyPI`_.
 Binary wheels are now available for 32 and 64 bit Windows versions.
 
 Please see `the installation documentation`_ for installation instructions.
 
 .. _PyPI: https://pypi.python.org/pypi/pycurl
-.. _Bintray: https://dl.bintray.com/pycurl/pycurl/
 .. _the installation documentation: http://pycurl.io/docs/latest/install.html
 
 


### PR DESCRIPTION
Bintray has shut down over the weekend.
- https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

Since a download link is not working, I've removed the links from the document.
- https://dl.bintray.com/pycurl/pycurl/ (403)