### PR TITLE
Fix curl_multi_info_read flow that loses messages

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -821,13 +821,12 @@ do_multi_info_read(CurlMultiObject *self, PyObject *args)
     if ((ok_list = PyList_New((Py_ssize_t)0)) == NULL) goto error;
     if ((err_list = PyList_New((Py_ssize_t)0)) == NULL) goto error;
 
-    /* Loop through all messages */
-    while ((msg = curl_multi_info_read(self->multi_handle, &in_queue)) != NULL) {
+    /* Loop through up to 'num_results' messages */
+    while (num_results-- > 0) {
         CURLcode res;
         CurlObject *co = NULL;
 
-        /* Check for termination as specified by the user */
-        if (num_results-- <= 0) {
+        if ((msg = curl_multi_info_read(self->multi_handle, &in_queue)) == NULL) {
             break;
         }
 


### PR DESCRIPTION
Fixes an issue where (if num_results is less than the number of messages in the queue) a message can be pulled out of the queue, then the flow breaks out of the loop before the message is added to one of the returned lists.  The user therefore never sees the message.