### PR TITLE
[docs] fix mailing list address

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,7 +12,7 @@ request.
 
 Please send support requests to our mailing list:
 
-http://cool.haxx.se/mailman/listinfo/curl-and-python
+https://lists.haxx.se/listinfo/curl-and-python
 
 People have also had success with getting help at Stack Overflow.
 

--- a/README.kr.rst
+++ b/README.kr.rst
@@ -66,7 +66,7 @@ PycURL 개발 버전에 대한 설명서는 `여기 <http://pycurl.io/docs/dev/>
 
 버그는 `GitHub`_를 통해 보고될 수 있습니다. 버그 보고서와 GitHub는 메일링 목록에 직접 문의하십시오.
 
-.. _curl-and-python 메일링 목록: http://cool.haxx.se/mailman/listinfo/curl-and-python
+.. _curl-and-python 메일링 목록: https://lists.haxx.se/listinfo/curl-and-python
 .. _Stack Overflow: http://stackoverflow.com/questions/tagged/pycurl
 .. _메일링 목록 보관소: https://curl.haxx.se/mail/list.cgi?list=curl-and-python
 .. _GitHub: https://github.com/pycurl/pycurl/issues
@@ -176,5 +176,5 @@ License
 .. _libcurl: https://curl.haxx.se/libcurl/
 .. _urllib: http://docs.python.org/library/urllib.html
 .. _`the repository`: https://github.com/pycurl/pycurl
-.. _`mailing list`: http://cool.haxx.se/mailman/listinfo/curl-and-python
+.. _`mailing list`: https://lists.haxx.se/listinfo/curl-and-python
 .. _`downloads repository`: https://github.com/pycurl/downloads

--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ popular with some PycURL users.
 Bugs can be reported `via GitHub`_. Please use GitHub only for bug
 reports and direct questions to our mailing list instead.
 
-.. _curl-and-python mailing list: http://cool.haxx.se/mailman/listinfo/curl-and-python
+.. _curl-and-python mailing list: https://lists.haxx.se/listinfo/curl-and-python
 .. _Stack Overflow: http://stackoverflow.com/questions/tagged/pycurl
 .. _Mailing list archives: https://curl.haxx.se/mail/list.cgi?list=curl-and-python
 .. _via GitHub: https://github.com/pycurl/pycurl/issues
@@ -186,5 +186,5 @@ License
 .. _libcurl: https://curl.haxx.se/libcurl/
 .. _urllib: http://docs.python.org/library/urllib.html
 .. _`the repository`: https://github.com/pycurl/pycurl
-.. _`mailing list`: http://cool.haxx.se/mailman/listinfo/curl-and-python
+.. _`mailing list`: https://lists.haxx.se/listinfo/curl-and-python
 .. _`downloads repository`: https://github.com/pycurl/downloads

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -118,7 +118,7 @@ certain you have found a bug in PycURL. If you do not have a patch to fix
 the bug, or at least a specific code fragment in PycURL that you believe is
 the cause, you should instead post your inquiry to the mailing list.
 
-.. _curl-and-python mailing list: http://cool.haxx.se/mailman/listinfo/curl-and-python
+.. _curl-and-python mailing list: https://lists.haxx.se/listinfo/curl-and-python
 .. _Stack Overflow: http://stackoverflow.com/questions/tagged/pycurl
 .. _Mailing list archives: https://curl.haxx.se/mail/list.cgi?list=curl-and-python
 .. _via GitHub: https://github.com/pycurl/pycurl/issues

--- a/setup.py
+++ b/setup.py
@@ -886,7 +886,7 @@ popular with some PycURL users.
 Bugs can be reported `via GitHub`_. Please use GitHub only for bug
 reports and direct questions to our mailing list instead.
 
-.. _curl-and-python mailing list: http://cool.haxx.se/mailman/listinfo/curl-and-python
+.. _curl-and-python mailing list: https://lists.haxx.se/listinfo/curl-and-python
 .. _Stack Overflow: http://stackoverflow.com/questions/tagged/pycurl
 .. _Mailing list archives: https://curl.haxx.se/mail/list.cgi?list=curl-and-python
 .. _via GitHub: https://github.com/pycurl/pycurl/issues


### PR DESCRIPTION
According to crt.sh, [cool.haxx.se](https://crt.sh/?q=cool.haxx.se) was retired around 2021-09-25
and [lists.haxx.se](https://crt.sh/?q=lists.haxx.se) replaced it around 2021-08-27 

This PR updates the URLs from cool.haxx.se and changes the scheme to https