### PR TITLE
tests: fix error message on error_test (for curl >= 7.83)

### DIFF
--- a/tests/error_test.py
+++ b/tests/error_test.py
@@ -29,7 +29,8 @@ class ErrorTest(unittest.TestCase):
             err, msg = exc.args
             self.assertEqual(pycurl.E_URL_MALFORMAT, err)
             # possibly fragile
-            self.assertEqual('No URL set!', msg)
+            # curl < 7.83.0 has an exclamation mark in this error message
+            self.assertIn(msg, ['No URL set!', 'No URL set'])
         else:
             self.fail('Expected pycurl.error to be raised')
     
@@ -43,9 +44,10 @@ class ErrorTest(unittest.TestCase):
             self.curl.perform()
         except pycurl.error:
             # might be fragile
-            self.assertEqual('No URL set!', self.curl.errstr())
+            # curl < 7.83.0 has an exclamation mark in this error message
+            self.assertIn(self.curl.errstr(), ['No URL set!', 'No URL set'])
             # repeated checks do not clear value
-            self.assertEqual('No URL set!', self.curl.errstr())
+            self.assertIn(self.curl.errstr(), ['No URL set!', 'No URL set'])
             # check the type - on all python versions
             self.assertEqual(str, type(self.curl.errstr()))
         else:


### PR DESCRIPTION
I'm one of the maintainers of the curl package on Debian and I noticed a regression in pycurl's integration tests with curl 7.83.0, this is the fix:

commit message below:
tests: fix error message on error_test (for curl >= 7.83)
curl 7.83.0 removed exclamation marks from a few error messages, curl commit:
https://github.com/curl/curl/commit/6968fb9d54dc3a1aaa1b16088f038eaf5dd8b2d7

This commit adds support for the new curl release while also supporting the previous ones.

Thanks