### PR TITLE
Review share API to avoid closing share handle if active easy handles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ DOCSTRINGS_SOURCES = \
 	doc/docstrings/curl_perform.rst \
 	doc/docstrings/curl_reset.rst \
 	doc/docstrings/curl_setopt.rst \
+	doc/docstrings/curl_share.rst \
 	doc/docstrings/curl_unsetopt.rst \
 	doc/docstrings/curl_set_ca_certs.rst \
 	doc/docstrings/multi.rst \
@@ -84,6 +85,7 @@ DOCSTRINGS_SOURCES = \
 	doc/docstrings/pycurl_version_info.rst \
 	doc/docstrings/share.rst \
 	doc/docstrings/share_close.rst \
+	doc/docstrings/share_closed.rst \
 	doc/docstrings/share_setopt.rst
 
 all: build

--- a/doc/docstrings/curl_share.rst
+++ b/doc/docstrings/curl_share.rst
@@ -1,0 +1,4 @@
+share() -> CurlShare | None
+
+Return the ``CurlShare`` object that this ``Curl`` handle is currently
+associated with, or ``None`` if it is not part of any ``CurlShare``.

--- a/doc/docstrings/share.rst
+++ b/doc/docstrings/share.rst
@@ -1,5 +1,42 @@
-CurlShare() -> New CurlShare object
+CurlShare(detach_on_close=True) -> New CurlShare object
 
 Creates a new :ref:`curlshareobject` which corresponds to a
 ``CURLSH`` handle in libcurl. CurlShare objects is what you pass as an
 argument to the SHARE option on :ref:`Curl objects <curlobject>`.
+
+The ``CurlShare`` object can be used as a context manager. Exiting the
+context calls ``close()``.
+
+When a ``CurlShare`` is closed, its behavior depends on the value of
+``detach_on_close``.
+
+Example::
+
+    with pycurl.CurlShare(detach_on_close=True) as s:
+        curl.setopt(pycurl.SHARE, s)
+        # perform operations
+    # the CurlShare is closed and the Curl object has been detached
+
+:param bool detach_on_close:
+    Controls how associated :ref:`Curl objects <curlobject>` are handled
+    when the ``CurlShare`` is closed.
+
+    If ``True`` (default), all live ``Curl`` objects associated with the
+    share are automatically detached when ``close()`` is called or when
+    exiting the context manager. Detaching clears the ``SHARE`` option on
+    each ``Curl`` object, but does **not** close them. The caller remains
+    responsible for managing the lifetime of the ``Curl`` objects.
+
+    If ``False``, calling ``close()`` (or exiting the context manager)
+    while there are still ``Curl`` objects associated with the share
+    raises an exception. In this mode, the caller must explicitly remove
+    or close all associated ``Curl`` objects before closing the
+    ``CurlShare``.
+
+.. warning::
+
+   Detaching ``Curl`` objects from a ``CurlShare`` is **not thread-safe**
+   with respect to those ``Curl`` objects.
+
+   The caller is responsible for ensuring proper synchronization when
+   using ``CurlShare`` and ``Curl`` objects across multiple threads.

--- a/doc/docstrings/share_close.rst
+++ b/doc/docstrings/share_close.rst
@@ -1,10 +1,30 @@
 close() -> None
+----------------
 
 Close shared handle.
 
 Corresponds to `curl_share_cleanup`_ in libcurl. This method is
-automatically called by pycurl when a CurlShare object no longer has
+automatically called by pycurl when a ``CurlShare`` object no longer has
 any references to it, but can also be called explicitly.
+
+The behavior of ``close()`` depends on the ``detach_on_close`` setting
+of the ``CurlShare``:
+
+- If ``detach_on_close`` is ``True`` (default), all associated
+  :ref:`Curl objects <curlobject>` are first detached from the share
+  before the share handle is closed. Detaching clears the ``SHARE``
+  option on each ``Curl`` object but does not close them.
+
+- If ``detach_on_close`` is ``False``, calling ``close()`` while there
+  are still associated ``Curl`` objects raises ``pycurl.error`` and the
+  share handle is not closed.
+
+.. warning::
+
+   Automatic detachment performed when ``detach_on_close`` is ``True``
+   is **not thread-safe** with respect to the associated ``Curl``
+   objects. The caller must ensure that no other thread is operating on
+   those ``Curl`` objects while ``close()`` is executing.
 
 .. _curl_share_cleanup:
     https://curl.haxx.se/libcurl/c/curl_share_cleanup.html

