### PR TITLE
Prefer setuptools.setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,7 @@ VERSION = "7.44.0"
 import glob, os, re, sys, subprocess
 import distutils
 try:
-    import wheel
-    if wheel:
-        from setuptools import setup
+    from setuptools import setup
 except ImportError:
     from distutils.core import setup
 from distutils.extension import Extension


### PR DESCRIPTION
Let's always prefer setuptools.setup as it generates better metadata, and fixes the following warning:

```
/usr/lib/python3.9/distutils/dist.py:274: UserWarning: Unknown distribution option: 'python_requires'
  warnings.warn(msg)
```