### PR TITLE
Fix compile regression for libcurl < 7.64.1

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -376,7 +376,11 @@ initpycurl(void)
                 case CURLSSLBACKEND_NSS:
                 case CURLSSLBACKEND_WOLFSSL:
                 case CURLSSLBACKEND_MBEDTLS:
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 64, 1)
                 case CURLSSLBACKEND_SECURETRANSPORT:
+#else
+                case CURLSSLBACKEND_DARWINSSL:
+#endif
                     runtime_supported_backend_found = 1;
                     break;
                 default:


### PR DESCRIPTION
The CURLSSLBACKEND_SECURETRANSPORT symbol was introduced in 7.64.1, so we
need to use the legacy name CURLSSLBACKEND_DARWINSSL before that.

Fixes #742.