### PR TITLE
AIX linker doesn't support -soname flag

### DIFF
--- a/tests/fake-curl/libcurl/Makefile
+++ b/tests/fake-curl/libcurl/Makefile
@@ -21,8 +21,15 @@ else
 endif
 
 .c.so:
+
+#AIX linker don't support -soname flag
+ifeq ($(UNAME),AIX)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -shared -fPIC \
+               -o $@ $<
+else
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -shared -fPIC \
 		-Wl,$(SONAME_FLAG),$@ -o $@ $<
+endif
 
 show-targets:
 	ls *c |sed -e 's/.c$$/.so/' | awk '{print $$1 " \\"}'


### PR DESCRIPTION
AIX Linker doesn't support "-soname" flag due to which we encounter below issue 

```make -C tests/fake-curl/libcurl
make[1]: Entering directory '/home/buildusr/rpmbuild/BUILD/pycurl-7.45.6/64bit/tests/fake-curl/libcurl'
`curl-config --cc` -maix64 `curl-config --cflags`   -shared -fPIC \
        -Wl,-soname,with_gnutls.so -o with_gnutls.so with_gnutls.c
collect2: fatal error: with_gnutls.so: cannot open as COFF file
compilation terminated.