--- a/doc/docstrings/share_closed.rst
+++ b/doc/docstrings/share_closed.rst
@@ -1,0 +1,3 @@
+closed() -> bool
+
+Return ``True`` if the ``CurlShare`` object was already closed, ``False`` otherwise.

--- a/doc/thread-safety.rst
+++ b/doc/thread-safety.rst
@@ -21,6 +21,13 @@ For Python programs using PycURL, this means:
   Python code *outside of a libcurl callback for the PycURL object in question*
   is unsafe.
 
+* Closing a ``CurlShare`` object with ``detach_on_close=True`` (the
+  default) is **not thread-safe** with respect to the associated
+  ``Curl`` objects. During ``CurlShare.close()``, PycURL automatically
+  detaches all associated ``Curl`` objects by clearing their ``SHARE``
+  option. The caller must ensure that no other thread is using the
+  associated ``Curl`` objects while ``CurlShare.close()`` is executing.
+
 PycURL handles the necessary SSL locks for OpenSSL/LibreSSL/BoringSSL,
 GnuTLS, NSS, mbedTLS and wolfSSL.
 

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -513,7 +513,11 @@ typedef struct CurlShareObject {
     CURLSH *share_handle;
 #ifdef WITH_THREAD
     ShareLock *lock;                /* lock object to implement CURLSHOPT_LOCKFUNC */
+    PyThread_type_lock easy_weakrefs_lock;  /* protects easy_weakrefs map */
 #endif
+    /* Set of weakref.ref(CurlObject) */
+    PyObject *easy_weakrefs;
+    int detach_on_close; /* boolean: True by default */
 } CurlShareObject;
 
 #ifdef WITH_THREAD
@@ -665,6 +669,9 @@ PYCURL_INTERNAL int
 prereq_callback(void *clientp, char *conn_primary_ip, char *conn_local_ip,
                 int conn_primary_port, int conn_local_port);
 #endif
+
+PYCURL_INTERNAL int share_register_easy(struct CurlShareObject *share, struct CurlObject *easy);
+PYCURL_INTERNAL void share_unregister_easy(struct CurlShareObject *share, struct CurlObject *easy);
 
 #if !defined(PYCURL_SINGLE_FILE)
 /* Type objects */

--- a/src/share.c
+++ b/src/share.c
@@ -1,9 +1,82 @@
 #include "pycurl.h"
 #include "docstrings.h"
 
+#ifdef WITH_THREAD
+#  define EASY_WEAKREFS_LOCK(share)   PyThread_acquire_lock((share)->easy_weakrefs_lock, 1)
+#  define EASY_WEAKREFS_UNLOCK(share) PyThread_release_lock((share)->easy_weakrefs_lock)
+#else
+#  define EASY_WEAKREFS_LOCK(share)   ((void)0)
+#  define EASY_WEAKREFS_UNLOCK(share) ((void)0)
+#endif
+
 /*************************************************************************
 // static utility functions
 **************************************************************************/
+
+PYCURL_INTERNAL int
+share_register_easy(CurlShareObject *share, CurlObject *easy)
+{
+    PyObject *wr;
+
+    assert(share != NULL);
+    assert(easy != NULL);
+
+    wr = PyWeakref_NewRef((PyObject *)easy, NULL);
+    if (wr == NULL) {
+        return -1;
+    }
+
+    EASY_WEAKREFS_LOCK(share);
+
+    if (share->share_handle == NULL || share->easy_weakrefs == NULL) {
+        PyErr_SetString(PyExc_RuntimeError, "CurlShare is closed");
+        goto error;
+    }
+
+    if (PySet_Add(share->easy_weakrefs, wr) < 0) {
+        goto error;
+    }
+
+    EASY_WEAKREFS_UNLOCK(share);
+    Py_DECREF(wr);
+    return 0;
+
+error:
+    EASY_WEAKREFS_UNLOCK(share);
+    Py_DECREF(wr);
+    return -1;
+}
+
+
+PYCURL_INTERNAL void
+share_unregister_easy(CurlShareObject *share, CurlObject *easy)
+{
+    PyObject *wr;
+
+    assert(share != NULL);
+    assert(easy != NULL);
+
+    wr = PyWeakref_NewRef((PyObject *)easy, NULL);
+    if (wr == NULL) {
+        PyErr_Clear();
+        return;
+    }
+
+    EASY_WEAKREFS_LOCK(share);
+
+    if (share->easy_weakrefs == NULL) {
+        EASY_WEAKREFS_UNLOCK(share);
+        Py_DECREF(wr);
+        return;
+    }
+
+    if (PySet_Discard(share->easy_weakrefs, wr) < 0) {
+        PyErr_Clear();
+    }
+
+    EASY_WEAKREFS_UNLOCK(share);
+    Py_DECREF(wr);
+}
 
 
 /* assert some CurlShareObject invariants */
