### PR TITLE
Add runtime warning to multi callback GIL failure

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -183,8 +183,12 @@ multi_socket_callback(CURL *easy,
 
     /* acquire thread */
     self = (CurlMultiObject *)userp;
-    if (!PYCURL_ACQUIRE_THREAD_MULTI())
+    if (!PYCURL_ACQUIRE_THREAD_MULTI()) {
+        PyGILState_STATE tmp_warn_state = PyGILState_Ensure();
+        PyErr_WarnEx(PyExc_RuntimeWarning, "multi_socket_callback failed to acquire thread", 1);
+        PyGILState_Release(tmp_warn_state);
         return 0;
+    }
 
     /* check args */
     if (self->s_cb == NULL)
@@ -232,8 +236,12 @@ multi_timer_callback(CURLM *multi,
 
     /* acquire thread */
     self = (CurlMultiObject *)userp;
-    if (!PYCURL_ACQUIRE_THREAD_MULTI())
+    if (!PYCURL_ACQUIRE_THREAD_MULTI()) {
+        PyGILState_STATE tmp_warn_state = PyGILState_Ensure();
+        PyErr_WarnEx(PyExc_RuntimeWarning, "multi_timer_callback failed to acquire thread", 1);
+        PyGILState_Release(tmp_warn_state);
         return ret;
+    }
 
     /* check args */
     if (self->t_cb == NULL)


### PR DESCRIPTION
This is a less extreme alternative to what was proposed in issue #709.

Without callback fixes from #708 the corresponding tests produce the following warnings:

```python
multi_callback_test.py::MultiCallbackTest::test_easy_close
  multi_callback_test.py:105: RuntimeWarning: multi_socket_callback failed to acquire thread
    self.easy.close()

multi_callback_test.py::MultiCallbackTest::test_easy_close
  multi_callback_test.py:105: RuntimeWarning: multi_timer_callback failed to acquire thread
    self.easy.close()

multi_callback_test.py::MultiCallbackTest::test_easy_pause_unpause
  multi_callback_test.py:85: RuntimeWarning: multi_socket_callback failed to acquire thread
    self.easy.pause(pycurl.PAUSE_ALL)
```

This has already proved fruitful as I didn't realize before that `easy.close()` could also invoke `multi_timer_callback`. The tests I added to #708 only check if `easy.close()` successfully invokes `multi_socket_callback`, although the PR already fixes both at the same time.

Note that `PyErr_WarnEx` needs GIL, but the catch is that these callbacks start without it (that's the root of these callback issues to begin with). So I wrapped it in `PyGILState_Ensure()` and `PyGILState_Release()`. [Python C API docs state this](https://docs.python.org/3/c-api/init.html#c.PyGILState_Ensure):

> PyGILState_STATE PyGILState_Ensure()  
>
> Ensure that the current thread is ready to call the Python C API regardless of the current state of Python, or of the global interpreter lock. This may be called as many times as desired by a thread as long as each call is matched with a call to PyGILState_Release().