### PR TITLE
Add binding for HTTP/3 that was added in libcurl 7.66.0

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1418,6 +1418,9 @@ initpycurl(void)
 #endif
 #if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 66, 0)
     insint(d, "CURL_VERSION_HTTP3", CURL_VERSION_HTTP3);
+
+    /* constant for setopt(HTTP_VERSION, x) */
+    insint_c(d, "CURL_HTTP_VERSION_3", CURL_HTTP_VERSION_3);
 #endif
 #if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 72, 0)
     insint(d, "CURL_VERSION_UNICODE", CURL_VERSION_UNICODE);


### PR DESCRIPTION
Add binding for HTTP/3 that was added in libcurl 7.66.0:
https://curl.se/libcurl/c/CURLOPT_HTTP_VERSION.html