### PR TITLE
easy.duphandle()

### DIFF
--- a/doc/docstrings/curl_duphandle.rst
+++ b/doc/docstrings/curl_duphandle.rst
@@ -1,0 +1,23 @@
+duphandle() -> Curl
+
+Clone a curl handle. This function will return a new curl handle,
+a duplicate, using all the options previously set in the input curl handle.
+Both handles can subsequently be used independently.
+
+The new handle will not inherit any state information, no connections,
+no SSL sessions and no cookies. It also will not inherit any share object
+states or options (it will be made as if SHARE was unset).
+
+Corresponds to `curl_easy_duphandle`_ in libcurl.
+
+Example usage::
+
+    import pycurl
+    curl = pycurl.Curl()
+    curl.setopt(pycurl.URL, "https://python.org")
+    dup = curl.duphandle()
+    curl.perform()
+    dup.perform()
+
+.. _curl_easy_duphandle:
+    https://curl.se/libcurl/c/curl_easy_duphandle.html

--- a/src/easy.c
+++ b/src/easy.c
@@ -416,7 +416,9 @@ do_curl_duphandle(CurlObject *self)
     return dup;
 
 error:
-    Py_CLEAR(dup->dict);
+    if (dup != NULL) {
+        Py_CLEAR(dup->dict);
+    }
     Py_DECREF(dup);    /* this also closes dup->handle */
     PyErr_SetString(ErrorObject, "cloning curl failed");
     return NULL;