@@ -37,8 +110,9 @@ do_share_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
     const curl_unlock_function unlock_cb = share_unlock_callback;
 #endif
     int *ptr;
-    
-    if (subtype == p_CurlShare_Type && !PyArg_ParseTupleAndKeywords(args, kwds, "", empty_keywords)) {
+    static char *kwlist[] = {"detach_on_close", NULL};
+    int detach_on_close = 1;
+    if (subtype == p_CurlShare_Type && !PyArg_ParseTupleAndKeywords(args, kwds, "|$p", kwlist, &detach_on_close)) {
         return NULL;
     }
 
@@ -54,11 +128,27 @@ do_share_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
         ++ptr) {
             assert(*ptr == 0);
     }
-    
+
 #ifdef WITH_THREAD
     self->lock = share_lock_new();
     assert(self->lock != NULL);
+    self->easy_weakrefs_lock = PyThread_allocate_lock();
+    if (self->easy_weakrefs_lock == NULL) {
+        Py_DECREF(self);
+        PyErr_NoMemory();
+        return NULL;
+    }
 #endif
+
+    self->easy_weakrefs = PySet_New(NULL);
+    if (self->easy_weakrefs == NULL) {
+        Py_DECREF(self);
+#ifdef WITH_THREAD
+        PyThread_free_lock(self->easy_weakrefs_lock);
+        self->easy_weakrefs_lock = NULL;
+#endif
+        return NULL;
+    }
 
     /* Allocate libcurl share handle */
     self->share_handle = curl_share_init();
@@ -78,6 +168,7 @@ do_share_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
     assert(res == CURLE_OK);
 #endif
 
+    self->detach_on_close = detach_on_close ? 1 : 0;
     return self;
 }
 
@@ -90,9 +181,27 @@ do_share_traverse(CurlShareObject *self, visitproc visit, void *arg)
 #define VISIT(v)    if ((v) != NULL && ((err = visit(v, arg)) != 0)) return err
 
     VISIT(self->dict);
+    VISIT(self->easy_weakrefs);
 
     return 0;
 #undef VISIT
+}
+
+static void
+util_share_xdecref(CurlShareObject *self)
+{
+    Py_CLEAR(self->dict);
+    /*
+     * The lock can be NULL for partially-initialized objects or during
+     * early destruction paths; guard against acquiring an uninitialized lock.
+     */
+#ifdef WITH_THREAD
+    if (self->easy_weakrefs_lock) EASY_WEAKREFS_LOCK(self);
+#endif
+    Py_CLEAR(self->easy_weakrefs);
+#ifdef WITH_THREAD
+    if (self->easy_weakrefs_lock) EASY_WEAKREFS_UNLOCK(self);
+#endif
 }
 
 
@@ -100,7 +209,7 @@ do_share_traverse(CurlShareObject *self, visitproc visit, void *arg)
 PYCURL_INTERNAL int
 do_share_clear(CurlShareObject *self)
 {
-    Py_CLEAR(self->dict);
+    util_share_xdecref(self);
     return 0;
 }
 
@@ -121,30 +230,119 @@ do_share_dealloc(CurlShareObject *self)
     PyObject_GC_UnTrack(self);
     CPy_TRASHCAN_BEGIN(self, do_share_dealloc);
 
-    Py_CLEAR(self->dict);
+    util_share_xdecref(self);
     util_share_close(self);
 
 #ifdef WITH_THREAD
     share_lock_destroy(self->lock);
+    if (self->easy_weakrefs_lock) {
+        PyThread_free_lock(self->easy_weakrefs_lock);
+        self->easy_weakrefs_lock = NULL;
+    }
 #endif
 
     if (self->weakreflist != NULL) {
         PyObject_ClearWeakRefs((PyObject *) self);
     }
-     
+
     CurlShare_Type.tp_free(self);
     CPy_TRASHCAN_END(self);
