### PR TITLE
Fix multi callback reference leak and missing GC traverse visits

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -275,6 +275,8 @@ do_multi_traverse(CurlMultiObject *self, visitproc visit, void *arg)
     VISIT(self->dict);
     VISIT(self->easy_object_dict);
     VISIT(self->socket_object_dict);
+    VISIT(self->t_cb);
+    VISIT(self->s_cb);
 
     return 0;
 #undef VISIT
@@ -512,12 +514,14 @@ do_multi_setopt_callable(CurlMultiObject *self, int option, PyObject *obj)
         curl_multi_setopt(self->multi_handle, CURLMOPT_SOCKETFUNCTION, s_cb);
         curl_multi_setopt(self->multi_handle, CURLMOPT_SOCKETDATA, self);
         Py_INCREF(obj);
+        Py_CLEAR(self->s_cb);
         self->s_cb = obj;
         break;
     case CURLMOPT_TIMERFUNCTION:
         curl_multi_setopt(self->multi_handle, CURLMOPT_TIMERFUNCTION, t_cb);
         curl_multi_setopt(self->multi_handle, CURLMOPT_TIMERDATA, self);
         Py_INCREF(obj);
+        Py_CLEAR(self->t_cb);
         self->t_cb = obj;
         break;
     default:

--- a/tests/multi_memory_mgmt_test.py
+++ b/tests/multi_memory_mgmt_test.py
@@ -11,14 +11,15 @@ from . import util
 
 debug = False
 
+
 @flaky.flaky(max_runs=3)
 class MultiMemoryMgmtTest(unittest.TestCase):
     def test_opensocketfunction_collection(self):
         self.check_callback(pycurl.M_SOCKETFUNCTION)
-    
+
     def test_seekfunction_collection(self):
         self.check_callback(pycurl.M_TIMERFUNCTION)
-    
+
     def check_callback(self, callback):
         # Note: extracting a context manager seems to result in
         # everything being garbage collected even if the C code
@@ -29,29 +30,59 @@ class MultiMemoryMgmtTest(unittest.TestCase):
         # settles tracked object count for the actual test below
         gc.collect()
         object_count = len(gc.get_objects())
-        
+
         c = pycurl.CurlMulti()
         c.setopt(callback, lambda x: True)
         del c
-        
+
         gc.collect()
         new_object_count = len(gc.get_objects())
         # it seems that GC sometimes collects something that existed
         # before this test ran, GH issues #273/#274
-        self.assertIn(new_object_count, (object_count, object_count-1))
+        self.assertIn(new_object_count, (object_count, object_count - 1))
+
+    def test_socketfunction_reassignment(self):
+        self.check_callback_reassignment(pycurl.M_SOCKETFUNCTION)
+
+    def test_timerfunction_reassignment(self):
+        self.check_callback_reassignment(pycurl.M_TIMERFUNCTION)
+
+    def check_callback_reassignment(self, callback):
+        """Setting a multi callback twice must not leak the old callback."""
+        import sys
+
+        def first_cb(x):
+            return True
+
+        m = pycurl.CurlMulti()
+        m.setopt(callback, first_cb)
+        refcount_before = sys.getrefcount(first_cb)
+
+        def second_cb(x):
+            return False
+
+        m.setopt(callback, second_cb)
+        refcount_after = sys.getrefcount(first_cb)
+
+        # After reassignment the old callback should have been released,
+        # so its refcount should have dropped by 1.
+        self.assertEqual(refcount_after, refcount_before - 1)
+
+        del m
+        gc.collect()
 
     def test_curl_ref(self):
         c = util.DefaultCurl()
         m = pycurl.CurlMulti()
-        
+
         ref = weakref.ref(c)
         m.add_handle(c)
         del c
-        
+
         assert ref()
         gc.collect()
         assert ref()
-        
+
         m.remove_handle(ref())
         gc.collect()
         assert ref() is None


### PR DESCRIPTION
 Fixes two reference counting bugs in CurlMultiObject