### PR TITLE
Don't use `-flat_namespace` on macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -341,10 +341,6 @@ ignore this message.''')
         if not self.libraries:
             self.libraries.append("curl")
 
-        # Add extra compile flag for MacOS X
-        if sys.platform.startswith('darwin'):
-            self.extra_link_args.append("-flat_namespace")
-
         # Recognize --avoid-stdio on Unix so that it can be tested
         self.check_avoid_stdio()
 


### PR DESCRIPTION
To preface, in Homebrew, we are trying to build packages for macOS 15 Sequoia that use `pycurl` linked to brew `curl` and saw the wrong library (i.e. system `curl`) get picked up at runtime even though linkage is correct.

e.g. https://github.com/Homebrew/homebrew-core/actions/runs/10842043074/job/30087048897#step:4:77
```
  Traceback (most recent call last):
    File "/opt/homebrew/Cellar/fb-client/2.3.0_2/bin/fb", line 15, in <module>
      import pycurl
  ImportError: pycurl: libcurl link-time version (8.7.1) is older than compile-time version (8.10.0)
```
```
❯ otool -L /opt/homebrew/opt/fb-client/libexec/lib/python3.12/site-packages/pycurl.cpython-312-darwin.so
/opt/homebrew/opt/fb-client/libexec/lib/python3.12/site-packages/pycurl.cpython-312-darwin.so:
	/opt/homebrew/opt/openssl@3/lib/libssl.3.dylib (compatibility version 3.0.0, current version 3.0.0)
	/opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib (compatibility version 3.0.0, current version 3.0.0)
	/opt/homebrew/opt/curl/lib/libcurl.4.dylib (compatibility version 13.0.0, current version 13.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)
```

The same build process was working for macOS 14 Sonoma and older.

---

One thing I noticed was `pycurl` builds with `-flat_namespace` which usually isn't recommended anymore. Modern versions of macOS default to building binaries and libraries with a 2-level namespace.

Removing the `-flat_namespace` seems to work for me to find correct runtime `libcurl`.

Not sure if there was a specific use-case the flat namespace was added for. Seems to be from 2001: https://github.com/pycurl/pycurl/commit/7f98c034cbaa21fd781200354ba9b4efc6c0bb82