+}
+
+static int
+share_cleanup_and_count_live_easies(CurlShareObject *self)
+{
+    int has_live = 0;
+
+    EASY_WEAKREFS_LOCK(self);
+
+    if (self->easy_weakrefs && PySet_Check(self->easy_weakrefs)) {
+        PyObject *it = PyObject_GetIter(self->easy_weakrefs);
+        PyObject *to_remove = PyList_New(0);
+
+        if (it && to_remove) {
+            PyObject *wr;
+
+            while ((wr = PyIter_Next(it))) {
+                PyObject *obj = PyWeakref_GetObject(wr);
+                if (obj != Py_None) {
+                    CurlObject *easy = (CurlObject *)obj;
+
+                    if (easy && easy->share == self) {
+                        if (self->detach_on_close) {
+                            curl_easy_setopt(easy->handle, CURLOPT_SHARE, NULL);
+                            easy->share = NULL;
+
+                            PyList_Append(to_remove, wr);
+                        } else {
+                            has_live += 1;
+                        }
+                    } else {
+                        PyList_Append(to_remove, wr);
+                    }
+                } else {
+                    PyList_Append(to_remove, wr);
+                }
+
+                Py_DECREF(wr);
+            }
+
+            Py_ssize_t i, n = PyList_GET_SIZE(to_remove);
+            for (i = 0; i < n; i++) {
+                PyObject *wr2 = PyList_GET_ITEM(to_remove, i);
+                PySet_Discard(self->easy_weakrefs, wr2);
+            }
+
+            Py_DECREF(it);
+            Py_DECREF(to_remove);
+
+            if (PyErr_Occurred()) {
+                PyErr_Clear();
+            }
+        } else {
+            Py_XDECREF(it);
+            Py_XDECREF(to_remove);
+            PyErr_Clear();
+        }
+    }
+
+    EASY_WEAKREFS_UNLOCK(self);
+    return has_live;
 }
 
 
 static PyObject *
 do_share_close(CurlShareObject *self, PyObject *Py_UNUSED(ignored))
 {
+    int nlive;
+
     if (check_share_state(self, 2, "close") != 0) {
         return NULL;
     }
+
+    nlive = share_cleanup_and_count_live_easies(self);
+    if (nlive > 0) {
+        PyErr_Format(
+            ErrorObject,
+            "cannot close CurlShare: still in use by %d active Curl object%s",
+            nlive,
+            (nlive == 1 ? "" : "s")
+        );
+        return NULL;
+    }
+
     util_share_close(self);
     Py_RETURN_NONE;
+}
+
+
+static PyObject *do_share_closed(CurlShareObject *self, PyObject *Py_UNUSED(ignored))
+{
+    if (self->share_handle == NULL) {
+        Py_RETURN_TRUE;
+    } else {
+        Py_RETURN_FALSE;
+    }
 }
 
 
@@ -152,7 +350,7 @@ do_share_close(CurlShareObject *self, PyObject *Py_UNUSED(ignored))
 /* --------------- unsetopt/setopt/getinfo --------------- */
 
 static PyObject *
-do_curlshare_setopt(CurlShareObject *self, PyObject *args)
+do_share_setopt(CurlShareObject *self, PyObject *args)
 {
     int option;
     PyObject *obj;
@@ -212,17 +410,23 @@ error:
 }
 
 
-static PyObject *do_curlshare_getstate(CurlShareObject *self, PyObject *Py_UNUSED(ignored))
+static PyObject *do_share_getstate(CurlShareObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyErr_SetString(PyExc_TypeError, "CurlShare objects do not support serialization");
     return NULL;
 }
 
 
-static PyObject *do_curlshare_setstate(CurlShareObject *self, PyObject *args)
+static PyObject *do_share_setstate(CurlShareObject *self, PyObject *args)
 {
     PyErr_SetString(PyExc_TypeError, "CurlShare objects do not support deserialization");
     return NULL;
+}
+
+static PyObject *do_share_enter(CurlShareObject *self, PyObject *Py_UNUSED(ignored))
+{
+    Py_INCREF(self);
+    return (PyObject *)self;
 }
 
 
