### PR TITLE
tests: handle change in debug output in curl 8.16.0

### DIFF
--- a/tests/debug_test.py
+++ b/tests/debug_test.py
@@ -34,8 +34,10 @@ class DebugTest(unittest.TestCase):
         self.check(0, util.b('Trying'))
         if util.pycurl_version_less_than(7, 24):
             self.check(0, util.b('connected'))
-        else:
+        elif util.pycurl_version_less_than(8, 16):
             self.check(0, util.b('Connected to %s' % localhost))
+        else:
+            self.check(0, util.b('Established connection to %s' % localhost))
         self.check(0, util.b('port 8380'))
         # request
         self.check(2, util.b('GET /success HTTP/1.1'))


### PR DESCRIPTION
Debug message has changed and so the assert in the test is failing. Handle this by checking the version to pick the expected string to compare in the test.