### PR TITLE
Track `CurlMulti` `assign()` objects

### DIFF
--- a/doc/docstrings/multi_assign.rst
+++ b/doc/docstrings/multi_assign.rst
@@ -3,5 +3,7 @@ assign(sock_fd, object) -> None
 Creates an association in the multi handle between the given socket and
 a private object in the application.
 Corresponds to `curl_multi_assign`_ in libcurl.
+If object is None, clears any association for the socket.
+The multi handle keeps a strong reference to the assigned object.
 
 .. _curl_multi_assign: https://curl.haxx.se/libcurl/c/curl_multi_assign.html

--- a/src/multi.c
+++ b/src/multi.c
@@ -110,6 +110,12 @@ do_multi_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
         return NULL;
     }
 
+    self->socket_object_dict = PyDict_New();
+    if (self->socket_object_dict == NULL) {
+        Py_DECREF(self);
+        return NULL;
+    }
+
     /* Allocate libcurl multi handle */
     self->multi_handle = curl_multi_init();
     if (self->multi_handle == NULL) {
@@ -148,6 +154,7 @@ util_multi_xdecref(CurlMultiObject *self)
     Py_CLEAR(self->dict);
     Py_CLEAR(self->t_cb);
     Py_CLEAR(self->s_cb);
+    Py_CLEAR(self->socket_object_dict);
 }
 
 
@@ -234,6 +241,9 @@ do_multi_close(CurlMultiObject *self, PyObject *Py_UNUSED(ignored))
     }
 
     util_multi_close(self);
+    if (self->socket_object_dict) {
+        PyDict_Clear(self->socket_object_dict);
+    }
     Py_RETURN_NONE;
 }
 
@@ -267,6 +277,7 @@ do_multi_traverse(CurlMultiObject *self, visitproc visit, void *arg)
 
     VISIT(self->dict);
     VISIT(self->easy_object_dict);
+    VISIT(self->socket_object_dict);
 
     return 0;
 #undef VISIT
@@ -635,6 +646,8 @@ do_multi_assign(CurlMultiObject *self, PyObject *args)
     curl_socket_t socket;
     PyObject *socket_obj;
     PyObject *obj;