@@ -234,9 +438,12 @@ static PyObject *do_curlshare_setstate(CurlShareObject *self, PyObject *args)
 
 PYCURL_INTERNAL PyMethodDef curlshareobject_methods[] = {
     {"close", (PyCFunction)do_share_close, METH_NOARGS, share_close_doc},
-    {"setopt", (PyCFunction)do_curlshare_setopt, METH_VARARGS, share_setopt_doc},
-    {"__getstate__", (PyCFunction)do_curlshare_getstate, METH_NOARGS, NULL},
-    {"__setstate__", (PyCFunction)do_curlshare_setstate, METH_VARARGS, NULL},
+    {"closed", (PyCFunction)do_share_closed, METH_NOARGS, share_closed_doc},
+    {"setopt", (PyCFunction)do_share_setopt, METH_VARARGS, share_setopt_doc},
+    {"__getstate__", (PyCFunction)do_share_getstate, METH_NOARGS, NULL},
+    {"__setstate__", (PyCFunction)do_share_setstate, METH_VARARGS, NULL},
+    {"__enter__", (PyCFunction)do_share_enter, METH_NOARGS, NULL},
+    {"__exit__", (PyCFunction)do_share_close, METH_VARARGS, NULL},
     {NULL, NULL, 0, 0}
 };
 

--- a/tests/share_test.py
+++ b/tests/share_test.py
@@ -2,23 +2,38 @@
 # -*- coding: utf-8 -*-
 # vi:ts=4:et
 
-from . import localhost
 import threading
 import pycurl
 import pytest
-import unittest
 
-from . import appmanager
 from . import util
 
-setup_module, teardown_module = appmanager.setup(('app', 8380))
+
+def set_share_defaults(s: pycurl.CurlShare):
+    s.setopt(pycurl.SH_SHARE, pycurl.LOCK_DATA_COOKIE)
+    s.setopt(pycurl.SH_SHARE, pycurl.LOCK_DATA_DNS)
+    s.setopt(pycurl.SH_SHARE, pycurl.LOCK_DATA_SSL_SESSION)
+
+
+@pytest.fixture
+def default_share() -> pycurl.CurlShare:
+    s = pycurl.CurlShare()
+    set_share_defaults(s)
+    return s
+
+
+@pytest.fixture
+def default_share_no_detach() -> pycurl.CurlShare:
+    s = pycurl.CurlShare(detach_on_close=False)
+    set_share_defaults(s)
+    return s
+
 
 class WorkerThread(threading.Thread):
-
-    def __init__(self, share):
+    def __init__(self, share: pycurl.CurlShare, url: str):
         threading.Thread.__init__(self)
         self.curl = util.DefaultCurl()
-        self.curl.setopt(pycurl.URL, 'http://%s:8380/success' % localhost)
+        self.curl.setopt(pycurl.URL, url + "/success")
         self.curl.setopt(pycurl.SHARE, share)
         self.sio = util.BytesIO()
         self.curl.setopt(pycurl.WRITEFUNCTION, self.sio.write)
@@ -27,42 +42,180 @@ class WorkerThread(threading.Thread):
         self.curl.perform()
         self.curl.close()
 
-class ShareTest(unittest.TestCase):
-    def test_share(self):
-        s = pycurl.CurlShare()
-        s.setopt(pycurl.SH_SHARE, pycurl.LOCK_DATA_COOKIE)
-        s.setopt(pycurl.SH_SHARE, pycurl.LOCK_DATA_DNS)
-        s.setopt(pycurl.SH_SHARE, pycurl.LOCK_DATA_SSL_SESSION)
 
-        t1 = WorkerThread(s)
-        t2 = WorkerThread(s)
+def test_share(app, default_share):
+    s = default_share
 
-        t1.start()
-        t2.start()
+    t1 = WorkerThread(s, url=app)
+    t2 = WorkerThread(s, url=app)
 
-        t1.join()
-        t2.join()
+    t1.start()
+    t2.start()
 
-        del s
+    t1.join()
+    t2.join()
 
-        self.assertEqual('success', t1.sio.getvalue().decode())
-        self.assertEqual('success', t2.sio.getvalue().decode())
+    del s
 
