### PR TITLE
CI: Fix Windows vcpkg install - schannel feature removed

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -58,7 +58,7 @@ jobs:
           setapikey "${{ secrets.GITHUB_TOKEN }}" \
           -source "https://nuget.pkg.github.com/${GITHUB_REPOSITORY_OWNER}/index.json"
     - name: Install packages
-      run: vcpkg install curl[brotli,core,http2,non-http,schannel,ssh]:${{ matrix.arch }}-windows
+      run: vcpkg install curl[brotli,core,http2,non-http,ssh,ssl]:${{ matrix.arch }}-windows
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Install packages (Windows)
         if: runner.os == 'Windows'
-        run: vcpkg install curl[brotli,core,http2,non-http,schannel,ssh]:${{ matrix.arch }}-windows
+        run: vcpkg install curl[brotli,core,http2,non-http,ssh,ssl]:${{ matrix.arch }}-windows
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel


### PR DESCRIPTION
It seems that schannel support should be enabled by default if http2 is selected, but request ssl feature anyway.