### PR TITLE
Fix test_pause_* on OpenIndiana

### DIFF
--- a/tests/pause_test.py
+++ b/tests/pause_test.py
@@ -92,6 +92,6 @@ class PauseTest(unittest.TestCase):
         self.assertEqual('part1part2', sio.getvalue().decode())
         end = _time.time()
         # check that client side waited
-        self.assertTrue(end-start > 1)
+        self.assertTrue(end-start > 0.9)
 
         assert state['resumed']


### PR DESCRIPTION
It seems on this platform that SIGALRM fires after slightly less than one second, so adjust the test to ensure the wait was at least 900ms.

Fixes: #876.