### PR TITLE
Wrap curl_slist and curl_httppost in their own Python type

### DIFF
--- a/src/easy.c
+++ b/src/easy.c
@@ -1,6 +1,48 @@
 #include "pycurl.h"
 #include "docstrings.h"
 
+#define PYCURL_TP_SLOTS_ZEROED \
+    0,      /* tp_print / tp_vectorcall_offset */ \
+    0,      /* tp_getattr */ \
+    0,      /* tp_setattr */ \
+    0,      /* tp_reserved / tp_as_async */ \
+    0,      /* tp_repr */ \
+    0,      /* tp_as_number */ \
+    0,      /* tp_as_sequence */ \
+    0,      /* tp_as_mapping */ \
+    0,      /* tp_hash */ \
+    0,      /* tp_call */ \
+    0,      /* tp_str */ \
+    0,      /* tp_getattro */ \
+    0,      /* tp_setattro */ \
+    0,      /* tp_as_buffer */ \
+    0,      /* tp_flags */ \
+    0,      /* tp_doc */ \
+    0,      /* tp_traverse */ \
+    0,      /* tp_clear */ \
+    0,      /* tp_richcompare */ \
+    0,      /* tp_weaklistoffset */ \
+    0,      /* tp_iter */ \
+    0,      /* tp_iternext */ \
+    0,      /* tp_methods */ \
+    0,      /* tp_members */ \
+    0,      /* tp_getset */ \
+    0,      /* tp_base */ \
+    0,      /* tp_dict */ \
+    0,      /* tp_descr_get */ \
+    0,      /* tp_descr_set */ \
+    0,      /* tp_dictoffset */ \
+    0,      /* tp_init */ \
+    0,      /* tp_alloc */ \
+    0,      /* tp_new */ \
+    0,      /* tp_free */ \
+    0,      /* tp_is_gc */ \
+    0,      /* tp_bases */ \
+    0,      /* tp_mro */ \
+    0,      /* tp_cache */ \
+    0,      /* tp_subclasses */ \
+    0,      /* tp_weaklist */
+
 /*************************************************************************
 // CurlSlistObject
 **************************************************************************/
@@ -26,13 +68,24 @@ do_curl_slist_dealloc(CurlSlistObject *self) {
     Py_TYPE(self)->tp_free((PyObject *) self);
 }
 
-/* TODO: Python 2 compatible */
 PYCURL_INTERNAL PyTypeObject CurlSlist_Type = {
+#if PY_MAJOR_VERSION >= 3
     PyVarObject_HEAD_INIT(NULL, 0)
-    .tp_name = "pycurl.CurlSlist",
-    .tp_basicsize = sizeof(CurlSlistObject),
-    .tp_itemsize = 0,
-    .tp_dealloc = (destructor) do_curl_slist_dealloc,
+#else
+    PyObject_HEAD_INIT(NULL)
+    0,                          /* ob_size */
+#endif
+    "pycurl.CurlSlist",         /* tp_name */
+    sizeof(CurlSlistObject),    /* tp_basicsize */
+    0,                          /* tp_itemsize */
+    (destructor)do_curl_slist_dealloc, /* tp_dealloc */
+    PYCURL_TP_SLOTS_ZEROED
+#if PY_MAJOR_VERSION >= 3
+    0,                          /* tp_del */
+    0,                          /* tp_version_tag */
+    0,                          /* tp_finalize */
+    0,                          /* tp_vectorcall */
+#endif
 };
 
 
@@ -63,13 +116,24 @@ do_curl_httppost_dealloc(CurlHttppostObject *self) {
     Py_TYPE(self)->tp_free((PyObject *) self);
 }
 
-/* TODO: Python 2 compatible */
 PYCURL_INTERNAL PyTypeObject CurlHttppost_Type = {
+#if PY_MAJOR_VERSION >= 3
     PyVarObject_HEAD_INIT(NULL, 0)
-    .tp_name = "pycurl.CurlHttppost",
-    .tp_basicsize = sizeof(CurlHttppostObject),
-    .tp_itemsize = 0,
-    .tp_dealloc = (destructor) do_curl_httppost_dealloc,
+#else
+    PyObject_HEAD_INIT(NULL)
+    0,                          /* ob_size */
+#endif
+    "pycurl.CurlHttppost",      /* tp_name */
+    sizeof(CurlHttppostObject), /* tp_basicsize */
+    0,                          /* tp_itemsize */
+    (destructor)do_curl_httppost_dealloc, /* tp_dealloc */
+    PYCURL_TP_SLOTS_ZEROED
+#if PY_MAJOR_VERSION >= 3
+    0,                          /* tp_del */
+    0,                          /* tp_version_tag */
+    0,                          /* tp_finalize */
+    0,                          /* tp_vectorcall */
+#endif
 };
 
 