+    int clear;
+    PyObject *old = NULL;
 
     if (!PyArg_ParseTuple(args, "OO:assign", &socket_obj, &obj)) {
         return NULL;
@@ -645,13 +658,41 @@ do_multi_assign(CurlMultiObject *self, PyObject *args)
     if (check_multi_state(self, 1 | 2, "assign") != 0) {
         return NULL;
     }
-    Py_INCREF(obj);
 
-    res = curl_multi_assign(self->multi_handle, socket, obj);
-    if (res != CURLM_OK) {
-        CURLERROR_MSG("assign failed");
+    clear = (obj == Py_None);
+    old = PyDict_GetItem(self->socket_object_dict, socket_obj);
+    Py_XINCREF(old);
+    /* First, update dict keeping previous value */
+    if (clear) {
+        if (old && PyDict_DelItem(self->socket_object_dict, socket_obj) < 0) {
+            Py_DECREF(old);
+            return NULL;
+        }
+    } else {
+        if (PyDict_SetItem(self->socket_object_dict, socket_obj, obj) < 0) {
+            Py_XDECREF(old);
+            return NULL;
+        }
     }
 
+    res = curl_multi_assign(self->multi_handle, socket, clear ? NULL : (void *)obj);
+    if (res != CURLM_OK) {
+        /* Restore previous value */
+        if (old) {
+            if (PyDict_SetItem(self->socket_object_dict, socket_obj, old) < 0) {
+                PyErr_Clear();
+            }
+            Py_DECREF(old);
+        } else if (!clear) {
+            if (PyDict_DelItem(self->socket_object_dict, socket_obj) < 0) {
+                PyErr_Clear();
+            }
+        }
+        CURLERROR_MSG("assign failed");
+        return NULL;
+    }
+
+    Py_XDECREF(old);
     Py_RETURN_NONE;
 }
 

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -503,6 +503,9 @@ typedef struct CurlMultiObject {
     PyObject *t_cb;
     PyObject *s_cb;
 
+    /* socket-to-object mappings for curl_multi_assign */
+    PyObject *socket_object_dict;
+
     PyObject *easy_object_dict;
     int close_handles; /* boolean: False by default */
 } CurlMultiObject;

--- a/tests/app.py
+++ b/tests/app.py
@@ -20,7 +20,10 @@ def ok():
 
 @app.route('/short_wait')
 def short_wait():
-    _time.sleep(0.1)
+    delay = flask.request.args.get('delay', default=0.1, type=float)
+    if delay < 0:
+        delay = 0.1
+    _time.sleep(delay)
     return 'success'
 
 @app.route('/status/403')

--- a/tests/multi_socket_test.py
+++ b/tests/multi_socket_test.py
@@ -2,94 +2,272 @@
 # -*- coding: utf-8 -*-
 # vi:ts=4:et
 
-from . import localhost
-import pycurl
-import unittest
+import gc
+import select
+import sys
+import time
+import weakref
 
-from . import appmanager
+import pycurl
+import pytest
+
 from . import util
 
-setup_module_1, teardown_module_1 = appmanager.setup(('app', 8380))
-setup_module_2, teardown_module_2 = appmanager.setup(('app', 8381))
-setup_module_3, teardown_module_3 = appmanager.setup(('app', 8382))
 
-def setup_module(mod):
-    setup_module_1(mod)
-    setup_module_2(mod)
-    setup_module_3(mod)
-
-def teardown_module(mod):
-    teardown_module_3(mod)
-    teardown_module_2(mod)
-    teardown_module_1(mod)
-
-class MultiSocketTest(unittest.TestCase):
-    def test_multi_socket(self):
-        urls = [
-            # not sure why requesting /success produces no events.
-            # see multi_socket_select_test.py for a longer explanation
-            # why short wait is used there.
-            'http://%s:8380/short_wait' % localhost,
-            'http://%s:8381/short_wait' % localhost,
-            'http://%s:8382/short_wait' % localhost,
-        ]
-
-        socket_events = []
-
-        # socket callback
-        def socket(event, socket, multi, data):
-            #print(event, socket, multi, data)
-            socket_events.append((event, multi))
-
-        # init
-        m = pycurl.CurlMulti()
-        m.setopt(pycurl.M_SOCKETFUNCTION, socket)
-        m.handles = []
-        for url in urls:
-            c = util.DefaultCurl()
-            # save info in standard Python attributes
-            c.url = url
-            c.body = util.BytesIO()
-            c.http_code = -1
-            m.handles.append(c)
-            # pycurl API calls
-            c.setopt(c.URL, c.url)
-            c.setopt(c.WRITEFUNCTION, c.body.write)
-            m.add_handle(c)
-
-        # get data
-        num_handles = len(m.handles)
-        while num_handles:
-            _, num_handles = m.socket_all()
-            # currently no more I/O is pending, could do something in the meantime
-            # (display a progress bar, etc.)
-            m.select(0.1)
-
-        for c in m.handles:
-            # save info in standard Python attributes
-            c.http_code = c.getinfo(c.HTTP_CODE)
-
-        # at least in and remove events per socket
-        assert len(socket_events) >= 6
-
-        # print result
-        for c in m.handles:
-            self.assertEqual('success', c.body.getvalue().decode())
-            self.assertEqual(200, c.http_code)
-
-            # multi, not curl handle
-            self.check(pycurl.POLL_IN, m, socket_events)
-            self.check(pycurl.POLL_REMOVE, m, socket_events)
-
-        # close handles
-        for c in m.handles:
-            # pycurl API calls
-            m.remove_handle(c)
-            c.close()
+@pytest.fixture
+def multi():
+    m = pycurl.CurlMulti()
+    try:
+        yield m
+    finally:
         m.close()
 
-    def check(self, event, multi, socket_events):
-        for event_, multi_ in socket_events:
-            if event == event_ and multi == multi_:
-                return
-        assert False, '%d %s not found in socket events' % (event, multi)
+
+def _setup_timer(multi):
+    timer_state = {"pending": False}
+
+    def timer(timeout_ms):
+        if timeout_ms == 0:
+            timer_state["pending"] = True
+
+    multi.setopt(pycurl.M_TIMERFUNCTION, timer)
+    return timer_state
+
+
+def _consume_timer(multi, timer_state):
+    if timer_state and timer_state["pending"]:
+        timer_state["pending"] = False
+        multi.socket_action(pycurl.SOCKET_TIMEOUT, 0)
+
+
+def _drive_multi(multi, timeout=0.2, timer_state=None):
+    _, running = multi.socket_action(pycurl.SOCKET_TIMEOUT, 0)
+
+    rset, wset, xset = multi.fdset()
+    if not (rset or wset or xset):
+        _consume_timer(multi, timer_state)
+        time.sleep(min(timeout, 0.01))
+        return running
+
+    r_ready, w_ready, x_ready = select.select(rset, wset, xset, timeout)
+    actions = {}
+    for s in r_ready:
+        actions[s] = actions.get(s, 0) | pycurl.CSELECT_IN
+    for s in w_ready:
+        actions[s] = actions.get(s, 0) | pycurl.CSELECT_OUT
+    for s in x_ready:
+        actions[s] = actions.get(s, 0) | pycurl.CSELECT_ERR
+
+    for s, act in actions.items():
+        _, running = multi.socket_action(s, act)
+
+    _consume_timer(multi, timer_state)
+    return running
+
+
+def _find_socket(multi, timeout=5.0, timer_state=None):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        multi.socket_action(pycurl.SOCKET_TIMEOUT, 0)
+        _consume_timer(multi, timer_state)
+        rset, wset, xset = multi.fdset()
+        if rset or wset or xset:
+            return (rset or wset or xset)[0]
+        time.sleep(0.01)
+    return None
+
+
+def _assert_socket_event(event, multi, socket_events):
+    for event_, multi_ in socket_events:
+        if event == event_ and multi == multi_:
+            return
+    assert False, "%d %s not found in socket events" % (event, multi)
+
+
+def _assert_within_deadline(deadline, label):
+    if time.monotonic() >= deadline:
+        pytest.fail(f"{label} timed out")
+
+
+def test_multi_socket(app, multi):
+    urls = [
+        # not sure why requesting /success produces no events.
+        # see multi_socket_select_test.py for a longer explanation
+        # why short wait is used there.
+        f"{app}/short_wait?delay=0.10",
+        f"{app}/short_wait?delay=0.11",
+        f"{app}/short_wait?delay=0.12",
+    ]
+
+    socket_events = []
+    timer_state = _setup_timer(multi)
+
+    # socket callback
+    def socket(event, socket, multi_handle, data):
+        # print(event, socket, multi_handle, data)
+        socket_events.append((event, multi_handle))
+
+    # init
+    multi.setopt(pycurl.M_SOCKETFUNCTION, socket)
+    handles = []
+    for url in urls:
+        c = util.DefaultCurl()
+        # save info in standard Python attributes
+        c.url = url
+        c.body = util.BytesIO()
+        c.http_code = -1
+        handles.append(c)
+        # pycurl API calls
+        c.setopt(c.URL, c.url)
+        c.setopt(c.WRITEFUNCTION, c.body.write)
+        multi.add_handle(c)
+
+    # get data
+    running = 1
+    deadline = time.monotonic() + 10.0
+    while running:
+        _assert_within_deadline(deadline, "multi socket transfer")
+        running = _drive_multi(multi, timeout=0.2, timer_state=timer_state)
+        # currently no more I/O is pending, could do something in the meantime
+        # (display a progress bar, etc.)
+        multi.select(0.1)
+
+    for c in handles:
+        # save info in standard Python attributes
+        c.http_code = c.getinfo(c.HTTP_CODE)
+
+    # at least in and remove events per socket
+    assert len(socket_events) >= 6
+
+    # print result
+    for c in handles:
+        assert "success" == c.body.getvalue().decode()
+        assert 200 == c.http_code
+
+        # multi, not curl handle
+        _assert_socket_event(pycurl.POLL_IN, multi, socket_events)
+        _assert_socket_event(pycurl.POLL_REMOVE, multi, socket_events)
+
+    # close handles
+    for c in handles:
+        # pycurl API calls
+        multi.remove_handle(c)
+        c.close()
+
+
+@pytest.mark.parametrize("reassign", [False, True])
+def test_multi_assign_objects(app, multi, reassign):
+    url = f"{app}/chunks?num_chunks=10&delay=0.1"
+
+    assigned = False
+    assigned_ref = None
+    first_ref = None
+    seen_data = None
+
+    class Sentinel:
+        pass
+
+    def socket(event, sock_fd, multi_handle, data):
+        nonlocal seen_data
+        if data is not None:
+            seen_data = data
+
+    timer_state = _setup_timer(multi)
+    multi.setopt(pycurl.M_SOCKETFUNCTION, socket)
+    c = util.DefaultCurl()
+    c.body = util.BytesIO()
+    c.setopt(c.URL, url)
+    c.setopt(c.WRITEFUNCTION, c.body.write)
+    multi.add_handle(c)
+
+    running = 1
+    deadline = time.monotonic() + 10.0
+    while running:
+        _assert_within_deadline(deadline, "multi assign objects transfer")
+        running = _drive_multi(multi, timeout=0.2, timer_state=timer_state)
+        if not assigned:
+            assigned_sock = _find_socket(multi, timeout=5.0, timer_state=timer_state)
+            assert assigned_sock is not None
+            first = Sentinel()
+            first_ref = weakref.ref(first)
+            rc_before = sys.getrefcount(first)
+            multi.assign(assigned_sock, first)
+            rc_after = sys.getrefcount(first)
+            assert rc_after >= rc_before + 1
+            if reassign:
+                second = Sentinel()
+                rc2_before = sys.getrefcount(second)
+                assigned_ref = weakref.ref(second)
+                multi.assign(assigned_sock, second)
+                rc2_after = sys.getrefcount(second)
+                assert rc2_after >= rc2_before + 1
+                del second
+            else:
+                assigned_ref = first_ref
+            assigned = True
+            del first
+        multi.select(0.1)
+
+    multi.remove_handle(c)
+    c.close()
+
+    assert assigned_ref is not None
+    assert first_ref is not None
+    gc.collect()
+    if reassign:
+        assert first_ref() is None
+    else:
+        assert first_ref() is assigned_ref()
+    assert assigned_ref() is not None
+    assert seen_data is assigned_ref()
+    seen_data = None
+    multi.close()
+    gc.collect()
+    assert first_ref() is None
+    assert assigned_ref() is None
+
+
+def test_multi_assign_none_clears(app, multi):
+    url = f"{app}/chunks?num_chunks=10&delay=0.1"
+
+    assigned_sock = None
+    assigned_ref = None
+
+    class Sentinel:
+        pass
+
+    def socket(event, sock_fd, multi_handle, data):
+        pass
+
+    timer_state = _setup_timer(multi)
+    multi.setopt(pycurl.M_SOCKETFUNCTION, socket)
+    c = util.DefaultCurl()
+    c.body = util.BytesIO()
+    c.setopt(c.URL, url)
+    c.setopt(c.WRITEFUNCTION, c.body.write)
+    multi.add_handle(c)
+
+    running = 1
+    deadline = time.monotonic() + 10.0
+    while running:
+        _assert_within_deadline(deadline, "multi assign none clears transfer")
+        running = _drive_multi(multi, timeout=0.2, timer_state=timer_state)
+        if assigned_sock is None:
+            assigned_sock = _find_socket(multi, timeout=5.0, timer_state=timer_state)
+            assert assigned_sock is not None
+            sentinel = Sentinel()
+            assigned_ref = weakref.ref(sentinel)
+            rc_before = sys.getrefcount(sentinel)
+            multi.assign(assigned_sock, sentinel)
+            rc_after = sys.getrefcount(sentinel)
+            assert rc_after >= rc_before + 1
+            multi.assign(assigned_sock, None)
+            del sentinel
+        multi.select(0.1)
+
+    multi.remove_handle(c)
+    c.close()
+
+    assert assigned_ref is not None
+    gc.collect()
+    assert assigned_ref() is None


### PR DESCRIPTION
- Added socket assignment tracking in `CurlMulti` to keep `assign()` objects alive and clear them on close.
- Modernized `multi_socket_test.py` to use pytest fixtures.
- Added tests to verify `assign()` retains objects and supports reassignment on the same socket.