### PR TITLE
Remove dead `CPy_TRASHCAN` compatibility macros for Python < `3.8`

### DIFF
--- a/src/easy.c
+++ b/src/easy.c
@@ -656,7 +656,7 @@ PYCURL_INTERNAL void
 do_curl_dealloc(CurlObject *self)
 {
     PyObject_GC_UnTrack(self);
-    CPy_TRASHCAN_BEGIN(self, do_curl_dealloc);
+    Py_TRASHCAN_BEGIN(self, do_curl_dealloc);
 
     Py_CLEAR(self->dict);
     util_curl_close(self);
@@ -666,7 +666,7 @@ do_curl_dealloc(CurlObject *self)
     }
 
     Curl_Type.tp_free(self);
-    CPy_TRASHCAN_END(self);
+    Py_TRASHCAN_END;
 }
 
 

--- a/src/mime.c
+++ b/src/mime.c
@@ -99,10 +99,10 @@ static void
 curlmime_data_cb_owner_dealloc(CurlMimeDataCbOwner *self)
 {
     PyObject_GC_UnTrack(self);
-    CPy_TRASHCAN_BEGIN(self, curlmime_data_cb_owner_dealloc);
+    Py_TRASHCAN_BEGIN(self, curlmime_data_cb_owner_dealloc);
     curlmime_data_cb_owner_clear(self);
     Py_TYPE(self)->tp_free((PyObject *)self);
-    CPy_TRASHCAN_END(self);
+    Py_TRASHCAN_END;
 }
 
 static CurlMimeDataCbOwner *
@@ -688,10 +688,10 @@ static void
 do_curlmime_dealloc(CurlMimeObject *self)
 {
     PyObject_GC_UnTrack(self);
-    CPy_TRASHCAN_BEGIN(self, do_curlmime_dealloc);
+    Py_TRASHCAN_BEGIN(self, do_curlmime_dealloc);
     do_curlmime_clear(self);
     CurlMime_Type.tp_free(self);
-    CPy_TRASHCAN_END(self);
+    Py_TRASHCAN_END;
 }
 
 static PyObject *
@@ -1403,10 +1403,10 @@ static void
 do_curlmimepart_dealloc(CurlMimePartObject *self)
 {
     PyObject_GC_UnTrack(self);
-    CPy_TRASHCAN_BEGIN(self, do_curlmimepart_dealloc);
+    Py_TRASHCAN_BEGIN(self, do_curlmimepart_dealloc);
     do_curlmimepart_clear(self);
     CurlMimePart_Type.tp_free(self);
-    CPy_TRASHCAN_END(self);
+    Py_TRASHCAN_END;
 }
 
 static PyObject *

--- a/src/multi.c
+++ b/src/multi.c
@@ -210,7 +210,7 @@ PYCURL_INTERNAL void
 do_multi_dealloc(CurlMultiObject *self)
 {
     PyObject_GC_UnTrack(self);
-    CPy_TRASHCAN_BEGIN(self, do_multi_dealloc);
+    Py_TRASHCAN_BEGIN(self, do_multi_dealloc);
 
     util_multi_detach_easies(self, 0, 1);
 
@@ -222,7 +222,7 @@ do_multi_dealloc(CurlMultiObject *self)
     }
 
     CurlMulti_Type.tp_free(self);
-    CPy_TRASHCAN_END(self);
+    Py_TRASHCAN_END
 }
 
 

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -735,13 +735,6 @@ extern PyMethodDef curlmultiobject_methods[];
 
 #define PYCURL_TYPE_FLAGS Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE
 
-#if PY_MINOR_VERSION >= 8
-# define CPy_TRASHCAN_BEGIN(op, dealloc) Py_TRASHCAN_BEGIN(op, dealloc)
-# define CPy_TRASHCAN_END(op) Py_TRASHCAN_END
-#else
-# define CPy_TRASHCAN_BEGIN(op, dealloc) Py_TRASHCAN_SAFE_BEGIN(op)
-# define CPy_TRASHCAN_END(op) Py_TRASHCAN_SAFE_END(op)
-#endif
 
 #ifdef PYCURL_AUTODETECT_CA
 extern char *g_pycurl_autodetected_cainfo;

--- a/src/share.c
+++ b/src/share.c
@@ -211,7 +211,7 @@ PYCURL_INTERNAL void
 do_share_dealloc(CurlShareObject *self)
 {
     PyObject_GC_UnTrack(self);
-    CPy_TRASHCAN_BEGIN(self, do_share_dealloc);
+    Py_TRASHCAN_BEGIN(self, do_share_dealloc);
 
     util_share_xdecref(self);
     util_share_close(self);
@@ -229,7 +229,7 @@ do_share_dealloc(CurlShareObject *self)
     }
 
     CurlShare_Type.tp_free(self);
-    CPy_TRASHCAN_END(self);
+    Py_TRASHCAN_END
 }
 
 static int


### PR DESCRIPTION
Remove dead `CPy_TRASHCAN` compatibility macros for Python < `3.8`