### PR TITLE
Avoid circular strong references between Curl and CurlMulti

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ DOCSTRINGS_SOURCES = \
 	doc/docstrings/curl_errstr_raw.rst \
 	doc/docstrings/curl_getinfo.rst \
 	doc/docstrings/curl_getinfo_raw.rst \
+	doc/docstrings/curl_multi.rst \
 	doc/docstrings/curl_pause.rst \
 	doc/docstrings/curl_perform.rst \
 	doc/docstrings/curl_reset.rst \
@@ -67,6 +68,7 @@ DOCSTRINGS_SOURCES = \
 	doc/docstrings/multi_assign.rst \
 	doc/docstrings/multi_close.rst \
 	doc/docstrings/multi_closed.rst \
+	doc/docstrings/multi_contains.rst \
 	doc/docstrings/multi_fdset.rst \
 	doc/docstrings/multi_info_read.rst \
 	doc/docstrings/multi_perform.rst \

--- a/doc/docstrings/curl_multi.rst
+++ b/doc/docstrings/curl_multi.rst
@@ -1,0 +1,4 @@
+multi() -> CurlMulti | None
+
+Return the ``CurlMulti`` object this ``Curl`` handle currently belongs to,
+or ``None`` if it is not part of any ``CurlMulti``.

--- a/doc/docstrings/multi_contains.rst
+++ b/doc/docstrings/multi_contains.rst
@@ -1,0 +1,7 @@
+__contains__(Curl object) -> bool
+
+Implements the ``in`` operator for CurlMulti objects. This method returns
+``True`` if the given Curl object is currently added to the CurlMulti
+object, and ``False`` otherwise.
+
+Raises ``TypeError`` if the argument is not a Curl object.

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -427,6 +427,7 @@ typedef struct CurlObject {
 #ifdef WITH_THREAD
     PyThreadState *state;
 #endif
+    PyObject *multi_weakref;
     struct CurlMultiObject *multi_stack;
     struct CurlShareObject *share;
     struct CurlHttppostObject *httppost;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,45 @@
+import socket
+import pytest
+import time
+from typing import Generator
+
+from . import appmanager, localhost
+
+
+def _get_free_port() -> int:
+    with socket.socket() as s:
+        s.bind((localhost, 0))
+        return s.getsockname()[1]
+
+
+def wait_listening(host: str, port: int, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+
+    while time.monotonic() < deadline:
+        try:
+            socket.create_connection((host, port), timeout=0.2).close()
+            return
+        except OSError:
+            time.sleep(0.05)
+
+    raise RuntimeError(f"App did not start listening on {host}:{port}")
+
+
+@pytest.fixture
+def free_port() -> int:
+    return _get_free_port()
+
+
+@pytest.fixture(scope="module")
+def app(request) -> Generator[str, None, None]:
+    port = _get_free_port()
+    setup, teardown = appmanager.setup(
+        (
+            "app",
+            port,
+        )
+    )
+    setup(request.module)
+    wait_listening(localhost, port, timeout=10.0)
+    yield f"http://{localhost}:{port}"
+    teardown(request.module)

--- a/tests/multi_callback_test.py
+++ b/tests/multi_callback_test.py
@@ -191,6 +191,8 @@ class MultiCallbackTest(unittest.TestCase):
     def test_easy_close(self):
         self.partial_transfer()
         self.socket_result = None
+        assert self.easy.multi() == self.multi
         self.easy.close()
+        assert self.easy.multi() is None
         self._run_until(lambda: self.socket_result is not None, timeout=10.0)
         assert self.socket_result is not None

--- a/tests/test_memory_mgmt_close_matrix.py
+++ b/tests/test_memory_mgmt_close_matrix.py
@@ -1,0 +1,180 @@
+import gc
+import logging
+import weakref
+import pytest
+import pycurl
+
+from . import util
+
+logger = logging.getLogger(__name__)
+
+
+def gc_collect_hard(rounds: int = 3) -> None:
+    for _ in range(rounds):
+        gc.collect()
+
+
+class Tracker:
+    """
+    Tracks python object liveness via weakref + optional gc.get_objects scan.
+    """
+
+    def __init__(self) -> None:
+        self._items: list[tuple[str, weakref.ref, int]] = []
+
+    def track(self, name: str, obj):
+        r = weakref.ref(obj)
+        self._items.append((name, r, id(obj)))
+        return obj
+
+    def assert_all_gone(self, *, also_check_gc_objects: bool = True) -> None:
+        gc_collect_hard()
+
+        for name, r, obj_id in self._items:
+            assert r() is None, f"{name} still alive (id={obj_id})"
+
+        if also_check_gc_objects:
+            live_ids = {id(o) for o in gc.get_objects()}
+            for name, _, obj_id in self._items:
+                assert obj_id not in live_ids, (
+                    f"{name} id still present in gc.get_objects() (id={obj_id})"
+                )
+
+
+@pytest.fixture(autouse=True)
+def _gc_sanity():
+    gc.set_debug(0)
+    gc_collect_hard()
+    yield
+    gc.set_debug(0)
+    gc_collect_hard()
+
+
+@pytest.fixture
+def make_multi():
+    def _make(n=50, *, close_handles=False, url: str | None = None):
+        m = pycurl.CurlMulti(close_handles=close_handles)
+        easies = [util.DefaultCurl() for _ in range(n)]
+        for e in easies:
+            if url is not None:
+                e.setopt(pycurl.URL, url)
+                e.setopt(pycurl.CONNECTTIMEOUT, 5)
+            m.add_handle(e)
+        return m, easies
+
+    return _make
+
+
+def drive_multi_a_bit(multi: pycurl.CurlMulti, nb_handles: int) -> None:
+    _, active = multi.perform()
+    multi.select(0.25)
+    _, active = multi.perform()
+    assert 0 < active <= nb_handles
+    queued, ok_list, err_list = multi.info_read()
+    logger.info(
+        "drive_multi_a_bit: active=%d queued=%d ok=%d err=%d",
+        active,
+        queued,
+        len(ok_list),
+        len(err_list),
+    )
+    assert queued >= 0
+    assert len(ok_list) + len(err_list) <= nb_handles
+
+
+@pytest.mark.parametrize(
+    "order",
+    [
+        "remove_then_close_easy",
+        "close_easy_then_remove",
+        "close_multi_then_drop",
+        "del_multi_without_close",
+        "close_multi_with_close_handles",
+    ],
+)
+@pytest.mark.parametrize("phase", ["idle", "in_flight"])
+def test_close_matrix(app, make_multi, order, phase):
+    tr = Tracker()
+
+    url = f"{app}/long_pause"
+
+    logger.info("test_close_matrix: order=%s phase=%s url=%s", order, phase, url)
+
+    if order == "close_multi_with_close_handles":
+        multi, easies = make_multi(n=50, close_handles=True, url=url)
+    else:
+        multi, easies = make_multi(n=50, close_handles=False, url=url)
+
+    tr.track("multi", multi)
+    for i, e in enumerate(easies):
+        tr.track(f"easy[{i}]", e)
+
+    if phase == "in_flight":
+        drive_multi_a_bit(multi, len(easies))
+
+    if order == "remove_then_close_easy":
+        for e in easies:
+            multi.remove_handle(e)
+            e.close()
+
+    elif order == "close_easy_then_remove":
+        for e in easies:
+            e.close()
+            multi.remove_handle(e)
+
+    elif order == "close_multi_then_drop":
+        multi.close()
+
+    elif order == "del_multi_without_close":
+        pass
+
+    elif order == "close_multi_with_close_handles":
+        multi.close()
+
+    else:
+        raise AssertionError(f"unknown order: {order}")
+
+    e = None
+    del e
+    del easies
+    del multi
+
+    tr.assert_all_gone()
+
+
+def test_close_and_remove_one_easy_gone_others_not(make_multi):
+    multi, easies = make_multi(n=3, close_handles=False)
+
+    victim = easies[1]
+    survivors = [easies[0], easies[2]]
+
+    victim_ref = weakref.ref(victim)
+    survivor_refs = [weakref.ref(e) for e in survivors]
+
+    victim.close()
+
+    easies[1] = None
+    victim = None
+    gc_collect_hard()
+
+    assert victim_ref() is None, "victim easy still alive (likely leaked strong ref)"
+
+    for i, r in enumerate(survivor_refs):
+        obj = r()
+        assert obj is not None, f"survivor[{i}] unexpectedly collected"
+        assert obj.closed() is False, f"survivor[{i}] unexpectedly closed"
+
+    for e in survivors:
+        multi.remove_handle(e)
+        e.close()
+    multi.close()
+
+    e = None
+    obj = None
+    easies = None
+    survivors = None
+    multi = None
+    gc_collect_hard()
+
+    for i, r in enumerate(survivor_refs):
+        assert r() is None, f"survivor[{i}] still alive after cleanup"


### PR DESCRIPTION
This change improves lifetime and memory management between `Curl` and `CurlMulti` objects to prevent circular strong references and ensure predictable cleanup behavior:

- Avoid circular strong references by storing the `CurlMulti` reference in `Curl` as a weak reference.
- Move weakref cleanup to object deallocation instead of performing it during `Curl.close()`, aligning with Python weakref semantics and avoiding premature weakref invalidation.
- Ensure deterministic and safe cleanup order for `Curl` and `CurlMulti` objects, following libcurl’s expected lifecycle and preventing reference leaks or inconsistent states.