### PR TITLE
Add headerpad_max_install_names to CFLAGS and LDFLAGS on macOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ repair-wheel-command = "DYLD_LIBRARY_PATH=$VCPKG_ROOT/installed/$VCPKG_TRIPLET/l
 [tool.cibuildwheel.macos.environment]
 PYCURL_CURL_CONFIG = "$VCPKG_ROOT/installed/$VCPKG_TRIPLET/tools/curl/bin/curl-config"
 PYCURL_SSL_LIBRARY = "openssl"
+LDFLAGS = "-headerpad_max_install_names"
 
 [[tool.cibuildwheel.overrides]]
 select = "cp*-macosx_x86_64"


### PR DESCRIPTION
This seems to be needed in order to build macOS wheels correctly.