-    def test_share_close(self):
-        s = pycurl.CurlShare()
+    assert t1.sio.getvalue().decode() == "success"
+    assert t2.sio.getvalue().decode() == "success"
+
+
+def test_share_close():
+    s = pycurl.CurlShare()
+    assert not s.closed()
+    s.close()
+    assert s.closed()
+
+
+def test_share_close_twice():
+    s = pycurl.CurlShare()
+    assert not s.closed()
+    s.close()
+    assert s.closed()
+    s.close()
+    assert s.closed()
+
+
+# positional arguments are rejected
+def test_positional_arguments():
+    with pytest.raises(TypeError):
+        pycurl.CurlShare(1)
+
+
+# keyword arguments are rejected
+def test_keyword_arguments():
+    with pytest.raises(TypeError):
+        pycurl.CurlShare(a=1)
+
+
+def test_detach_on_close_keyword_argument_accepted():
+    s1 = pycurl.CurlShare(detach_on_close=True)
+    s2 = pycurl.CurlShare(detach_on_close=False)
+    assert not s1.closed()
+    assert not s2.closed()
+    s1.close()
+    s2.close()
+    assert s1.closed()
+    assert s2.closed()
+
+
+def test_easy_with_share_closed_before_perform(app, default_share):
+    s = default_share
+    n_easies = 10
+    easies = []
+    for _ in range(n_easies):
+        c = util.DefaultCurl()
+        c.setopt(pycurl.URL, app + "/success")
+        c.setopt(pycurl.SHARE, s)
+
+        sio = util.BytesIO()
+        c.setopt(pycurl.WRITEFUNCTION, sio.write)
+
+        easies.append((c, sio))
+
+    s.close()
+    assert s.closed()
+
+    for c, _ in easies:
+        assert c.share() is None
+        assert not c.closed()
+
+
+def test_easy_with_share_closed_before_perform_no_detach(app, default_share_no_detach):
+    s = default_share_no_detach
+    n_easies = 10
+    easies = []
+    for _ in range(n_easies):
+        c = util.DefaultCurl()
+        c.setopt(pycurl.URL, app + "/success")
+        c.setopt(pycurl.SHARE, s)
+
+        sio = util.BytesIO()
+        c.setopt(pycurl.WRITEFUNCTION, sio.write)
+
+        easies.append((c, sio))
+
+    with pytest.raises(pycurl.error):
         s.close()
+    assert not s.closed()
 
-    def test_share_close_twice(self):
-        s = pycurl.CurlShare()
-        s.close()
-        s.close()
+    for c, _ in easies:
+        assert c.share() == s
 
-    # positional arguments are rejected
-    def test_positional_arguments(self):
-        with pytest.raises(TypeError):
-            pycurl.CurlShare(1)
+    for c, sio in easies:
+        for _ in range(3):
+            sio.seek(0)
+            sio.truncate(0)
+            c.perform()
+            assert sio.getvalue().decode() == "success"
 
-    # keyword arguments are rejected
-    def test_keyword_arguments(self):
-        with pytest.raises(TypeError):
-            pycurl.CurlShare(a=1)
+    n = len(easies)
+    q1 = n // 4
+    q3 = (3 * n) // 4
+
+    for c, _ in easies[q1:q3]:
+        c.unsetopt(pycurl.SHARE)
+
+    for c, _ in easies[:q1] + easies[q3:]:
+        c.close()
+        assert c.closed()
+
+    s.close()
+    assert s.closed()
+
+
+def test_easy_set_share_closed_raises(app):
+    s = pycurl.CurlShare()
+    s.setopt(pycurl.SH_SHARE, pycurl.LOCK_DATA_COOKIE)
+    s.close()
+    assert s.closed()
+
+    c = util.DefaultCurl()
+    c.setopt(pycurl.URL, app + "/success")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        c.setopt(pycurl.SHARE, s)
+
+    assert "CurlShare is closed" == str(excinfo.value)
+
+
+def test_share_context_manager_detaches_by_default(app):
+    c = util.DefaultCurl()
+    c.setopt(pycurl.URL, app + "/success")
+    sio = util.BytesIO()
+    c.setopt(pycurl.WRITEFUNCTION, sio.write)
+
+    with pycurl.CurlShare() as s:
+        set_share_defaults(s)
+        c.setopt(pycurl.SHARE, s)
+        assert c.share() == s
+
+    assert s.closed()
+    assert c.share() is None
+
+    sio.seek(0)
+    sio.truncate(0)
+    c.perform()
+    assert sio.getvalue().decode() == "success"
+    c.close()
+
+
+def test_share_context_manager_strict_raises_if_live_easies(app):
+    c = util.DefaultCurl()
+    c.setopt(pycurl.URL, app + "/success")
+    sio = util.BytesIO()
+    c.setopt(pycurl.WRITEFUNCTION, sio.write)
+
+    with pytest.raises(pycurl.error):
+        with pycurl.CurlShare(detach_on_close=False) as s:
+            set_share_defaults(s)
+            c.setopt(pycurl.SHARE, s)
+            assert c.share() == s
+
+    assert not s.closed()
+    assert c.share() == s
+
+    c.unsetopt(pycurl.SHARE)
+    s.close()
+    c.close()