--- a/src/easyopt.c
+++ b/src/easyopt.c
@@ -713,48 +713,48 @@ error:
 static PyObject *
 do_curl_setopt_list(CurlObject *self, int option, int which, PyObject *obj)
 {
-    struct curl_slist **old_slist = NULL;
+    CurlSlistObject **old_slist_obj = NULL;
     struct curl_slist *slist = NULL;
     Py_ssize_t len;
     int res;
 
     switch (option) {
     case CURLOPT_HTTP200ALIASES:
-        old_slist = &self->http200aliases;
+        old_slist_obj = &self->http200aliases;
         break;
     case CURLOPT_HTTPHEADER:
-        old_slist = &self->httpheader;
+        old_slist_obj = &self->httpheader;
         break;
 #if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 37, 0)
     case CURLOPT_PROXYHEADER:
-        old_slist = &self->proxyheader;
+        old_slist_obj = &self->proxyheader;
         break;
 #endif
     case CURLOPT_POSTQUOTE:
-        old_slist = &self->postquote;
+        old_slist_obj = &self->postquote;
         break;
     case CURLOPT_PREQUOTE:
-        old_slist = &self->prequote;
+        old_slist_obj = &self->prequote;
         break;
     case CURLOPT_QUOTE:
-        old_slist = &self->quote;
+        old_slist_obj = &self->quote;
         break;
     case CURLOPT_TELNETOPTIONS:
-        old_slist = &self->telnetoptions;
+        old_slist_obj = &self->telnetoptions;
         break;
 #ifdef HAVE_CURLOPT_RESOLVE
     case CURLOPT_RESOLVE:
-        old_slist = &self->resolve;
+        old_slist_obj = &self->resolve;
         break;
 #endif
 #ifdef HAVE_CURL_7_20_0_OPTS
     case CURLOPT_MAIL_RCPT:
-        old_slist = &self->mail_rcpt;
+        old_slist_obj = &self->mail_rcpt;
         break;
 #endif
 #ifdef HAVE_CURLOPT_CONNECT_TO
     case CURLOPT_CONNECT_TO:
-        old_slist = &self->connect_to;
+        old_slist_obj = &self->connect_to;
         break;
 #endif
     default:
@@ -768,7 +768,7 @@ do_curl_setopt_list(CurlObject *self, int option, int which, PyObject *obj)
         Py_RETURN_NONE;
 
     /* Just to be sure we do not bug off here */
-    assert(old_slist != NULL && slist == NULL);
+    assert(old_slist_obj != NULL && slist == NULL);
 
     /* Handle regular list operations on the other options */
     slist = pycurl_list_or_tuple_to_slist(which, obj, len);
@@ -781,9 +781,9 @@ do_curl_setopt_list(CurlObject *self, int option, int which, PyObject *obj)
         curl_slist_free_all(slist);
         CURLERROR_RETVAL();
     }
-    /* Finally, free previously allocated list and update */
-    curl_slist_free_all(*old_slist);
-    *old_slist = slist;
+    /* Finally, decref previous slist object and replace it with a
+     * new one. */
+    util_curlslist_update(old_slist_obj, slist);
 
     Py_RETURN_NONE;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -28,6 +28,7 @@ PYCURL_INTERNAL char *g_pycurl_useragent = NULL;
 /* Type objects */
 PYCURL_INTERNAL PyObject *ErrorObject = NULL;
 PYCURL_INTERNAL PyTypeObject *p_Curl_Type = NULL;
+PYCURL_INTERNAL PyTypeObject *p_CurlSlist_Type = NULL;
 PYCURL_INTERNAL PyTypeObject *p_CurlMulti_Type = NULL;
 PYCURL_INTERNAL PyTypeObject *p_CurlShare_Type = NULL;
 #ifdef HAVE_CURL_7_19_6_OPTS
@@ -416,9 +417,11 @@ initpycurl(void)
     /* Initialize the type of the new type objects here; doing it here
      * is required for portability to Windows without requiring C++. */
     p_Curl_Type = &Curl_Type;
+    p_CurlSlist_Type = &CurlSlist_Type;
     p_CurlMulti_Type = &CurlMulti_Type;
     p_CurlShare_Type = &CurlShare_Type;
     Py_SET_TYPE(&Curl_Type, &PyType_Type);
+    Py_SET_TYPE(&CurlSlist_Type, &PyType_Type);
     Py_SET_TYPE(&CurlMulti_Type, &PyType_Type);
     Py_SET_TYPE(&CurlShare_Type, &PyType_Type);
 
@@ -426,11 +429,15 @@ initpycurl(void)
     if (PyType_Ready(&Curl_Type) < 0)
         goto error;
 
+    if (PyType_Ready(&CurlSlist_Type) < 0)
+        goto error;
+
     if (PyType_Ready(&CurlMulti_Type) < 0)
         goto error;
 
     if (PyType_Ready(&CurlShare_Type) < 0)
         goto error;
+
 
 #if PY_MAJOR_VERSION >= 3
     m = PyModule_Create(&curlmodule);

--- a/src/module.c
+++ b/src/module.c
@@ -29,6 +29,7 @@ PYCURL_INTERNAL char *g_pycurl_useragent = NULL;
 PYCURL_INTERNAL PyObject *ErrorObject = NULL;
 PYCURL_INTERNAL PyTypeObject *p_Curl_Type = NULL;
 PYCURL_INTERNAL PyTypeObject *p_CurlSlist_Type = NULL;
+PYCURL_INTERNAL PyTypeObject *p_CurlHttppost_Type = NULL;
 PYCURL_INTERNAL PyTypeObject *p_CurlMulti_Type = NULL;
 PYCURL_INTERNAL PyTypeObject *p_CurlShare_Type = NULL;
 #ifdef HAVE_CURL_7_19_6_OPTS
@@ -418,10 +419,12 @@ initpycurl(void)
      * is required for portability to Windows without requiring C++. */
     p_Curl_Type = &Curl_Type;
     p_CurlSlist_Type = &CurlSlist_Type;
+    p_CurlHttppost_Type = &CurlHttppost_Type;
     p_CurlMulti_Type = &CurlMulti_Type;
     p_CurlShare_Type = &CurlShare_Type;
     Py_SET_TYPE(&Curl_Type, &PyType_Type);
     Py_SET_TYPE(&CurlSlist_Type, &PyType_Type);
+    Py_SET_TYPE(&CurlHttppost_Type, &PyType_Type);
     Py_SET_TYPE(&CurlMulti_Type, &PyType_Type);
     Py_SET_TYPE(&CurlShare_Type, &PyType_Type);
 
@@ -430,6 +433,9 @@ initpycurl(void)
         goto error;
 
     if (PyType_Ready(&CurlSlist_Type) < 0)
+        goto error;
+
+    if (PyType_Ready(&CurlHttppost_Type) < 0)
         goto error;
 
     if (PyType_Ready(&CurlMulti_Type) < 0)

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -388,6 +388,13 @@ typedef struct CurlSlistObject {
     struct curl_slist *slist;
 } CurlSlistObject;
 
+typedef struct CurlHttppostObject {
+    PyObject_HEAD
+    struct curl_httppost *httppost;
+    /* List of INC'ed references associated with httppost. */
+    PyObject *reflist;
+} CurlHttppostObject;
+
 typedef struct CurlObject {
     PyObject_HEAD
     PyObject *dict;                 /* Python attributes dictionary */
@@ -399,9 +406,7 @@ typedef struct CurlObject {
 #endif
     struct CurlMultiObject *multi_stack;
     struct CurlShareObject *share;
-    struct curl_httppost *httppost;
-    /* List of INC'ed references associated with httppost. */
-    PyObject *httppost_ref_list;
+    struct CurlHttppostObject *httppost;
     struct CurlSlistObject *httpheader;
 #if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 37, 0)
     struct CurlSlistObject *proxyheader;
@@ -627,12 +632,14 @@ ssl_ctx_callback(CURL *curl, void *ssl_ctx, void *ptr);
 /* Type objects */
 extern PyTypeObject Curl_Type;
 extern PyTypeObject CurlSlist_Type;
+extern PyTypeObject CurlHttppost_Type;
 extern PyTypeObject CurlMulti_Type;
 extern PyTypeObject CurlShare_Type;
 
 extern PyObject *ErrorObject;
 extern PyTypeObject *p_Curl_Type;
 extern PyTypeObject *p_CurlSlist_Type;
+extern PyTypeObject *p_CurlHttppost_Type;
 extern PyTypeObject *p_CurlMulti_Type;
 extern PyTypeObject *p_CurlShare_Type;
 extern PyObject *khkey_type;

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -570,6 +570,11 @@ util_curl_xdecref(CurlObject *self, int flags, CURL *handle);
 PYCURL_INTERNAL PyObject *
 do_curl_setopt_filelike(CurlObject *self, int option, PyObject *obj);
 
+PYCURL_INTERNAL void
+util_curlslist_update(CurlSlistObject **old, struct curl_slist *slist);
+PYCURL_INTERNAL void
+util_curlhttppost_update(CurlObject *obj, struct curl_httppost *httppost, PyObject *reflist);
+
 PYCURL_INTERNAL PyObject *
 do_curl_getinfo_raw(CurlObject *self, PyObject *args);
 #if PY_MAJOR_VERSION >= 3

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -371,15 +371,22 @@ create_and_set_error_object(struct CurlObject *self, int code);
 #define PYCURL_MEMGROUP_POSTFIELDS      64
 /* CA certs object */
 #define PYCURL_MEMGROUP_CACERTS         128
+/* Curl slist objects */
+#define PYCURL_MEMGROUP_SLIST           256
 
 #define PYCURL_MEMGROUP_EASY \
     (PYCURL_MEMGROUP_CALLBACK | PYCURL_MEMGROUP_FILE | \
     PYCURL_MEMGROUP_HTTPPOST | PYCURL_MEMGROUP_POSTFIELDS | \
-    PYCURL_MEMGROUP_CACERTS)
+    PYCURL_MEMGROUP_CACERTS | PYCURL_MEMGROUP_SLIST)
 
 #define PYCURL_MEMGROUP_ALL \
     (PYCURL_MEMGROUP_ATTRDICT | PYCURL_MEMGROUP_EASY | \
     PYCURL_MEMGROUP_MULTI | PYCURL_MEMGROUP_SHARE)
+
+typedef struct CurlSlistObject {
+    PyObject_HEAD
+    struct curl_slist *slist;
+} CurlSlistObject;
 
 typedef struct CurlObject {
     PyObject_HEAD
@@ -395,23 +402,23 @@ typedef struct CurlObject {
     struct curl_httppost *httppost;
     /* List of INC'ed references associated with httppost. */
     PyObject *httppost_ref_list;
-    struct curl_slist *httpheader;
+    struct CurlSlistObject *httpheader;
 #if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 37, 0)
-    struct curl_slist *proxyheader;
+    struct CurlSlistObject *proxyheader;
 #endif
-    struct curl_slist *http200aliases;
-    struct curl_slist *quote;
-    struct curl_slist *postquote;
-    struct curl_slist *prequote;
-    struct curl_slist *telnetoptions;
+    struct CurlSlistObject *http200aliases;
+    struct CurlSlistObject *quote;
+    struct CurlSlistObject *postquote;
+    struct CurlSlistObject *prequote;
+    struct CurlSlistObject *telnetoptions;
 #ifdef HAVE_CURLOPT_RESOLVE
-    struct curl_slist *resolve;
+    struct CurlSlistObject *resolve;
 #endif
 #ifdef HAVE_CURL_7_20_0_OPTS
-    struct curl_slist *mail_rcpt;
+    struct CurlSlistObject *mail_rcpt;
 #endif
 #ifdef HAVE_CURLOPT_CONNECT_TO
-    struct curl_slist *connect_to;
+    struct CurlSlistObject *connect_to;
 #endif
     /* callbacks */
     PyObject *w_cb;
@@ -619,11 +626,13 @@ ssl_ctx_callback(CURL *curl, void *ssl_ctx, void *ptr);
 #if !defined(PYCURL_SINGLE_FILE)
 /* Type objects */
 extern PyTypeObject Curl_Type;
+extern PyTypeObject CurlSlist_Type;
 extern PyTypeObject CurlMulti_Type;
 extern PyTypeObject CurlShare_Type;
 
 extern PyObject *ErrorObject;
 extern PyTypeObject *p_Curl_Type;
+extern PyTypeObject *p_CurlSlist_Type;
 extern PyTypeObject *p_CurlMulti_Type;
 extern PyTypeObject *p_CurlShare_Type;
 extern PyObject *khkey_type;


### PR DESCRIPTION
This PR is the basis for adding `duphandle()` in #714.

It wraps `curl_slist` and `curl_httppost` in their own Python type, so that duphandle() can simply incref them.

I tried to keep the types at a bare minimum, explicitly zeroing all tp_slots except for tp_dealloc. An instance of CurlSlistObject or CurlHttppostObject adds 16 bytes of overhead due to type and reference count that every PyObject has. This is of course the case only if an instance is created at all, via setopt.

On the other hand they don't take any memory at all in duplicate handles. Duplication itself is also more efficient because it just has to incref these objects instead of deep-copying them.

I also made `do_curl_traverse` "visit" these objects just to be safe, although at least for CurlSlistObject I don't think that's necessary because it just holds curl_slist.

Demonstration:
```python
curl = pycurl.Curl()
curl.setopt(pycurl.URL, 'https://httpbin.org/anything')

# create a new curl_slist
curl.setopt(pycurl.HTTPHEADER, ['Name: value'])

# create a clone and incref all objects
dup = curl.duphandle()

# decref all objects
curl.close()
del curl

# perform with the curl_slist still there
dup.perform()

# decref - this finally frees curl_slist
dup.close()
```