### PR TITLE
Enable callbacks during close()

### DIFF
--- a/src/easy.c
+++ b/src/easy.c
@@ -639,7 +639,6 @@ util_curl_close(CurlObject *self)
     assert(self != NULL);
     assert(PyObject_IsInstance((PyObject *) self, (PyObject *) p_Curl_Type) == 1);
     handle = self->handle;
-    self->handle = NULL;
     if (handle == NULL) {
         /* Some paranoia assertions just to make sure the object
          * deallocation problem is finally really fixed... */
@@ -664,9 +663,10 @@ util_curl_close(CurlObject *self)
     util_curl_xdecref(self, PYCURL_MEMGROUP_SHARE, handle);
 
     /* Cleanup curl handle - must be done without the gil */
-    Py_BEGIN_ALLOW_THREADS
+    PYCURL_BEGIN_ALLOW_THREADS
     curl_easy_cleanup(handle);
-    Py_END_ALLOW_THREADS
+    PYCURL_END_ALLOW_THREADS
+    self->handle = NULL;
     handle = NULL;
 
     /* Decref easy related objects */

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -300,7 +300,14 @@ PYCURL_INTERNAL void pycurl_ssl_cleanup(void);
 #  define PYCURL_END_ALLOW_THREADS
 #endif
 
+#if PY_VERSION_HEX < 0x030D0000  /* Python 3.13 */
+#  define Py_IsFinalizing _Py_IsFinalizing
+#endif
+
 #define PYCURL_BEGIN_CALLBACK_COMMON(acquire_expr, retval, callback_name) \
+    if (Py_IsFinalizing()) { \
+        return (retval); \
+    } \
     if (!(acquire_expr)) { \
         warn_failed_to_acquire_thread(#callback_name " failed to acquire thread"); \
         return (retval); \

--- a/tests/close_socket_cb_test.py
+++ b/tests/close_socket_cb_test.py
@@ -3,9 +3,11 @@
 # vi:ts=4:et
 
 from . import localhost
+import gc
 import socket
 import unittest
 import pycurl
+import pytest
 
 from . import util
 from . import appmanager
@@ -77,3 +79,59 @@ class CloseSocketCbUnsetTest(unittest.TestCase):
     @util.min_libcurl(7, 21, 7)
     def test_closesocketfunction_unset(self):
         self.curl.unsetopt(pycurl.CLOSESOCKETFUNCTION)
+
+# test_closesocketfunction_on_close leaves the server in a weird state, so use
+# one specific to this test, rather than the session one.
+@pytest.fixture
+def app():
+    from .conftest import make_app
+    yield from make_app()
+
+@util.min_libcurl(7, 21, 7)
+def test_closesocketfunction_on_close(app):
+    called = {}
+
+    def closesocketfunction(curlfd) -> int:
+        called["called"] = True
+        return 1
+
+    curl = util.DefaultCurl()
+    curl.setopt(curl.URL, f"{app}/success")
+    curl.setopt(pycurl.FORBID_REUSE, False)
+    curl.setopt(pycurl.CONNECT_ONLY, True)
+    curl.setopt(pycurl.CLOSESOCKETFUNCTION, closesocketfunction)
+
+    assert curl.getinfo(pycurl.ACTIVESOCKET) == -1
+
+    curl.perform()
+    assert curl.getinfo(pycurl.ACTIVESOCKET) != -1
+    assert not called.get("called", False)
+
+    curl.close()
+
+    assert called.get("called", False)
+
+@util.min_libcurl(7, 21, 7)
+def test_closesocketfunction_on_dealloc(app):
+    called = {}
+
+    def closesocketfunction(curlfd) -> int:
+        called["called"] = True
+        return 1
+
+    curl = util.DefaultCurl()
+    curl.setopt(curl.URL, f"{app}/success")
+    curl.setopt(pycurl.FORBID_REUSE, False)
+    curl.setopt(pycurl.CONNECT_ONLY, True)
+    curl.setopt(pycurl.CLOSESOCKETFUNCTION, closesocketfunction)
+
+    assert curl.getinfo(pycurl.ACTIVESOCKET) == -1
+
+    curl.perform()
+    assert curl.getinfo(pycurl.ACTIVESOCKET) != -1
+    assert not called.get("called", False)
+
+    del curl
+    gc.collect()
+
+    assert called.get("called", False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,9 +36,11 @@ def curl():
     yield c
     c.close()
 
-
 @pytest.fixture(scope="session")
 def app() -> Generator[str, None, None]:
+    yield from make_app()
+
+def make_app() -> Generator[str, None, None]:
     port = _get_free_port()
     setup, teardown = appmanager.setup(
         (


### PR DESCRIPTION
Callbacks can be invoked during curl_easy_cleanup() and curl_multi_remove_handle() so make this possible in pycurl.

Fixes: https://github.com/pycurl/pycurl/issues/748
Fixes: https://github.com/pycurl/pycurl/issues/865