### PR TITLE
Fix test_multi_socket_select

### DIFF
--- a/tests/multi_socket_select_test.py
+++ b/tests/multi_socket_select_test.py
@@ -88,6 +88,8 @@ class MultiSocketSelectTest(unittest.TestCase):
             pass
 
         timeout = m.timeout()
+        if timeout == -1:
+            timeout = 1000
 
         # timeout might be -1, indicating that all work is done
         # XXX make sure there is always work to be done here?


### PR DESCRIPTION
curl_multi_timeout can return -1 so we need to handle this case and use a default timeout.