### PR TITLE
Skip Kerberos tests on libcurl >= 8.17.0

### DIFF
--- a/tests/option_constants_test.py
+++ b/tests/option_constants_test.py
@@ -502,12 +502,14 @@ class OptionConstantsTest(unittest.TestCase):
         curl.setopt(curl.SSL_SESSIONID_CACHE, True)
         curl.close()
 
+    @util.removed_in_libcurl(8, 17, 0)
     @util.only_gssapi
     def test_krblevel(self):
         curl = pycurl.Curl()
         curl.setopt(curl.KRBLEVEL, 'clear')
         curl.close()
 
+    @util.removed_in_libcurl(8, 17, 0)
     @util.only_gssapi
     def test_krb4level(self):
         curl = pycurl.Curl()


### PR DESCRIPTION
CURLOPT_KRBLEVEL and CURLOPT_KRB4LEVEL were removed in libcurl 8.17.0 and now return CURLE_NOT_BUILT_IN.

Failed build:
https://kojipkgs.fedoraproject.org//work/tasks/3657/138223657/build.log