### PR TITLE
Review GIL management

### DIFF
--- a/src/easycb.c
+++ b/src/easycb.c
@@ -6,7 +6,7 @@
  */
 
 #define PYCURL_BEGIN_CALLBACK(callback_name, retval) \
-    PYCURL_BEGIN_CALLBACK_COMMON(PYCURL_ACQUIRE_THREAD(), retval, callback_name)
+    PYCURL_BEGIN_CALLBACK_COMMON(PYCURL_GET_THREAD_STATE, retval, callback_name)
 
 PYCURL_INTERNAL int
 callback_return_value_to_int(PyObject *ret_obj, const char *callback_name, int *ret_out)

--- a/src/multi.c
+++ b/src/multi.c
@@ -2,7 +2,7 @@
 #include "docstrings.h"
 
 #define PYCURL_BEGIN_MULTI_CALLBACK(callback_name, retval) \
-    PYCURL_BEGIN_CALLBACK_COMMON(PYCURL_ACQUIRE_THREAD_MULTI(), retval, callback_name)
+    PYCURL_BEGIN_CALLBACK_COMMON(PYCURL_GET_THREAD_STATE_MULTI, retval, callback_name)
 
 /*************************************************************************
 // static utility functions
@@ -451,7 +451,8 @@ multi_notify_callback(CURLM *multi,
     if (Py_IsFinalizing()) {
         return;
     }
-    if (!PYCURL_ACQUIRE_THREAD_MULTI()) {
+    PYCURL_GET_THREAD_STATE_MULTI;
+    if (!PYCURL_PYTHON_ENTER()) {
         warn_failed_to_acquire_thread(
             "multi_notify_callback failed to acquire thread");
         return;
@@ -478,7 +479,7 @@ multi_notify_callback(CURLM *multi,
 
 done:
     Py_XDECREF(result);
-    PYCURL_RELEASE_THREAD();
+    PYCURL_PYTHON_LEAVE();
     return;
 
 verbose_error:

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -290,46 +290,53 @@ PYCURL_INTERNAL int pycurl_ssl_init(void);
 PYCURL_INTERNAL void pycurl_ssl_cleanup(void);
 #endif
 
-#  define PYCURL_DECLARE_THREAD_STATE PyThreadState *tmp_state
-#  define PYCURL_ACQUIRE_THREAD() pycurl_acquire_thread(self, &tmp_state)
-#  define PYCURL_ACQUIRE_THREAD_MULTI() pycurl_acquire_thread_multi(self, &tmp_state)
-#  define PYCURL_RELEASE_THREAD() pycurl_release_thread(tmp_state)
+#  define PYCURL_DECLARE_THREAD_STATE PyThreadState **tstate
+#  define PYCURL_GET_THREAD_STATE tstate = pycurl_get_thread_state_slot(self)
+#  define PYCURL_GET_THREAD_STATE_MULTI tstate = pycurl_get_thread_state_slot_multi(self)
+#  define PYCURL_PYTHON_ENTER() pycurl_python_enter(tstate)
+#  define PYCURL_PYTHON_LEAVE() pycurl_python_leave(tstate)
 #  define PYCURL_END_CALLBACK(retval) \
-       PYCURL_RELEASE_THREAD(); \
+       PYCURL_PYTHON_LEAVE(); \
        return (retval)
 /* Replacement for Py_BEGIN_ALLOW_THREADS/Py_END_ALLOW_THREADS when python
    callbacks are expected during blocking i/o operations: self->state will hold
    the handle to current thread to be used as context */
 #  define PYCURL_BEGIN_ALLOW_THREADS \
-       self->state = PyThreadState_Get(); \
-       assert(self->state != NULL); \
-       Py_BEGIN_ALLOW_THREADS
+       self->state = PyEval_SaveThread(); \
+       assert(self->state != NULL);
 #  define PYCURL_END_ALLOW_THREADS \
-       Py_END_ALLOW_THREADS \
+       assert(self->state != NULL); \
+       PyEval_RestoreThread(self->state); \
        self->state = NULL;
 #  define PYCURL_BEGIN_ALLOW_THREADS_EASY \
        if (self->multi_stack == NULL) { \
-           self->state = PyThreadState_Get(); \
+           self->state = PyEval_SaveThread(); \
            assert(self->state != NULL); \
        } else { \
-           self->multi_stack->state = PyThreadState_Get(); \
+           self->multi_stack->state = PyEval_SaveThread(); \
            assert(self->multi_stack->state != NULL); \
-       } \
-       Py_BEGIN_ALLOW_THREADS
+       }
 #  define PYCURL_END_ALLOW_THREADS_EASY \
-       PYCURL_END_ALLOW_THREADS \
-       if (self->multi_stack != NULL) \
-           self->multi_stack->state = NULL;
+       if (self->multi_stack == NULL) { \
+           assert(self->state != NULL); \
+           PyEval_RestoreThread(self->state); \
+           self->state = NULL; \
+       } else { \
+           assert(self->multi_stack->state != NULL); \
+           PyEval_RestoreThread(self->multi_stack->state); \
+           self->multi_stack->state = NULL; \
+       }
 
 #if PY_VERSION_HEX < 0x030D0000  /* Python 3.13 */
 #  define Py_IsFinalizing _Py_IsFinalizing
 #endif
 
-#define PYCURL_BEGIN_CALLBACK_COMMON(acquire_expr, retval, callback_name) \
+#define PYCURL_BEGIN_CALLBACK_COMMON(get_expr, retval, callback_name) \
     if (Py_IsFinalizing()) { \
         return (retval); \
     } \