--- a/tests/test_memory_mgmt_close_matrix.py
+++ b/tests/test_memory_mgmt_close_matrix.py
@@ -9,6 +9,14 @@ from . import util
 logger = logging.getLogger(__name__)
 
 
+def default_share() -> pycurl.CurlShare:
+    s = pycurl.CurlShare(detach_on_close=False)
+    s.setopt(pycurl.SH_SHARE, pycurl.LOCK_DATA_COOKIE)
+    s.setopt(pycurl.SH_SHARE, pycurl.LOCK_DATA_DNS)
+    s.setopt(pycurl.SH_SHARE, pycurl.LOCK_DATA_SSL_SESSION)
+    return s
+
+
 def gc_collect_hard(rounds: int = 3) -> None:
     for _ in range(rounds):
         gc.collect()
@@ -65,6 +73,35 @@ def make_multi():
     return _make
 
 
+@pytest.fixture
+def make_share_easies():
+    def _make(
+        share: pycurl.CurlShare,
+        n: int = 25,
+        *,
+        url: str | None = None,
+        set_write: bool = True,
+    ):
+        easies: list[pycurl.Curl] = []
+        sios: list[util.BytesIO] = []
+
+        for _ in range(n):
+            c = util.DefaultCurl()
+            c.setopt(pycurl.SHARE, share)
+            if url is not None:
+                c.setopt(pycurl.URL, url)
+                c.setopt(pycurl.CONNECTTIMEOUT, 5)
+            if set_write:
+                sio = util.BytesIO()
+                c.setopt(pycurl.WRITEFUNCTION, sio.write)
+                sios.append(sio)
+            easies.append(c)
+
+        return easies, sios
+
+    return _make
+
+
 def drive_multi_a_bit(multi: pycurl.CurlMulti, nb_handles: int) -> None:
     _, active = multi.perform()
     multi.select(0.25)
@@ -82,6 +119,11 @@ def drive_multi_a_bit(multi: pycurl.CurlMulti, nb_handles: int) -> None:
     assert len(ok_list) + len(err_list) <= nb_handles
 
 
+def perform_all(easies: list[pycurl.Curl]) -> None:
+    for c in easies:
+        c.perform()
+
+
 @pytest.mark.parametrize(
     "order",
     [
@@ -93,7 +135,7 @@ def drive_multi_a_bit(multi: pycurl.CurlMulti, nb_handles: int) -> None:
     ],
 )
 @pytest.mark.parametrize("phase", ["idle", "in_flight"])
-def test_close_matrix(app, make_multi, order, phase):
+def test_multi_close_matrix(app, make_multi, order, phase):
     tr = Tracker()
 
     url = f"{app}/long_pause"
@@ -142,7 +184,7 @@ def test_close_matrix(app, make_multi, order, phase):
     tr.assert_all_gone()
 
 
-def test_close_and_remove_one_easy_gone_others_not(make_multi):
+def test_multi_close_and_remove_one_easy_gone_others_not(make_multi):
     multi, easies = make_multi(n=3, close_handles=False)
 
     victim = easies[1]
@@ -176,5 +218,160 @@ def test_close_and_remove_one_easy_gone_others_not(make_multi):
     multi = None
     gc_collect_hard()
 
