### PR TITLE
Linux CI: run 'apt-get update' before installing packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install packages
-      run: sudo apt-get install libcurl4-gnutls-dev libgnutls28-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install libcurl4-gnutls-dev libgnutls28-dev
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
This should fix issues with mirroring errors.