--- a/src/easy.c
+++ b/src/easy.c
@@ -276,13 +276,14 @@ static inline PyObject* my_Py_XNewRef(PyObject *obj)
 PYCURL_INTERNAL CurlObject *
 do_curl_duphandle(CurlObject *self)
 {
+    PyTypeObject *subtype;
     CurlObject *dup;
     int res;
     int *ptr;
 
     /* Allocate python curl object */
-    /* TODO: allocate subtype instead of Curl_Type */
-    dup = (CurlObject *) p_Curl_Type->tp_alloc(p_Curl_Type, 0);
+    subtype = Py_TYPE(self);
+    dup = (CurlObject *) subtype->tp_alloc(subtype, 0);
     if (dup == NULL)
         return NULL;
 

--- a/src/easy.c
+++ b/src/easy.c
@@ -389,27 +389,27 @@ do_curl_duphandle(CurlObject *self)
     dup->ca_certs_obj = my_Py_XNewRef(self->ca_certs_obj);
 
     /* Assign and incref every curl_slist allocated by setopt */
-    dup->httpheader = my_Py_XNewRef(self->httpheader);
+    dup->httpheader = (CurlSlistObject *)my_Py_XNewRef((PyObject *)self->httpheader);
 #if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 37, 0)
-    dup->proxyheader = my_Py_XNewRef(self->proxyheader);
+    dup->proxyheader = (CurlSlistObject *)my_Py_XNewRef((PyObject *)self->proxyheader);
 #endif
-    dup->http200aliases = my_Py_XNewRef(self->http200aliases);
-    dup->quote = my_Py_XNewRef(self->quote);
-    dup->postquote = my_Py_XNewRef(self->postquote);
-    dup->prequote = my_Py_XNewRef(self->prequote);
-    dup->telnetoptions = my_Py_XNewRef(self->telnetoptions);
+    dup->http200aliases = (CurlSlistObject *)my_Py_XNewRef((PyObject *)self->http200aliases);
+    dup->quote = (CurlSlistObject *)my_Py_XNewRef((PyObject *)self->quote);
+    dup->postquote = (CurlSlistObject *)my_Py_XNewRef((PyObject *)self->postquote);
+    dup->prequote = (CurlSlistObject *)my_Py_XNewRef((PyObject *)self->prequote);
+    dup->telnetoptions = (CurlSlistObject *)my_Py_XNewRef((PyObject *)self->telnetoptions);
 #ifdef HAVE_CURLOPT_RESOLVE
-    dup->resolve = my_Py_XNewRef(self->resolve);
+    dup->resolve = (CurlSlistObject *)my_Py_XNewRef((PyObject *)self->resolve);
 #endif
 #ifdef HAVE_CURL_7_20_0_OPTS
-    dup->mail_rcpt = my_Py_XNewRef(self->mail_rcpt);
+    dup->mail_rcpt = (CurlSlistObject *)my_Py_XNewRef((PyObject *)self->mail_rcpt);
 #endif
 #ifdef HAVE_CURLOPT_CONNECT_TO
-    dup->connect_to = my_Py_XNewRef(self->connect_to);
+    dup->connect_to = (CurlSlistObject *)my_Py_XNewRef((PyObject *)self->connect_to);
 #endif
 
     /* Assign and incref httppost */
-    dup->httppost = my_Py_XNewRef(self->httppost);
+    dup->httppost = (CurlHttppostObject *)my_Py_XNewRef((PyObject *)self->httppost);
 
     /* Success - return cloned object */
     return dup;

--- a/src/easy.c
+++ b/src/easy.c
@@ -1,47 +1,6 @@
 #include "pycurl.h"
 #include "docstrings.h"
 
-#define PYCURL_TP_SLOTS_ZEROED \
-    0,      /* tp_print / tp_vectorcall_offset */ \
-    0,      /* tp_getattr */ \
-    0,      /* tp_setattr */ \
-    0,      /* tp_reserved / tp_as_async */ \
-    0,      /* tp_repr */ \
-    0,      /* tp_as_number */ \
-    0,      /* tp_as_sequence */ \
-    0,      /* tp_as_mapping */ \
-    0,      /* tp_hash */ \
-    0,      /* tp_call */ \
-    0,      /* tp_str */ \
-    0,      /* tp_getattro */ \
-    0,      /* tp_setattro */ \
-    0,      /* tp_as_buffer */ \
-    0,      /* tp_flags */ \
-    0,      /* tp_doc */ \
-    0,      /* tp_traverse */ \
-    0,      /* tp_clear */ \
-    0,      /* tp_richcompare */ \
-    0,      /* tp_weaklistoffset */ \
-    0,      /* tp_iter */ \
-    0,      /* tp_iternext */ \
-    0,      /* tp_methods */ \
-    0,      /* tp_members */ \
-    0,      /* tp_getset */ \
-    0,      /* tp_base */ \
-    0,      /* tp_dict */ \
-    0,      /* tp_descr_get */ \
-    0,      /* tp_descr_set */ \
-    0,      /* tp_dictoffset */ \
-    0,      /* tp_init */ \
-    0,      /* tp_alloc */ \
-    0,      /* tp_new */ \
-    0,      /* tp_free */ \
-    0,      /* tp_is_gc */ \
-    0,      /* tp_bases */ \
-    0,      /* tp_mro */ \
-    0,      /* tp_cache */ \
-    0,      /* tp_subclasses */ \
-    0,      /* tp_weaklist */
 
 /*************************************************************************
 // CurlSlistObject
@@ -60,7 +19,7 @@ util_curlslist_update(CurlSlistObject **old, struct curl_slist *slist)
 }
 
 PYCURL_INTERNAL void
-do_curl_slist_dealloc(CurlSlistObject *self) {
+do_curlslist_dealloc(CurlSlistObject *self) {
     if (self->slist != NULL) {
         curl_slist_free_all(self->slist);
         self->slist = NULL;
@@ -78,8 +37,47 @@ PYCURL_INTERNAL PyTypeObject CurlSlist_Type = {
     "pycurl.CurlSlist",         /* tp_name */
     sizeof(CurlSlistObject),    /* tp_basicsize */
     0,                          /* tp_itemsize */
-    (destructor)do_curl_slist_dealloc, /* tp_dealloc */
-    PYCURL_TP_SLOTS_ZEROED
+    (destructor)do_curlslist_dealloc, /* tp_dealloc */
+    0,                          /* tp_print / tp_vectorcall_offset */
+    0,                          /* tp_getattr */
+    0,                          /* tp_setattr */
+    0,                          /* tp_reserved / tp_as_async */
+    0,                          /* tp_repr */
+    0,                          /* tp_as_number */
+    0,                          /* tp_as_sequence */
+    0,                          /* tp_as_mapping */
+    0,                          /* tp_hash */
+    0,                          /* tp_call */
+    0,                          /* tp_str */
+    0,                          /* tp_getattro */
+    0,                          /* tp_setattro */
+    0,                          /* tp_as_buffer */
+    0,                          /* tp_flags */
+    0,                          /* tp_doc */
+    0,                          /* tp_traverse */
+    0,                          /* tp_clear */
+    0,                          /* tp_richcompare */
+    0,                          /* tp_weaklistoffset */
+    0,                          /* tp_iter */
+    0,                          /* tp_iternext */
+    0,                          /* tp_methods */
+    0,                          /* tp_members */
+    0,                          /* tp_getset */
+    0,                          /* tp_base */
+    0,                          /* tp_dict */
+    0,                          /* tp_descr_get */
+    0,                          /* tp_descr_set */
+    0,                          /* tp_dictoffset */
+    0,                          /* tp_init */
+    0,                          /* tp_alloc */
+    0,                          /* tp_new */
+    0,                          /* tp_free */
+    0,                          /* tp_is_gc */
+    0,                          /* tp_bases */
+    0,                          /* tp_mro */
+    0,                          /* tp_cache */
+    0,                          /* tp_subclasses */
+    0,                          /* tp_weaklist */
 #if PY_MAJOR_VERSION >= 3
     0,                          /* tp_del */
     0,                          /* tp_version_tag */
@@ -107,7 +105,7 @@ util_curlhttppost_update(CurlObject *obj, struct curl_httppost *httppost, PyObje
 }
 
 PYCURL_INTERNAL void
-do_curl_httppost_dealloc(CurlHttppostObject *self) {
+do_curlhttppost_dealloc(CurlHttppostObject *self) {
     if (self->httppost != NULL) {
         curl_formfree(self->httppost);
         self->httppost = NULL;
@@ -126,8 +124,47 @@ PYCURL_INTERNAL PyTypeObject CurlHttppost_Type = {
     "pycurl.CurlHttppost",      /* tp_name */
     sizeof(CurlHttppostObject), /* tp_basicsize */
     0,                          /* tp_itemsize */
-    (destructor)do_curl_httppost_dealloc, /* tp_dealloc */
-    PYCURL_TP_SLOTS_ZEROED
+    (destructor)do_curlhttppost_dealloc, /* tp_dealloc */
+    0,                          /* tp_print / tp_vectorcall_offset */
+    0,                          /* tp_getattr */
+    0,                          /* tp_setattr */
+    0,                          /* tp_reserved / tp_as_async */
+    0,                          /* tp_repr */
+    0,                          /* tp_as_number */
+    0,                          /* tp_as_sequence */
+    0,                          /* tp_as_mapping */
+    0,                          /* tp_hash */
+    0,                          /* tp_call */
+    0,                          /* tp_str */
+    0,                          /* tp_getattro */
+    0,                          /* tp_setattro */
+    0,                          /* tp_as_buffer */
+    0,                          /* tp_flags */
+    0,                          /* tp_doc */
+    0,                          /* tp_traverse */
+    0,                          /* tp_clear */
+    0,                          /* tp_richcompare */
+    0,                          /* tp_weaklistoffset */
+    0,                          /* tp_iter */
+    0,                          /* tp_iternext */
+    0,                          /* tp_methods */
+    0,                          /* tp_members */
+    0,                          /* tp_getset */
+    0,                          /* tp_base */
+    0,                          /* tp_dict */
+    0,                          /* tp_descr_get */
+    0,                          /* tp_descr_set */
+    0,                          /* tp_dictoffset */
+    0,                          /* tp_init */
+    0,                          /* tp_alloc */
+    0,                          /* tp_new */
+    0,                          /* tp_free */
+    0,                          /* tp_is_gc */
+    0,                          /* tp_bases */
+    0,                          /* tp_mro */
+    0,                          /* tp_cache */
+    0,                          /* tp_subclasses */
+    0,                          /* tp_weaklist */
 #if PY_MAJOR_VERSION >= 3
     0,                          /* tp_del */
     0,                          /* tp_version_tag */
@@ -259,20 +296,7 @@ error:
     return NULL;
 }
 
-
-/* Py_NewRef and Py_XNewRef - only since Python 3.10 (Include/object.h) */
-static inline PyObject* my_Py_NewRef(PyObject *obj)
-{
-    Py_INCREF(obj);
-    return obj;
-}
-
-static inline PyObject* my_Py_XNewRef(PyObject *obj)
-{
-    Py_XINCREF(obj);
-    return obj;
-}
-
+/* duphandle */
 PYCURL_INTERNAL CurlObject *
 do_curl_duphandle(CurlObject *self)
 {

--- a/src/easy.c
+++ b/src/easy.c
@@ -728,7 +728,7 @@ PYCURL_INTERNAL PyMethodDef curlobject_methods[] = {
     {"setopt_string", (PyCFunction)do_curl_setopt_string, METH_VARARGS, curl_setopt_string_doc},
     {"unsetopt", (PyCFunction)do_curl_unsetopt, METH_VARARGS, curl_unsetopt_doc},
     {"reset", (PyCFunction)do_curl_reset, METH_NOARGS, curl_reset_doc},
-    {"duphandle", (PyCFunction)do_curl_duphandle, METH_NOARGS, NULL},
+    {"duphandle", (PyCFunction)do_curl_duphandle, METH_NOARGS, curl_duphandle_doc},
 #if defined(HAVE_CURL_OPENSSL)
     {"set_ca_certs", (PyCFunction)do_curl_set_ca_certs, METH_VARARGS, curl_set_ca_certs_doc},
 #endif

--- a/src/easy.c
+++ b/src/easy.c
@@ -65,7 +65,7 @@ do_curl_slist_dealloc(CurlSlistObject *self) {
         curl_slist_free_all(self->slist);
         self->slist = NULL;
     }
-    Py_TYPE(self)->tp_free((PyObject *) self);
+    CurlSlist_Type.tp_free(self);
 }
 
 PYCURL_INTERNAL PyTypeObject CurlSlist_Type = {
@@ -113,7 +113,7 @@ do_curl_httppost_dealloc(CurlHttppostObject *self) {
         self->httppost = NULL;
     }
     Py_CLEAR(self->reflist);
-    Py_TYPE(self)->tp_free((PyObject *) self);
+    CurlHttppost_Type.tp_free(self);
 }
 
 PYCURL_INTERNAL PyTypeObject CurlHttppost_Type = {

--- a/src/easy.c
+++ b/src/easy.c
@@ -416,9 +416,7 @@ do_curl_duphandle(CurlObject *self)
     return dup;
 
 error:
-    if (dup != NULL) {
-        Py_CLEAR(dup->dict);
-    }
+    Py_CLEAR(dup->dict);
     Py_DECREF(dup);    /* this also closes dup->handle */
     PyErr_SetString(ErrorObject, "cloning curl failed");
     return NULL;

--- a/src/easyopt.c
+++ b/src/easyopt.c
@@ -65,10 +65,57 @@ util_curl_unsetopt(CurlObject *self, int option)
         Py_XDECREF(self->share);
         self->share = NULL;
         break;
+    case CURLOPT_HTTPHEADER:
+        SETOPT((void *) 0);
+        Py_CLEAR(self->httpheader);
+        break;
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 37, 0)
+    case CURLOPT_PROXYHEADER:
+        SETOPT((void *) 0);
+        Py_CLEAR(self->proxyheader);
+        break;
+#endif
+    case CURLOPT_HTTP200ALIASES:
+        SETOPT((void *) 0);
+        Py_CLEAR(self->http200aliases);
+        break;
+    case CURLOPT_QUOTE:
+        SETOPT((void *) 0);
+        Py_CLEAR(self->quote);
+        break;
+    case CURLOPT_POSTQUOTE:
+        SETOPT((void *) 0);
+        Py_CLEAR(self->postquote);
+        break;
+    case CURLOPT_PREQUOTE:
+        SETOPT((void *) 0);
+        Py_CLEAR(self->prequote);
+        break;
+    case CURLOPT_TELNETOPTIONS:
+        SETOPT((void *) 0);
+        Py_CLEAR(self->telnetoptions);
+        break;
+#ifdef HAVE_CURLOPT_RESOLVE
+    case CURLOPT_RESOLVE:
+        SETOPT((void *) 0);
+        Py_CLEAR(self->resolve);
+        break;
+#endif
+#ifdef HAVE_CURL_7_20_0_OPTS
+    case CURLOPT_MAIL_RCPT:
+        SETOPT((void *) 0);
+        Py_CLEAR(self->mail_rcpt);
+        break;
+#endif
+#ifdef HAVE_CURLOPT_CONNECT_TO
+    case CURLOPT_CONNECT_TO:
+        SETOPT((void *) 0);
+        Py_CLEAR(self->connect_to);
+        break;
+#endif
     case CURLOPT_HTTPPOST:
         SETOPT((void *) 0);
         Py_CLEAR(self->httppost);
-        self->httppost = NULL;
         /* FIXME: what about data->set.httpreq ?? */
         break;
     case CURLOPT_INFILESIZE:
@@ -106,10 +153,6 @@ util_curl_unsetopt(CurlObject *self, int option)
 #if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 43, 0)
     case CURLOPT_SERVICE_NAME:
     case CURLOPT_PROXY_SERVICE_NAME:
-#endif
-    case CURLOPT_HTTPHEADER:
-#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 37, 0)
-    case CURLOPT_PROXYHEADER:
 #endif
 #if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 52, 0)
     case CURLOPT_PROXY_CAPATH:

--- a/src/easyopt.c
+++ b/src/easyopt.c
@@ -46,6 +46,12 @@ util_curl_unsetopt(CurlObject *self, int option)
 #define SETOPT2(o,x) \
     if ((res = curl_easy_setopt(self->handle, (o), (x))) != CURLE_OK) goto error
 #define SETOPT(x)   SETOPT2((CURLoption)option, (x))
+#define CLEAR_OBJECT(object_option, object_field) \
+    case object_option: \
+        if ((res = curl_easy_setopt(self->handle, object_option, NULL)) != CURLE_OK) \
+            goto error; \
+        Py_CLEAR(object_field); \
+        break
 #define CLEAR_CALLBACK(callback_option, data_option, callback_field) \
     case callback_option: \
         if ((res = curl_easy_setopt(self->handle, callback_option, NULL)) != CURLE_OK) \
@@ -64,59 +70,6 @@ util_curl_unsetopt(CurlObject *self, int option)
         SETOPT((CURLSH *) NULL);
         Py_XDECREF(self->share);
         self->share = NULL;
-        break;
-    case CURLOPT_HTTPHEADER:
-        SETOPT((void *) 0);
-        Py_CLEAR(self->httpheader);
-        break;
-#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 37, 0)
-    case CURLOPT_PROXYHEADER:
-        SETOPT((void *) 0);
-        Py_CLEAR(self->proxyheader);
-        break;
-#endif
-    case CURLOPT_HTTP200ALIASES:
-        SETOPT((void *) 0);
-        Py_CLEAR(self->http200aliases);
-        break;
-    case CURLOPT_QUOTE:
-        SETOPT((void *) 0);
-        Py_CLEAR(self->quote);
-        break;
-    case CURLOPT_POSTQUOTE:
-        SETOPT((void *) 0);
-        Py_CLEAR(self->postquote);
-        break;
-    case CURLOPT_PREQUOTE:
-        SETOPT((void *) 0);
-        Py_CLEAR(self->prequote);
-        break;
-    case CURLOPT_TELNETOPTIONS:
-        SETOPT((void *) 0);
-        Py_CLEAR(self->telnetoptions);
-        break;
-#ifdef HAVE_CURLOPT_RESOLVE
-    case CURLOPT_RESOLVE:
-        SETOPT((void *) 0);
-        Py_CLEAR(self->resolve);
-        break;
-#endif
-#ifdef HAVE_CURL_7_20_0_OPTS
-    case CURLOPT_MAIL_RCPT:
-        SETOPT((void *) 0);
-        Py_CLEAR(self->mail_rcpt);
-        break;
-#endif
-#ifdef HAVE_CURLOPT_CONNECT_TO
-    case CURLOPT_CONNECT_TO:
-        SETOPT((void *) 0);
-        Py_CLEAR(self->connect_to);
-        break;
-#endif
-    case CURLOPT_HTTPPOST:
-        SETOPT((void *) 0);
-        Py_CLEAR(self->httppost);
-        /* FIXME: what about data->set.httpreq ?? */
         break;
     case CURLOPT_INFILESIZE:
         SETOPT((long) -1);
@@ -171,6 +124,27 @@ util_curl_unsetopt(CurlObject *self, int option)
         SETOPT((long) 0);
         break;
 #endif
+
+    CLEAR_OBJECT(CURLOPT_HTTPHEADER, self->httpheader);
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 37, 0)
+    CLEAR_OBJECT(CURLOPT_PROXYHEADER, self->proxyheader);
+#endif
+    CLEAR_OBJECT(CURLOPT_HTTP200ALIASES, self->http200aliases);
+    CLEAR_OBJECT(CURLOPT_QUOTE, self->quote);
+    CLEAR_OBJECT(CURLOPT_POSTQUOTE, self->postquote);
+    CLEAR_OBJECT(CURLOPT_PREQUOTE, self->prequote);
+    CLEAR_OBJECT(CURLOPT_TELNETOPTIONS, self->telnetoptions);
+#ifdef HAVE_CURLOPT_RESOLVE
+    CLEAR_OBJECT(CURLOPT_RESOLVE, self->resolve);
+#endif
+#ifdef HAVE_CURL_7_20_0_OPTS
+    CLEAR_OBJECT(CURLOPT_MAIL_RCPT, self->mail_rcpt);
+#endif
+#ifdef HAVE_CURLOPT_CONNECT_TO
+    CLEAR_OBJECT(CURLOPT_CONNECT_TO, self->connect_to);
+#endif
+    /* FIXME: what about data->set.httpreq ?? */
+    CLEAR_OBJECT(CURLOPT_HTTPPOST, self->httppost);
 
     CLEAR_CALLBACK(CURLOPT_OPENSOCKETFUNCTION, CURLOPT_OPENSOCKETDATA, self->opensocket_cb);
 #if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 21, 7)

--- a/src/easyopt.c
+++ b/src/easyopt.c
@@ -67,8 +67,7 @@ util_curl_unsetopt(CurlObject *self, int option)
         break;
     case CURLOPT_HTTPPOST:
         SETOPT((void *) 0);
-        curl_formfree(self->httppost);
-        util_curl_xdecref(self, PYCURL_MEMGROUP_HTTPPOST, self->handle);
+        Py_CLEAR(self->httppost);
         self->httppost = NULL;
         /* FIXME: what about data->set.httpreq ?? */
         break;
@@ -690,16 +689,9 @@ do_curl_setopt_httppost(CurlObject *self, int option, int which, PyObject *obj)
         CURLERROR_SET_RETVAL();
         goto error;
     }
-    /* Finally, free previously allocated httppost, ZAP any
-     * buffer references, and update */
-    curl_formfree(self->httppost);
-    util_curl_xdecref(self, PYCURL_MEMGROUP_HTTPPOST, self->handle);
-    self->httppost = post;
-
-    /* The previous list of INCed references was ZAPed above; save
-     * the new one so that we can clean it up on the next
-     * self->httppost free. */
-    self->httppost_ref_list = ref_params;
+    /* Finally, decref previous httppost object and replace it with a
+     * new one. */
+    util_curlhttppost_update(self, post, ref_params);
 
     Py_RETURN_NONE;
 
@@ -713,48 +705,48 @@ error:
 static PyObject *
 do_curl_setopt_list(CurlObject *self, int option, int which, PyObject *obj)
 {
-    struct curl_slist **old_slist = NULL;
+    CurlSlistObject **old_slist_obj = NULL;
     struct curl_slist *slist = NULL;
     Py_ssize_t len;
     int res;
 
     switch (option) {
     case CURLOPT_HTTP200ALIASES:
-        old_slist = &self->http200aliases;
+        old_slist_obj = &self->http200aliases;
         break;
     case CURLOPT_HTTPHEADER:
-        old_slist = &self->httpheader;
+        old_slist_obj = &self->httpheader;
         break;
 #if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 37, 0)
     case CURLOPT_PROXYHEADER:
-        old_slist = &self->proxyheader;
+        old_slist_obj = &self->proxyheader;
         break;
 #endif
     case CURLOPT_POSTQUOTE:
-        old_slist = &self->postquote;
+        old_slist_obj = &self->postquote;
         break;
     case CURLOPT_PREQUOTE:
-        old_slist = &self->prequote;
+        old_slist_obj = &self->prequote;
         break;
     case CURLOPT_QUOTE:
-        old_slist = &self->quote;
+        old_slist_obj = &self->quote;
         break;
     case CURLOPT_TELNETOPTIONS:
-        old_slist = &self->telnetoptions;
+        old_slist_obj = &self->telnetoptions;
         break;
 #ifdef HAVE_CURLOPT_RESOLVE
     case CURLOPT_RESOLVE:
-        old_slist = &self->resolve;
+        old_slist_obj = &self->resolve;
         break;
 #endif
 #ifdef HAVE_CURL_7_20_0_OPTS
     case CURLOPT_MAIL_RCPT:
-        old_slist = &self->mail_rcpt;
+        old_slist_obj = &self->mail_rcpt;
         break;
 #endif
 #ifdef HAVE_CURLOPT_CONNECT_TO
     case CURLOPT_CONNECT_TO:
-        old_slist = &self->connect_to;
+        old_slist_obj = &self->connect_to;
         break;
 #endif
     default:
@@ -768,7 +760,7 @@ do_curl_setopt_list(CurlObject *self, int option, int which, PyObject *obj)
         Py_RETURN_NONE;
 
     /* Just to be sure we do not bug off here */
-    assert(old_slist != NULL && slist == NULL);
+    assert(old_slist_obj != NULL && slist == NULL);
 
     /* Handle regular list operations on the other options */
     slist = pycurl_list_or_tuple_to_slist(which, obj, len);
@@ -781,9 +773,9 @@ do_curl_setopt_list(CurlObject *self, int option, int which, PyObject *obj)
         curl_slist_free_all(slist);
         CURLERROR_RETVAL();
     }
-    /* Finally, free previously allocated list and update */
-    curl_slist_free_all(*old_slist);
-    *old_slist = slist;
+    /* Finally, decref previous slist object and replace it with a
+     * new one. */
+    util_curlslist_update(old_slist_obj, slist);
 
     Py_RETURN_NONE;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -28,6 +28,8 @@ PYCURL_INTERNAL char *g_pycurl_useragent = NULL;
 /* Type objects */
 PYCURL_INTERNAL PyObject *ErrorObject = NULL;
 PYCURL_INTERNAL PyTypeObject *p_Curl_Type = NULL;
+PYCURL_INTERNAL PyTypeObject *p_CurlSlist_Type = NULL;
+PYCURL_INTERNAL PyTypeObject *p_CurlHttppost_Type = NULL;
 PYCURL_INTERNAL PyTypeObject *p_CurlMulti_Type = NULL;
 PYCURL_INTERNAL PyTypeObject *p_CurlShare_Type = NULL;
 #ifdef HAVE_CURL_7_19_6_OPTS
@@ -416,9 +418,13 @@ initpycurl(void)
     /* Initialize the type of the new type objects here; doing it here
      * is required for portability to Windows without requiring C++. */
     p_Curl_Type = &Curl_Type;
+    p_CurlSlist_Type = &CurlSlist_Type;
+    p_CurlHttppost_Type = &CurlHttppost_Type;
     p_CurlMulti_Type = &CurlMulti_Type;
     p_CurlShare_Type = &CurlShare_Type;
     Py_SET_TYPE(&Curl_Type, &PyType_Type);
+    Py_SET_TYPE(&CurlSlist_Type, &PyType_Type);
+    Py_SET_TYPE(&CurlHttppost_Type, &PyType_Type);
     Py_SET_TYPE(&CurlMulti_Type, &PyType_Type);
     Py_SET_TYPE(&CurlShare_Type, &PyType_Type);
 
@@ -426,11 +432,18 @@ initpycurl(void)
     if (PyType_Ready(&Curl_Type) < 0)
         goto error;
 
+    if (PyType_Ready(&CurlSlist_Type) < 0)
+        goto error;
+
+    if (PyType_Ready(&CurlHttppost_Type) < 0)
+        goto error;
+
     if (PyType_Ready(&CurlMulti_Type) < 0)
         goto error;
 
     if (PyType_Ready(&CurlShare_Type) < 0)
         goto error;
+
 
 #if PY_MAJOR_VERSION >= 3
     m = PyModule_Create(&curlmodule);

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -371,15 +371,29 @@ create_and_set_error_object(struct CurlObject *self, int code);
 #define PYCURL_MEMGROUP_POSTFIELDS      64
 /* CA certs object */
 #define PYCURL_MEMGROUP_CACERTS         128
+/* Curl slist objects */
+#define PYCURL_MEMGROUP_SLIST           256
 
 #define PYCURL_MEMGROUP_EASY \
     (PYCURL_MEMGROUP_CALLBACK | PYCURL_MEMGROUP_FILE | \
     PYCURL_MEMGROUP_HTTPPOST | PYCURL_MEMGROUP_POSTFIELDS | \
-    PYCURL_MEMGROUP_CACERTS)
+    PYCURL_MEMGROUP_CACERTS | PYCURL_MEMGROUP_SLIST)
 
 #define PYCURL_MEMGROUP_ALL \
     (PYCURL_MEMGROUP_ATTRDICT | PYCURL_MEMGROUP_EASY | \
     PYCURL_MEMGROUP_MULTI | PYCURL_MEMGROUP_SHARE)
+
+typedef struct CurlSlistObject {
+    PyObject_HEAD
+    struct curl_slist *slist;
+} CurlSlistObject;
+
+typedef struct CurlHttppostObject {
+    PyObject_HEAD
+    struct curl_httppost *httppost;
+    /* List of INC'ed references associated with httppost. */
+    PyObject *reflist;
+} CurlHttppostObject;
 
 typedef struct CurlObject {
     PyObject_HEAD
@@ -392,26 +406,24 @@ typedef struct CurlObject {
 #endif
     struct CurlMultiObject *multi_stack;
     struct CurlShareObject *share;
-    struct curl_httppost *httppost;
-    /* List of INC'ed references associated with httppost. */
-    PyObject *httppost_ref_list;
-    struct curl_slist *httpheader;
+    struct CurlHttppostObject *httppost;
+    struct CurlSlistObject *httpheader;
 #if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 37, 0)
-    struct curl_slist *proxyheader;
+    struct CurlSlistObject *proxyheader;
 #endif
-    struct curl_slist *http200aliases;
-    struct curl_slist *quote;
-    struct curl_slist *postquote;
-    struct curl_slist *prequote;
-    struct curl_slist *telnetoptions;
+    struct CurlSlistObject *http200aliases;
+    struct CurlSlistObject *quote;
+    struct CurlSlistObject *postquote;
+    struct CurlSlistObject *prequote;
+    struct CurlSlistObject *telnetoptions;
 #ifdef HAVE_CURLOPT_RESOLVE
-    struct curl_slist *resolve;
+    struct CurlSlistObject *resolve;
 #endif
 #ifdef HAVE_CURL_7_20_0_OPTS
-    struct curl_slist *mail_rcpt;
+    struct CurlSlistObject *mail_rcpt;
 #endif
 #ifdef HAVE_CURLOPT_CONNECT_TO
-    struct curl_slist *connect_to;
+    struct CurlSlistObject *connect_to;
 #endif
     /* callbacks */
     PyObject *w_cb;
@@ -619,11 +631,15 @@ ssl_ctx_callback(CURL *curl, void *ssl_ctx, void *ptr);
 #if !defined(PYCURL_SINGLE_FILE)
 /* Type objects */
 extern PyTypeObject Curl_Type;
+extern PyTypeObject CurlSlist_Type;
+extern PyTypeObject CurlHttppost_Type;
 extern PyTypeObject CurlMulti_Type;
 extern PyTypeObject CurlShare_Type;
 
 extern PyObject *ErrorObject;
 extern PyTypeObject *p_Curl_Type;
+extern PyTypeObject *p_CurlSlist_Type;
+extern PyTypeObject *p_CurlHttppost_Type;
 extern PyTypeObject *p_CurlMulti_Type;
 extern PyTypeObject *p_CurlShare_Type;
 extern PyObject *khkey_type;

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -570,6 +570,11 @@ util_curl_xdecref(CurlObject *self, int flags, CURL *handle);
 PYCURL_INTERNAL PyObject *
 do_curl_setopt_filelike(CurlObject *self, int option, PyObject *obj);
 
+PYCURL_INTERNAL void
+util_curlslist_update(CurlSlistObject **old, struct curl_slist *slist);
+PYCURL_INTERNAL void
+util_curlhttppost_update(CurlObject *obj, struct curl_httppost *httppost, PyObject *reflist);
+
 PYCURL_INTERNAL PyObject *
 do_curl_getinfo_raw(CurlObject *self, PyObject *args);
 #if PY_MAJOR_VERSION >= 3

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -318,6 +318,10 @@ PyText_Check(PyObject *o);
 PYCURL_INTERNAL PyObject *
 PyText_FromString_Ignore(const char *string);
 
+/* Py_NewRef and Py_XNewRef - not part of Python's C API before 3.10 */
+static inline PyObject* my_Py_NewRef(PyObject *obj) { Py_INCREF(obj); return obj; }
+static inline PyObject* my_Py_XNewRef(PyObject *obj) { Py_XINCREF(obj); return obj; }
+
 struct CurlObject;
 
 PYCURL_INTERNAL void

--- a/tests/app.py
+++ b/tests/app.py
@@ -30,6 +30,7 @@ def forbidden():
 def not_found():
     return bottle.HTTPResponse('not found', 404)
 
+@app.route('/postfields', method='get')
 @app.route('/postfields', method='post')
 def postfields():
     return json.dumps(dict(bottle.request.forms))
@@ -88,7 +89,7 @@ def header():
 # Thanks to bdarnell for the idea: https://github.com/pycurl/pycurl/issues/124
 @app.route('/header_utf8')
 def header_utf8():
-    header_value = bottle.request.headers[bottle.request.query['h']]
+    header_value = bottle.request.headers.get(bottle.request.query['h'], '' if py3 else b'')
     if py3:
         # header_value is a string, headers are decoded in latin1
         header_value = header_value.encode('latin1').decode('utf8')

--- a/tests/duphandle_test.py
+++ b/tests/duphandle_test.py
@@ -1,0 +1,94 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# vi:ts=4:et
+
+from . import localhost
+import pycurl
+import unittest
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
+from . import appmanager
+from . import util
+
+setup_module, teardown_module = appmanager.setup(('app', 8380))
+
+class DuphandleTest(unittest.TestCase):
+    def setUp(self):
+        self.curl = util.DefaultCurl()
+        self.dup = None
+
+    def tearDown(self):
+        if self.dup:
+            self.dup.close()
+
+    def test_duphandle_attribute_dict(self):
+        self.curl.original_attr = 'original-value'
+        # attribute dict should be copied - the *object*, not the reference
+        self.dup = self.curl.duphandle()
+        assert self.dup.original_attr == 'original-value'
+        # cloned dict should be a separate object
+        self.dup.clone_attr = 'clone-value'
+        try:
+            self.curl.clone_attr == 'does not exist'
+        except AttributeError as error:
+            assert 'trying to obtain a non-existing attribute: clone_attr' in str(error.args)
+        else:
+            self.fail('should have raised AttributeError')
+        # decref - original dict is freed from memory
+        self.curl.close()
+        del self.curl
+        # cloned dict should still exist
+        assert self.dup.original_attr == 'original-value'
+        assert self.dup.clone_attr == 'clone-value'
+
+    def test_duphandle_slist(self):
+        self.curl.setopt(pycurl.HTTPHEADER, ['x-test-header: original-slist'])
+        # slist *reference* should be copied and incremented
+        self.dup = self.curl.duphandle()
+        # decref
+        self.curl.close()
+        del self.curl
+        # slist object should still exist
+        body = util.BytesIO()
+        self.dup.setopt(pycurl.WRITEFUNCTION, body.write)
+        self.dup.setopt(pycurl.URL, 'http://%s:8380/header_utf8?h=x-test-header' % localhost)
+        self.dup.perform()
+        result = body.getvalue().decode('utf-8')
+        assert result == 'original-slist'
+
+    def test_duphandle_httppost(self):
+        self.curl.setopt(pycurl.HTTPPOST, [
+            ('field', (pycurl.FORM_CONTENTS, 'original-httppost')),
+        ])
+        # httppost *reference* should be copied and incremented
+        self.dup = self.curl.duphandle()
+        # decref
+        self.curl.close()
+        del self.curl
+        # httppost object should still exist
+        body = util.BytesIO()
+        self.dup.setopt(pycurl.WRITEFUNCTION, body.write)
+        self.dup.setopt(pycurl.URL, 'http://%s:8380/postfields' % localhost)
+        self.dup.perform()
+        result = json.loads(body.getvalue())
+        assert result == {'field': 'original-httppost'}
+
+    def test_duphandle_callback(self):
+        body = util.BytesIO()
+        def callback(data):
+            body.write(data)
+        self.curl.setopt(pycurl.WRITEFUNCTION, callback)
+        # callback *reference* should be copied and incremented
+        self.dup = self.curl.duphandle()
+        # decref
+        self.curl.close()
+        del self.curl
+        del callback
+        # callback object should still exist
+        self.dup.setopt(pycurl.URL, 'http://%s:8380/success' % localhost)
+        self.dup.perform()
+        result = body.getvalue().decode('utf-8')
+        assert result == 'success'


### PR DESCRIPTION
@p I'm working on adding [`curl_easy_duphandle()`](https://curl.se/libcurl/c/curl_easy_duphandle.html). This is just a prototype for now. It works fine, but I stumbled upon two possible ways to go about this.

`do_curl_duphandle` must duplicate all additional values that PycURL keeps stored in a Curl object. For Python objects that's just a matter of increasing reference counts, except for attribute dictionary (easy->dict) which is copied.

The question is what to do with non-Python data: `curl_slist` and `curl_httppost`.

**Memory copies**
Right now I'm creating copies of slists (and I haven't done much yet about httppost). This requires no change to other code, but I believe it wastes memory for no reason. The user doesn't interact with these objects anyway, and they are never modified at any point. Instead they're always created from scratch on each setopt.

**Reference counts**
So these objects don't have to be copied, they can be shared between the original and clone handle. However this requires that each of these objects has a reference count as well. This would require encapsulating each of these in a struct that holds the count, something like this:

```c
struct CurlSlist {
    struct curl_slist *slist;
    int refcount;
};
```

All freeing of memory would then be replaced by decref wrappers that manage the counts, one for `curl_slist` and one for `curl_httppost`. While duphandle would increase the counts.

I think this approach is better, but I want your opinion before I go making any changes all over the place.