### PR TITLE
Fix unsetting multi options

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -419,18 +419,12 @@ do_multi_setopt_none(CurlMultiObject *self, int option, PyObject *obj)
     case CURLMOPT_SOCKETFUNCTION:
         curl_multi_setopt(self->multi_handle, CURLMOPT_SOCKETFUNCTION, NULL);
         curl_multi_setopt(self->multi_handle, CURLMOPT_SOCKETDATA, NULL);
-        if (self->s_cb != NULL) {
-            Py_DECREF(self->s_cb);
-            self->s_cb = NULL;
-        }
+        Py_CLEAR(self->s_cb);
         break;
     case CURLMOPT_TIMERFUNCTION:
         curl_multi_setopt(self->multi_handle, CURLMOPT_TIMERFUNCTION, NULL);
         curl_multi_setopt(self->multi_handle, CURLMOPT_TIMERDATA, NULL);
-        if (self->s_cb != NULL) {
-            Py_DECREF(self->s_cb);
-            self->s_cb = NULL;
-        }
+        Py_CLEAR(self->t_cb);
         break;
     default:
         PyErr_SetString(PyExc_TypeError, "unsetting is not supported for this option");

--- a/tests/multi_option_constants_test.py
+++ b/tests/multi_option_constants_test.py
@@ -63,6 +63,7 @@ class MultiOptionConstantsTest(unittest.TestCase):
         input = (util.u('test1'), util.u('test2'))
         self.m.setopt(option, input)
         self.m.setopt(option, ())
+        self.m.setopt(option, None)
 
         try:
             self.m.setopt(option, 1)
@@ -70,3 +71,19 @@ class MultiOptionConstantsTest(unittest.TestCase):
         except TypeError:
             exc = sys.exc_info()[1]
             assert 'integers are not supported for this option' in str(exc)
+
+    def test_multi_callback_opts(self):
+        def callback(*args, **kwargs):
+            pass
+        self.m.setopt(pycurl.M_SOCKETFUNCTION, callback)
+        self.m.setopt(pycurl.M_TIMERFUNCTION, callback)
+        self.m.setopt(pycurl.M_SOCKETFUNCTION, None)
+        self.m.setopt(pycurl.M_TIMERFUNCTION, None)
+
+    def test_multi_unsetopt_unsupported(self):
+        try:
+            self.m.setopt(pycurl.M_MAXCONNECTS, None)
+            self.fail('expected to raise')
+        except TypeError:
+            exc = sys.exc_info()[1]
+            assert 'unsetting is not supported for this option' in str(exc)


### PR DESCRIPTION
Previously there was no way to unset multi options.

This patch adds `do_multi_setopt_none()`, which supports using `None` value for those libcurl options that one can set to NULL:

* CURLMOPT_SOCKETFUNCTION
* CURLMOPT_TIMERFUNCTION
* CURLMOPT_PIPELINING_SERVER_BL
* CURLMOPT_PIPELINING_SITE_BL

---

Additionally, `multi_option_constants_test.py` has also been updated:

 * add missing test for setting callback options
 * test setting options to `None`, with supported and unsupported options