-    if (!(acquire_expr)) { \
+    get_expr; \
+    if (!pycurl_python_enter(tstate)) { \
         warn_failed_to_acquire_thread(#callback_name " failed to acquire thread"); \
         return (retval); \
     }
@@ -591,14 +598,14 @@ curlmime_duphandle_incref_data_cb_owners(PyObject *mime_obj);
 
 PYCURL_INTERNAL PyThreadState *
 pycurl_get_thread_state(const CurlObject *self);
-PYCURL_INTERNAL PyThreadState *
-pycurl_get_thread_state_multi(const CurlMultiObject *self);
+PYCURL_INTERNAL PyThreadState **
+pycurl_get_thread_state_slot(CurlObject *self);
+PYCURL_INTERNAL PyThreadState **
+pycurl_get_thread_state_slot_multi(CurlMultiObject *self);
 PYCURL_INTERNAL int
-pycurl_acquire_thread(const CurlObject *self, PyThreadState **state);
-PYCURL_INTERNAL int
-pycurl_acquire_thread_multi(const CurlMultiObject *self, PyThreadState **state);
+pycurl_python_enter(PyThreadState **tstate);
 PYCURL_INTERNAL void
-pycurl_release_thread(PyThreadState *state);
+pycurl_python_leave(PyThreadState **tstate);
 
 PYCURL_INTERNAL void
 share_lock_lock(ShareLock *lock, curl_lock_data data);

--- a/src/threadsupport.c
+++ b/src/threadsupport.c
@@ -3,6 +3,18 @@
 PYCURL_INTERNAL PyThreadState *
 pycurl_get_thread_state(const CurlObject *self)
 {
+    PyThreadState **slot = pycurl_get_thread_state_slot((CurlObject *)self);
+    if (slot == NULL) {
+        return NULL;
+    } else {
+        return *slot;
+    }
+}
+
+
+PYCURL_INTERNAL PyThreadState **
+pycurl_get_thread_state_slot(CurlObject *self)
+{
     /* Get the thread state for callbacks to run in.
      * This is either `self->state' when running inside perform() or
      * `self->multi_stack->state' when running inside multi_perform().
@@ -19,7 +31,7 @@ pycurl_get_thread_state(const CurlObject *self)
         if (self->multi_stack != NULL) {
             assert(self->multi_stack->state == NULL);
         }
-        return self->state;
+        return &self->state;
     }
     if (self->multi_stack != NULL && self->multi_stack->state != NULL)
     {
@@ -27,14 +39,14 @@ pycurl_get_thread_state(const CurlObject *self)
         assert(self->handle != NULL);
         assert(self->multi_stack->multi_handle != NULL);
         assert(self->state == NULL);
-        return self->multi_stack->state;
+        return &self->multi_stack->state;
     }
     return NULL;
 }
 
 
-PYCURL_INTERNAL PyThreadState *
-pycurl_get_thread_state_multi(const CurlMultiObject *self)
+PYCURL_INTERNAL PyThreadState **
+pycurl_get_thread_state_slot_multi(CurlMultiObject *self)
 {
     /* Get the thread state for callbacks to run in when given
      * multi handles instead of regular handles
@@ -46,38 +58,39 @@ pycurl_get_thread_state_multi(const CurlMultiObject *self)
     {
         /* inside multi_perform() */
         assert(self->multi_handle != NULL);
-        return self->state;
+        return &self->state;
     }
     return NULL;
 }
 
 
 PYCURL_INTERNAL int
-pycurl_acquire_thread(const CurlObject *self, PyThreadState **state)
+pycurl_python_enter(PyThreadState **tstate)
 {
-    *state = pycurl_get_thread_state(self);
-    if (*state == NULL)
+    /* graceful skip if no perform is open on this handle */
+    if (tstate == NULL || *tstate == NULL) {
         return 0;
-    PyEval_AcquireThread(*state);
-    return 1;
-}
-
-
-PYCURL_INTERNAL int
-pycurl_acquire_thread_multi(const CurlMultiObject *self, PyThreadState **state)
-{
-    *state = pycurl_get_thread_state_multi(self);
-    if (*state == NULL)
-        return 0;
-    PyEval_AcquireThread(*state);
+    }
+    /* On 3.13+ PyEval_RestoreThread itself fatals if the calling thread
+       already has a state attached. On 3.10-3.12 there is no public
+       per-thread accessor we can check before take_gil(). */
+    PyEval_RestoreThread(*tstate);
     return 1;
 }
 
 
 PYCURL_INTERNAL void
-pycurl_release_thread(PyThreadState *state)
+pycurl_python_leave(PyThreadState **tstate)
 {
-    PyEval_ReleaseThread(state);
+    /* slot is set by PYCURL_BEGIN_ALLOW_THREADS_*; identity-check, then
+       detach without overwriting it */
+    if (tstate == NULL || *tstate == NULL) {
+        Py_FatalError("pycurl_python_leave: NULL thread state slot");
+    }
+    if (PyThreadState_Get() != *tstate) {
+        Py_FatalError("pycurl_python_leave: attached thread state differs from slot");
+    }
+    (void)PyEval_SaveThread();
 }
 
 /*************************************************************************


### PR DESCRIPTION
This PR introduces a refactor around GIL and thread-state handling:

- Unifies the API for releasing/acquiring the GIL using `PyEval_SaveThread()` and `PyEval_RestoreThread()` (the same primitives used by `Py_BEGIN_ALLOW_THREADS` / `Py_END_ALLOW_THREADS`), instead of mixing them with `PyEval_AcquireThread` and `PyEval_ReleaseThread`.
- Adds helper functions to retrieve the thread state associated with `Curl`/`CurlMulti` objects (i.e. multi state > easy state).
- Renames several defines to better reflect their actual functionality.