### PR TITLE
Add support for SecureTransport SSL backend

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -53,7 +53,7 @@ It will then fail at runtime as follows::
 
 To fix this, you need to tell ``setup.py`` what SSL backend is used::
 
-    python setup.py --with-[openssl|gnutls|nss|mbedtls|wolfssl] install
+    python setup.py --with-[openssl|gnutls|nss|mbedtls|wolfssl|sectransp] install
 
 Note: as of PycURL 7.21.5, setup.py accepts ``--with-openssl`` option to
 indicate that libcurl is built against OpenSSL/LibreSSL/BoringSSL.
@@ -86,7 +86,7 @@ environment variable::
 The same applies to the SSL backend, if you need to specify it (see the SSL
 note above)::
 
-    export PYCURL_SSL_LIBRARY=[openssl|gnutls|nss|mbedtls]
+    export PYCURL_SSL_LIBRARY=[openssl|gnutls|nss|mbedtls|sectransp]
     easy_install pycurl
 
 

--- a/src/module.c
+++ b/src/module.c
@@ -374,6 +374,7 @@ initpycurl(void)
                 case CURLSSLBACKEND_NSS:
                 case CURLSSLBACKEND_WOLFSSL:
                 case CURLSSLBACKEND_MBEDTLS:
+                case CURLSSLBACKEND_SECURETRANSPORT:
                     runtime_supported_backend_found = 1;
                     break;
                 default:
@@ -404,6 +405,8 @@ initpycurl(void)
         runtime_ssl_lib = "nss";
     } else if (!strncmp(vi->ssl_version, "mbedTLS/", 8)) {
         runtime_ssl_lib = "mbedtls";
+    } else if (!strncmp(vi->ssl_version, "Secure Transport", 16)) {
+        runtime_ssl_lib = "secure-transport";
     } else {
         runtime_ssl_lib = "none/other";
     }

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -220,6 +220,9 @@ pycurl_inet_ntop (int family, void *addr, char *string, size_t string_size);
 #   define PYCURL_NEED_MBEDTLS_TSL
 #   define COMPILE_SSL_LIB "mbedtls"
 #   define COMPILE_SUPPORTED_SSL_BACKEND_FOUND 1
+# elif defined(HAVE_CURL_SECTRANSP)
+#   define COMPILE_SSL_LIB "secure-transport"
+#   define COMPILE_SUPPORTED_SSL_BACKEND_FOUND 1
 # else
 #  ifdef _MSC_VER
     /* sigh */
@@ -237,7 +240,7 @@ pycurl_inet_ntop (int family, void *addr, char *string, size_t string_size);
     * no reason to require users match those */
 #  define COMPILE_SSL_LIB "none/other"
 #  define COMPILE_SUPPORTED_SSL_BACKEND_FOUND 0
-# endif /* HAVE_CURL_OPENSSL || HAVE_CURL_WOLFSSL || HAVE_CURL_GNUTLS || HAVE_CURL_NSS || HAVE_CURL_MBEDTLS */
+# endif /* HAVE_CURL_OPENSSL || HAVE_CURL_WOLFSSL || HAVE_CURL_GNUTLS || HAVE_CURL_NSS || HAVE_CURL_MBEDTLS || HAVE_CURL_SECTRANSP */
 #else
 # define COMPILE_SSL_LIB "none/other"
 # define COMPILE_SUPPORTED_SSL_BACKEND_FOUND 0

--- a/tests/fake-curl/libcurl/Makefile
+++ b/tests/fake-curl/libcurl/Makefile
@@ -13,10 +13,16 @@ clean:
 
 CC = `curl-config --cc`
 CFLAGS += `curl-config --cflags`
+UNAME := $(shell uname -s)
+ifeq ($(UNAME),Darwin)
+	SONAME_FLAG = -install_name
+else
+	SONAME_FLAG = -soname
+endif
 
 .c.so:
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -shared -fPIC \
-		-Wl,-soname,$@ -o $@ $<
+		-Wl,$(SONAME_FLAG),$@ -o $@ $<
 
 show-targets:
 	ls *c |sed -e 's/.c$$/.so/' | awk '{print $$1 " \\"}'

--- a/tests/option_constants_test.py
+++ b/tests/option_constants_test.py
@@ -241,7 +241,7 @@ class OptionConstantsTest(unittest.TestCase):
         curl.close()
 
     @util.min_libcurl(7, 42, 0)
-    @util.only_ssl_backends('nss')
+    @util.only_ssl_backends('nss', 'secure-transport')
     def test_ssl_falsestart(self):
         curl = pycurl.Curl()
         curl.setopt(curl.SSL_FALSESTART, 1)
@@ -263,7 +263,7 @@ class OptionConstantsTest(unittest.TestCase):
         curl.setopt(curl.ISSUERCERT, '/bogus-issuercert')
         curl.close()
 
-    @util.only_ssl
+    @util.only_ssl_backends('openssl', 'gnutls', 'nss')
     def test_capath(self):
         curl = pycurl.Curl()
         curl.setopt(curl.CAPATH, '/bogus-capath')
@@ -271,7 +271,7 @@ class OptionConstantsTest(unittest.TestCase):
 
     # CURLOPT_PROXY_CAPATH was introduced in libcurl-7.52.0
     @util.min_libcurl(7, 52, 0)
-    @util.only_ssl
+    @util.only_ssl_backends('openssl', 'gnutls', 'nss')
     def test_proxy_capath(self):
         curl = pycurl.Curl()
         curl.setopt(curl.PROXY_CAPATH, '/bogus-capath')
@@ -331,7 +331,7 @@ class OptionConstantsTest(unittest.TestCase):
         curl.setopt(curl.RANDOM_FILE, '/bogus-random')
         curl.close()
 
-    @util.only_ssl_backends('openssl', 'gnutls')
+    @util.only_ssl_backends('openssl', 'gnutls', 'secure-transport')
     def test_egdsocket(self):
         curl = pycurl.Curl()
         curl.setopt(curl.EGDSOCKET, '/bogus-egdsocket')

--- a/tests/util.py
+++ b/tests/util.py
@@ -175,6 +175,8 @@ def only_ssl_backends(*backends):
                 current_backend = 'gnutls'
             elif 'NSS/' in pycurl.version:
                 current_backend = 'nss'
+            elif 'SecureTransport' in pycurl.version:
+                current_backend = 'secure-transport'
             else:
                 current_backend = 'none'
             if current_backend not in backends:


### PR DESCRIPTION
This allows pycurl to be compiled with the curl that is shipped with macOS.