### PR TITLE
Add missing 2nd parameters to METH_NOARGS functions

### DIFF
--- a/src/easy.c
+++ b/src/easy.c
@@ -302,7 +302,7 @@ error:
 
 /* duphandle */
 PYCURL_INTERNAL CurlObject *
-do_curl_duphandle(CurlObject *self)
+do_curl_duphandle(CurlObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyTypeObject *subtype;
     CurlObject *dup;
@@ -617,7 +617,7 @@ do_curl_dealloc(CurlObject *self)
 
 
 static PyObject *
-do_curl_close(CurlObject *self)
+do_curl_close(CurlObject *self, PyObject *Py_UNUSED(ignored))
 {
     if (check_curl_state(self, 2, "close") != 0) {
         return NULL;
@@ -706,7 +706,7 @@ do_curl_traverse(CurlObject *self, visitproc visit, void *arg)
 /* ------------------------ reset ------------------------ */
 
 static PyObject*
-do_curl_reset(CurlObject *self)
+do_curl_reset(CurlObject *self, PyObject *Py_UNUSED(ignored))
 {
     int res;
 
@@ -726,7 +726,7 @@ do_curl_reset(CurlObject *self)
 }
 
 
-static PyObject *do_curl_getstate(CurlObject *self)
+static PyObject *do_curl_getstate(CurlObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyErr_SetString(PyExc_TypeError, "Curl objects do not support serialization");
     return NULL;

--- a/src/easyinfo.c
+++ b/src/easyinfo.c
@@ -356,7 +356,7 @@ do_curl_getinfo(CurlObject *self, PyObject *args)
 
 
 PYCURL_INTERNAL PyObject *
-do_curl_errstr(CurlObject *self)
+do_curl_errstr(CurlObject *self, PyObject *Py_UNUSED(ignored))
 {
     if (check_curl_state(self, 1 | 2, "errstr") != 0) {
         return NULL;
@@ -369,7 +369,7 @@ do_curl_errstr(CurlObject *self)
 
 #if PY_MAJOR_VERSION >= 3
 PYCURL_INTERNAL PyObject *
-do_curl_errstr_raw(CurlObject *self)
+do_curl_errstr_raw(CurlObject *self, PyObject *Py_UNUSED(ignored))
 {
     if (check_curl_state(self, 1 | 2, "errstr") != 0) {
         return NULL;

--- a/src/easyperform.c
+++ b/src/easyperform.c
@@ -4,7 +4,7 @@
 /* --------------- perform --------------- */
 
 PYCURL_INTERNAL PyObject *
-do_curl_perform(CurlObject *self)
+do_curl_perform(CurlObject *self, PyObject *Py_UNUSED(ignored))
 {
     int res;
 
@@ -24,7 +24,7 @@ do_curl_perform(CurlObject *self)
 
 
 PYCURL_INTERNAL PyObject *
-do_curl_perform_rb(CurlObject *self)
+do_curl_perform_rb(CurlObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *v, *io;
     
@@ -49,7 +49,7 @@ do_curl_perform_rb(CurlObject *self)
         return NULL;
     }
     
-    v = do_curl_perform(self);
+    v = do_curl_perform(self, NULL);
     if (v == NULL) {
         return NULL;
     }
@@ -61,11 +61,11 @@ do_curl_perform_rb(CurlObject *self)
 
 #if PY_MAJOR_VERSION >= 3
 PYCURL_INTERNAL PyObject *
-do_curl_perform_rs(CurlObject *self)
+do_curl_perform_rs(CurlObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *v, *decoded;
     
-    v = do_curl_perform_rb(self);
+    v = do_curl_perform_rb(self, NULL);
     if (v == NULL) {
         return NULL;
     }

--- a/src/module.c
+++ b/src/module.c
@@ -94,7 +94,7 @@ do_global_init(PyObject *dummy, PyObject *args)
 
 
 PYCURL_INTERNAL PyObject *
-do_global_cleanup(PyObject *dummy)
+do_global_cleanup(PyObject *dummy, PyObject *Py_UNUSED(ignored))
 {
     UNUSED(dummy);
     curl_global_cleanup();

--- a/src/multi.c
+++ b/src/multi.c
@@ -132,7 +132,7 @@ do_multi_dealloc(CurlMultiObject *self)
 
 
 static PyObject *
-do_multi_close(CurlMultiObject *self)
+do_multi_close(CurlMultiObject *self, PyObject *Py_UNUSED(ignored))
 {
     if (check_multi_state(self, 2, "close") != 0) {
         return NULL;
@@ -492,7 +492,7 @@ error:
 /* --------------- timeout --------------- */
 
 static PyObject *
-do_multi_timeout(CurlMultiObject *self)
+do_multi_timeout(CurlMultiObject *self, PyObject *Py_UNUSED(ignored))
 {
     CURLMcode res;
     long timeout;
@@ -565,7 +565,7 @@ do_multi_socket_action(CurlMultiObject *self, PyObject *args)
 /* --------------- socket_all --------------- */
 
 static PyObject *
-do_multi_socket_all(CurlMultiObject *self)
+do_multi_socket_all(CurlMultiObject *self, PyObject *Py_UNUSED(ignored))
 {
     CURLMcode res;
     int running = -1;
@@ -591,7 +591,7 @@ do_multi_socket_all(CurlMultiObject *self)
 /* --------------- perform --------------- */
 
 static PyObject *
-do_multi_perform(CurlMultiObject *self)
+do_multi_perform(CurlMultiObject *self, PyObject *Py_UNUSED(ignored))
 {
     CURLMcode res;
     int running = -1;
@@ -734,7 +734,7 @@ done:
 /* --------------- fdset ---------------------- */
 
 static PyObject *
-do_multi_fdset(CurlMultiObject *self)
+do_multi_fdset(CurlMultiObject *self, PyObject *Py_UNUSED(ignored))
 {
     CURLMcode res;
     int max_fd = -1, fd;
@@ -935,7 +935,7 @@ do_multi_select(CurlMultiObject *self, PyObject *args)
 }
 
 
-static PyObject *do_curlmulti_getstate(CurlMultiObject *self)
+static PyObject *do_curlmulti_getstate(CurlMultiObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyErr_SetString(PyExc_TypeError, "CurlMulti objects do not support serialization");
     return NULL;

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -555,7 +555,7 @@ assert_curl_state(const CurlObject *self);
 PYCURL_INTERNAL PyObject *
 do_global_init(PyObject *dummy, PyObject *args);
 PYCURL_INTERNAL PyObject *
-do_global_cleanup(PyObject *dummy);
+do_global_cleanup(PyObject *dummy, PyObject *Py_UNUSED(ignored));
 PYCURL_INTERNAL PyObject *
 do_version_info(PyObject *dummy, PyObject *args);
 
@@ -570,12 +570,12 @@ PYCURL_INTERNAL PyObject *
 do_curl_set_ca_certs(CurlObject *self, PyObject *args);
 #endif
 PYCURL_INTERNAL PyObject *
-do_curl_perform(CurlObject *self);
+do_curl_perform(CurlObject *self, PyObject *Py_UNUSED(ignored));
 PYCURL_INTERNAL PyObject *
-do_curl_perform_rb(CurlObject *self);
+do_curl_perform_rb(CurlObject *self, PyObject *Py_UNUSED(ignored));
 #if PY_MAJOR_VERSION >= 3
 PYCURL_INTERNAL PyObject *
-do_curl_perform_rs(CurlObject *self);
+do_curl_perform_rs(CurlObject *self, PyObject *Py_UNUSED(ignored));
 #else
 # define do_curl_perform_rs do_curl_perform_rb
 #endif
@@ -604,10 +604,10 @@ do_curl_getinfo(CurlObject *self, PyObject *args);
 # define do_curl_getinfo do_curl_getinfo_raw
 #endif
 PYCURL_INTERNAL PyObject *
-do_curl_errstr(CurlObject *self);
+do_curl_errstr(CurlObject *self, PyObject *Py_UNUSED(ignored));
 #if PY_MAJOR_VERSION >= 3
 PYCURL_INTERNAL PyObject *
-do_curl_errstr_raw(CurlObject *self);
+do_curl_errstr_raw(CurlObject *self, PyObject *Py_UNUSED(ignored));
 #else
 # define do_curl_errstr_raw do_curl_errstr
 #endif

--- a/src/share.c
+++ b/src/share.c
@@ -138,7 +138,7 @@ do_share_dealloc(CurlShareObject *self)
 
 
 static PyObject *
-do_share_close(CurlShareObject *self)
+do_share_close(CurlShareObject *self, PyObject *Py_UNUSED(ignored))
 {
     if (check_share_state(self, 2, "close") != 0) {
         return NULL;
@@ -212,7 +212,7 @@ error:
 }
 
 
-static PyObject *do_curlshare_getstate(CurlShareObject *self)
+static PyObject *do_curlshare_getstate(CurlShareObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyErr_SetString(PyExc_TypeError, "CurlShare objects do not support serialization");
     return NULL;


### PR DESCRIPTION
The PyCFunction function signature is defined as:

PyObject *PyCFunction(PyObject *self,
                      PyObject *args);

Thus, technically all these functions need a second (unused) parameter, although this does not seem to generate a compiler warning or cause any problems with current calling conventions.

Fixes #781.