### PR TITLE
Add Linux(x86_64 and aarch64) wheel build support

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -1,0 +1,58 @@
+name: Linux Wheels
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  package-wheel:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86_64, aarch64]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Set up QEMU
+        if: ${{ matrix.arch == 'aarch64' }}
+        uses: docker/setup-qemu-action@v1          
+      - name: Build wheels
+        env:
+          CIBW_ARCHS: ${{matrix.arch}}
+          CIBW_BUILD: cp3*
+          CIBW_SKIP: '*-musllinux*'
+          CIBW_BEFORE_ALL: yum install -y libcurl-devel
+        run: |
+          python -m pip install --upgrade pip setuptools
+          pip install cibuildwheel
+          cibuildwheel --output-dir dist
+        shell: bash
+      - name: Upload wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist/
+
+  deploy:
+
+    runs-on: ubuntu-latest
+    needs: package-wheel
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download distributions
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: ${{ secrets.PYPI_USERNAME }}
+          password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
Added Linux(x86_64 and aarch64) wheel build support. 
Related to https://github.com/pycurl/pycurl/issues/738, @p Could you please review this PR? 