+    for i, r in enumerate(survivor_refs):
+        assert r() is None, f"survivor[{i}] still alive after cleanup"
+
+
+@pytest.mark.parametrize(
+    "order",
+    [
+        # detach via easy close first, then close share
+        "close_easies_then_close_share",
+        # close share first, then close easies (should auto-detach)
+        "close_share_then_perform_then_close_easies",
+        # close share first, then just drop everything
+        "close_share_then_drop",
+        # detach explicitly (setopt SHARE=None), then close share
+        "unsetopt_share_then_close_share",
+        # drop share without close (exercise dealloc path)
+        "del_share_without_close",
+        # drop easies without close then close share (exercise GC finalizers)
+        "del_easies_then_close_share",
+    ],
+)
+def test_share_close_matrix(app, make_share_easies, order):
+    tr = Tracker()
+    s = default_share()
+    tr.track("share", s)
+
+    url = f"{app}/success"
+    easies, sios = make_share_easies(s, n=40, url=url)
+    for i, e in enumerate(easies):
+        tr.track(f"easy[{i}]", e)
+
+    e = None
+    del e
+
+    logger.info("test_share_close_matrix: order=%s n=%d", order, len(easies))
+
+    if order == "close_easies_then_close_share":
+        for e in easies:
+            e.close()
+            assert e.closed()
+        s.close()
+        assert s.closed()
+
+    elif order == "close_share_then_perform_then_close_easies":
+        with pytest.raises(pycurl.error):
+            s.close()
+        assert not s.closed()
+        for e in easies:
+            assert e.share() == s
+        perform_all(easies)
+        for e in easies:
+            e.close()
+            assert e.closed()
+
+        for sio in sios:
+            assert sio.getvalue().decode() == "success"
+
+    elif order == "close_share_then_drop":
+        with pytest.raises(pycurl.error):
+            s.close()
+        assert not s.closed()
+        for e in easies:
+            assert e.share() == s
+
+    elif order == "unsetopt_share_then_close_share":
+        for e in easies:
+            e.setopt(pycurl.SHARE, None)
+            assert e.share() is None
+        s.close()
+        assert s.closed()
+
+    elif order == "del_share_without_close":
+        pass
+
+    elif order == "del_easies_then_close_share":
+        for i in range(len(easies)):
+            easies[i] = None
+        gc_collect_hard()
+        s.close()
+
+    else:
+        raise AssertionError(f"unknown order: {order}")
+
+    e = None
+    del e
+    del sios
+    del easies
+    del s
+    gc_collect_hard()
+
+    tr.assert_all_gone()
+
+
+def test_share_close_detaches_and_easy_still_succeeds(app, make_share_easies):
+    s = default_share()
+    easies, sios = make_share_easies(s, n=20, url=f"{app}/success")
+
+    with pytest.raises(pycurl.error):
+        s.close()
+    assert not s.closed()
+
+    for e in easies:
+        assert e.share() == s
+
+    for e in easies:
+        e.unsetopt(pycurl.SHARE)
+        assert e.share() is None
+
+    perform_all(easies)
+
+    for e in easies:
+        e.close()
+
+    for sio in sios:
+        assert sio.getvalue().decode() == "success"
+
+
+def test_share_close_one_easy_does_not_keep_share_or_others_alive(
+    app, make_share_easies
+):
+    s = default_share()
+    easies, _sios = make_share_easies(s, n=3, url=f"{app}/success", set_write=False)
+
+    victim = easies[1]
+    survivors = [easies[0], easies[2]]
+
+    victim_ref = weakref.ref(victim)
+    survivor_refs = [weakref.ref(e) for e in survivors]
+    share_ref = weakref.ref(s)
+
+    victim.close()
+    easies[1] = None
+    victim = None
+    gc_collect_hard()
+
+    assert victim_ref() is None, "victim easy still alive (likely leaked strong ref)"
+
+    for i, r in enumerate(survivor_refs):
+        obj = r()
+        assert obj is not None, f"survivor[{i}] unexpectedly collected"
+        assert obj.closed() is False, f"survivor[{i}] unexpectedly closed"
+
+    for e in survivors:
+        e.close()
+    s.close()
+
+    e = None
+    r = None
+    obj = None
+    survivors = None
+    easies = None
+    s = None
+    gc_collect_hard()
+
+    assert share_ref() is None, "share still alive after cleanup"
     for i, r in enumerate(survivor_refs):
         assert r() is None, f"survivor[{i}] still alive after cleanup"


### PR DESCRIPTION
This PR improves CurlShare lifecycle:

- `CurlShare` now tracks associated `Curl` easy handles via weakrefs, and refuses to `close()` while there are active easies still using the share. This prevents cleaning up share resources that are still referenced by libcurl easy handles.
- Adds `Curl.share()` to retrieve the associated `CurlShare` (if any).
- Adds `CurlShare.closed()` to check whether the underlying share handle has been closed.
- Expands unit tests to cover the new behavior and regressions.


We have several options for the `CurlShare.close()` behavior. Due to the nature of the code, this operation is not thread-safe:

1. Allow `CurlShare.close()` to automatically unset the `SHARE` option on all associated `Curl` objects. This would require a clear disclaimer that `close()` must only be called when the `Curl` objects and the `CurlShare` instance live in the same thread.
2. Add an explicit option (e.g. `force`, `detach_easies_on_close`, or similar) either to the `CurlShare` constructor or/and to `close()`, which would optionally detach all associated easies before closing.
3. (current implementation): Do not allow closing a `CurlShare` while there are active `Curl` objects still associated with it.

The main advantage of options 1 and 2 is that they would allow implementing a proper context manager for `CurlShare`.