### PR TITLE
Inline PyText_*/PyByteStr_* passthrough macros to direct Python C API calls

### DIFF
--- a/src/easycb.c
+++ b/src/easycb.c
@@ -568,7 +568,7 @@ read_callback(char *ptr, size_t size, size_t nmemb, void *stream)
         if (encoded == NULL) {
             goto verbose_error;
         }
-        r = PyByteStr_AsStringAndSize(encoded, &buf, &obj_size);
+        r = PyBytes_AsStringAndSize(encoded, &buf, &obj_size);
         if (r != 0 || obj_size < 0 || obj_size > total_size) {
             Py_DECREF(encoded);
             PyErr_Format(ErrorObject, "invalid return value for read callback (%ld bytes returned after encoding to utf-8 when at most %ld bytes were wanted)", (long)obj_size, (long)total_size);

--- a/src/easyinfo.c
+++ b/src/easyinfo.c
@@ -18,7 +18,7 @@ static PyObject *convert_slist(struct curl_slist *slist, int free_flags)
         if (slist->data == NULL) {
             v = Py_None; Py_INCREF(v);
         } else {
-            v = PyByteStr_FromString(slist->data);
+            v = PyBytes_FromString(slist->data);
         }
         if (v == NULL || PyList_Append(ret, v) != 0) {
             Py_XDECREF(v);
@@ -86,9 +86,9 @@ static PyObject *convert_certinfo(struct curl_certinfo *cinfo, int decode)
                 const char *sep = strchr(field, ':');
                 if (!sep) {
                     if (decode) {
-                        field_tuple = PyText_FromString(field);
+                        field_tuple = PyUnicode_FromString(field);
                     } else {
-                        field_tuple = PyByteStr_FromString(field);
+                        field_tuple = PyBytes_FromString(field);
                     }
                 } else {
                     /* XXX check */
@@ -196,7 +196,7 @@ do_curl_getinfo_raw(CurlObject *self, PyObject *args)
             if (s_res == NULL) {
                 Py_RETURN_NONE;
             }
-            return PyByteStr_FromString(s_res);
+            return PyBytes_FromString(s_res);
 
         }
 
@@ -429,7 +429,7 @@ do_curl_errstr(CurlObject *self, PyObject *Py_UNUSED(ignored))
     }
     self->error[sizeof(self->error) - 1] = 0;
 
-    return PyText_FromString(self->error);
+    return PyUnicode_FromString(self->error);
 }
 
 
@@ -441,5 +441,5 @@ do_curl_errstr_raw(CurlObject *self, PyObject *Py_UNUSED(ignored))
     }
     self->error[sizeof(self->error) - 1] = 0;
 
-    return PyByteStr_FromString(self->error);
+    return PyBytes_FromString(self->error);
 }

--- a/src/easyopt.c
+++ b/src/easyopt.c
@@ -26,7 +26,7 @@ pycurl_list_or_tuple_to_slist(int which, PyObject *obj, Py_ssize_t len)
             return NULL;
         }
         nlist = curl_slist_append(slist, str);
-        PyText_EncodedDecref(sencoded_obj);
+        Py_XDECREF(sencoded_obj);
         if (nlist == NULL || nlist->data == NULL) {
             curl_slist_free_all(slist);
             PyErr_NoMemory();
@@ -424,7 +424,7 @@ do_curl_setopt_string_impl(CurlObject *self, int option, PyObject *obj)
             res = curl_easy_setopt(self->handle, CURLOPT_POSTFIELDSIZE_LARGE, (curl_off_t)len);
         }
         if (res != CURLE_OK) {
-            PyText_EncodedDecref(encoded_obj);
+            Py_XDECREF(encoded_obj);
             CURLERROR_RETVAL();
         }
         break;
@@ -448,10 +448,10 @@ do_curl_setopt_string_impl(CurlObject *self, int option, PyObject *obj)
 
         res = curl_easy_setopt(self->handle, (CURLoption)option, &curlblob);
         if (res != CURLE_OK) {
-            PyText_EncodedDecref(encoded_obj);
+            Py_XDECREF(encoded_obj);
             CURLERROR_RETVAL();
         }
-        PyText_EncodedDecref(encoded_obj);
+        Py_XDECREF(encoded_obj);
         Py_RETURN_NONE;
         break;
 #endif
@@ -464,7 +464,7 @@ do_curl_setopt_string_impl(CurlObject *self, int option, PyObject *obj)
     res = curl_easy_setopt(self->handle, (CURLoption)option, str);
     /* Check for errors */
     if (res != CURLE_OK) {
-        PyText_EncodedDecref(encoded_obj);
+        Py_XDECREF(encoded_obj);
         CURLERROR_RETVAL();
     }
     /* libcurl does not copy the value of CURLOPT_POSTFIELDS */
@@ -486,7 +486,7 @@ do_curl_setopt_string_impl(CurlObject *self, int option, PyObject *obj)
         util_curl_xdecref(self, PYCURL_MEMGROUP_POSTFIELDS, self->handle);
         self->postfields_obj = store_obj;
     } else {
-        PyText_EncodedDecref(encoded_obj);
+        Py_XDECREF(encoded_obj);
     }
     Py_RETURN_NONE;
 }
@@ -574,7 +574,7 @@ do_curl_setopt_httppost(CurlObject *self, int option, int which, PyObject *obj)
             /* Handle strings as second argument for backwards compatibility */
 
             if (PyText_AsStringAndSize(httppost_option, &cstr, &clen, &cencoded_obj)) {
-                PyText_EncodedDecref(nencoded_obj);
+                Py_XDECREF(nencoded_obj);
                 create_and_set_error_object(self, CURLE_BAD_FUNCTION_ARGUMENT);
                 goto error;
             }
@@ -586,9 +586,9 @@ do_curl_setopt_httppost(CurlObject *self, int option, int which, PyObject *obj)
                                CURLFORM_COPYCONTENTS, cstr,
                                CURLFORM_CONTENTSLENGTH, (long) clen,
                                CURLFORM_END);
-            PyText_EncodedDecref(cencoded_obj);
+            Py_XDECREF(cencoded_obj);
             if (res != CURLE_OK) {
-                PyText_EncodedDecref(nencoded_obj);
+                Py_XDECREF(nencoded_obj);
                 CURLERROR_SET_RETVAL();
                 goto error;
             }
@@ -602,13 +602,13 @@ do_curl_setopt_httppost(CurlObject *self, int option, int which, PyObject *obj)
 
             /* Sanity check that there are at least two tuple items */
             if (tlen < 2) {
-                PyText_EncodedDecref(nencoded_obj);
+                Py_XDECREF(nencoded_obj);
                 PyErr_SetString(PyExc_TypeError, "list or tuple must contain at least one option and one value");
                 goto error;
             }
 
             if (tlen % 2 == 1) {
-                PyText_EncodedDecref(nencoded_obj);
+                Py_XDECREF(nencoded_obj);
                 PyErr_SetString(PyExc_TypeError, "list or tuple must contain an even number of items");
                 goto error;
             }
@@ -616,7 +616,7 @@ do_curl_setopt_httppost(CurlObject *self, int option, int which, PyObject *obj)
             /* Allocate enough space to accommodate length options for content or buffers, plus a terminator. */
             forms = PyMem_New(struct curl_forms, (tlen*2) + 1);
             if (forms == NULL) {
-                PyText_EncodedDecref(nencoded_obj);
+                Py_XDECREF(nencoded_obj);
                 PyErr_NoMemory();
                 goto error;
             }
@@ -630,19 +630,19 @@ do_curl_setopt_httppost(CurlObject *self, int option, int which, PyObject *obj)
                 if (j == (tlen-1)) {
                     PyErr_SetString(PyExc_TypeError, "expected value");
                     PyMem_Free(forms);
-                    PyText_EncodedDecref(nencoded_obj);
+                    Py_XDECREF(nencoded_obj);
                     goto error;
                 }
                 if (!PyLong_Check(PyListOrTuple_GetItem(httppost_option, j, which_httppost_option))) {
                     PyErr_SetString(PyExc_TypeError, "option must be an integer");
                     PyMem_Free(forms);
-                    PyText_EncodedDecref(nencoded_obj);
+                    Py_XDECREF(nencoded_obj);
                     goto error;
                 }
                 if (!PyText_Check(PyListOrTuple_GetItem(httppost_option, j+1, which_httppost_option))) {
                     PyErr_SetString(PyExc_TypeError, "value must be a byte string or a Unicode string with ASCII code points only");
                     PyMem_Free(forms);
-                    PyText_EncodedDecref(nencoded_obj);
+                    Py_XDECREF(nencoded_obj);
                     goto error;
                 }
 
@@ -656,14 +656,14 @@ do_curl_setopt_httppost(CurlObject *self, int option, int which, PyObject *obj)
                 {
                     PyErr_SetString(PyExc_TypeError, "unsupported option");
                     PyMem_Free(forms);
-                    PyText_EncodedDecref(nencoded_obj);
+                    Py_XDECREF(nencoded_obj);
                     goto error;
                 }
 
                 if (PyText_AsStringAndSize(PyListOrTuple_GetItem(httppost_option, j+1, which_httppost_option), &ostr, &olen, &oencoded_obj)) {
                     /* exception should be already set */
                     PyMem_Free(forms);
-                    PyText_EncodedDecref(nencoded_obj);
+                    Py_XDECREF(nencoded_obj);
                     goto error;
                 }
                 forms[k].option = val;
@@ -681,9 +681,9 @@ do_curl_setopt_httppost(CurlObject *self, int option, int which, PyObject *obj)
                     if (ref_params == NULL) {
                         ref_params = PyList_New((Py_ssize_t)0);
                         if (ref_params == NULL) {
-                            PyText_EncodedDecref(oencoded_obj);
+                            Py_XDECREF(oencoded_obj);
                             PyMem_Free(forms);
-                            PyText_EncodedDecref(nencoded_obj);
+                            Py_XDECREF(nencoded_obj);
                             goto error;
                         }
                     }
@@ -698,9 +698,9 @@ do_curl_setopt_httppost(CurlObject *self, int option, int which, PyObject *obj)
 
                     /* Ensure that the buffer remains alive until curl_easy_cleanup() */
                     if (PyList_Append(ref_params, obj) != 0) {
-                        PyText_EncodedDecref(oencoded_obj);
+                        Py_XDECREF(oencoded_obj);
                         PyMem_Free(forms);
-                        PyText_EncodedDecref(nencoded_obj);
+                        Py_XDECREF(nencoded_obj);
                         goto error;
                     }
 
@@ -716,20 +716,20 @@ do_curl_setopt_httppost(CurlObject *self, int option, int which, PyObject *obj)
                                CURLFORM_NAMELENGTH, (long) nlen,
                                CURLFORM_ARRAY, forms,
                                CURLFORM_END);
-            PyText_EncodedDecref(oencoded_obj);
+            Py_XDECREF(oencoded_obj);
             PyMem_Free(forms);
             if (res != CURLE_OK) {
-                PyText_EncodedDecref(nencoded_obj);
+                Py_XDECREF(nencoded_obj);
                 CURLERROR_SET_RETVAL();
                 goto error;
             }
         } else {
             /* Some other type was given, ignore */
-            PyText_EncodedDecref(nencoded_obj);
+            Py_XDECREF(nencoded_obj);
             PyErr_SetString(PyExc_TypeError, "unsupported second type in tuple");
             goto error;
         }
-        PyText_EncodedDecref(nencoded_obj);
+        Py_XDECREF(nencoded_obj);
     }
 #ifdef HAVE_CURL_MIME
     if (self->mimepost_obj != NULL) {

--- a/src/mime.c
+++ b/src/mime.c
@@ -312,7 +312,7 @@ curlmimepart_read_callback(char *ptr, size_t size, size_t nmemb, void *arg)
         if (encoded == NULL) {
             goto verbose_error;
         }
-        conv_res = PyByteStr_AsStringAndSize(encoded, &buf, &obj_size);
+        conv_res = PyBytes_AsStringAndSize(encoded, &buf, &obj_size);
         if (conv_res != 0 || obj_size < 0 || obj_size > total_size) {
             Py_DECREF(encoded);
             PyErr_Format(ErrorObject, "invalid return value for mime read callback (%ld bytes returned after ASCII encoding when at most %ld bytes were wanted)", (long)obj_size, (long)total_size);
@@ -508,7 +508,7 @@ curlmime_headers_to_slist(PyObject *obj)
         }
 
         next = curl_slist_append(slist, header);
-        PyText_EncodedDecref(encoded_obj);
+        Py_XDECREF(encoded_obj);
         if (next == NULL) {
             curl_slist_free_all(slist);
             PyErr_NoMemory();
@@ -801,7 +801,7 @@ curlmimepart_data_as_string_or_buffer(PyObject *arg,
         return 0;
     }
 
-    if (PyByteStr_Check(arg) || PyUnicode_Check(arg)) {
+    if (PyBytes_Check(arg) || PyUnicode_Check(arg)) {
         return PyText_AsStringAndSize(arg, data, data_len, encoded_obj);
     }
 
@@ -826,7 +826,7 @@ curlmime_validate_text_arg(PyObject *obj, const char *name)
     }
 
     value = PyText_AsString_NoNUL(obj, &encoded_obj);
-    PyText_EncodedDecref(encoded_obj);
+    Py_XDECREF(encoded_obj);
     if (value == NULL) {
         return -1;
     }
@@ -856,7 +856,7 @@ curlmime_validate_data_arg(PyObject *obj)
     if (view_active) {
         PyBuffer_Release(&view);
     }
-    PyText_EncodedDecref(encoded_obj);
+    Py_XDECREF(encoded_obj);
 
     return 0;
 }
@@ -882,7 +882,7 @@ curlmime_validate_file_arg(CurlMimeObject *self, PyObject *obj, const char *name
     }
 
     fp = fopen(path, "rb");
-    PyText_EncodedDecref(encoded_obj);
+    Py_XDECREF(encoded_obj);
     if (fp == NULL) {
         curlmime_set_error(self != NULL ? self->curl : NULL, CURLE_READ_ERROR);
         return -1;
@@ -1169,7 +1169,7 @@ do_curlmime_add_multipart(CurlMimeObject *self, PyObject *args, PyObject *kwds)
     }
 
     if (subtype_obj == NULL) {
-        subtype_ref = PyText_FromString("mixed");
+        subtype_ref = PyUnicode_FromString("mixed");
         if (subtype_ref == NULL) {
             return NULL;
         }
@@ -1183,8 +1183,8 @@ do_curlmime_add_multipart(CurlMimeObject *self, PyObject *args, PyObject *kwds)
             goto error;
         }
 
-        content_type_obj = PyText_FromFormat("multipart/%s", subtype);
-        PyText_EncodedDecref(encoded_obj);
+        content_type_obj = PyUnicode_FromFormat("multipart/%s", subtype);
+        Py_XDECREF(encoded_obj);
         encoded_obj = NULL;
         if (content_type_obj == NULL) {
             goto error;
@@ -1230,7 +1230,7 @@ do_curlmime_add_multipart(CurlMimeObject *self, PyObject *args, PyObject *kwds)
 
 error:
     Py_XDECREF(rv);
-    PyText_EncodedDecref(encoded_obj);
+    Py_XDECREF(encoded_obj);
     Py_XDECREF(content_type_obj);
     Py_XDECREF(subtype_ref);
     Py_XDECREF(child_obj);
@@ -1426,7 +1426,7 @@ do_curlmimepart_name(CurlMimePartObject *self, PyObject *arg)
     }
 
     res = (int)curl_mime_name(self->part, name);
-    PyText_EncodedDecref(encoded_obj);
+    Py_XDECREF(encoded_obj);
     if (res != CURLE_OK) {
         curlmime_set_error(self->mime != NULL ? self->mime->curl : NULL, res);
         return NULL;
@@ -1459,7 +1459,7 @@ do_curlmimepart_data(CurlMimePartObject *self, PyObject *arg)
     if (view_active) {
         PyBuffer_Release(&view);
     }
-    PyText_EncodedDecref(encoded_obj);
+    Py_XDECREF(encoded_obj);
     if (res != CURLE_OK) {
         curlmime_set_error(self->mime != NULL ? self->mime->curl : NULL, res);
         return NULL;
@@ -1607,7 +1607,7 @@ do_curlmimepart_filedata(CurlMimePartObject *self, PyObject *arg)
     }
 
     res = (int)curl_mime_filedata(self->part, path);
-    PyText_EncodedDecref(encoded_obj);
+    Py_XDECREF(encoded_obj);
     if (res != CURLE_OK) {
         curlmime_set_error(self->mime != NULL ? self->mime->curl : NULL, res);
         return NULL;
@@ -1636,7 +1636,7 @@ do_curlmimepart_filename(CurlMimePartObject *self, PyObject *arg)
     }
 
     res = (int)curl_mime_filename(self->part, name);
-    PyText_EncodedDecref(encoded_obj);
+    Py_XDECREF(encoded_obj);
     if (res != CURLE_OK) {
         curlmime_set_error(self->mime != NULL ? self->mime->curl : NULL, res);
         return NULL;
@@ -1662,7 +1662,7 @@ do_curlmimepart_type(CurlMimePartObject *self, PyObject *arg)
     }
 
     res = (int)curl_mime_type(self->part, type);
-    PyText_EncodedDecref(encoded_obj);
+    Py_XDECREF(encoded_obj);
     if (res != CURLE_OK) {
         curlmime_set_error(self->mime != NULL ? self->mime->curl : NULL, res);
         return NULL;
@@ -1688,7 +1688,7 @@ do_curlmimepart_encoder(CurlMimePartObject *self, PyObject *arg)
     }
 
     res = (int)curl_mime_encoder(self->part, encoding);
-    PyText_EncodedDecref(encoded_obj);
+    Py_XDECREF(encoded_obj);
     if (res != CURLE_OK) {
         curlmime_set_error(self->mime != NULL ? self->mime->curl : NULL, res);
         return NULL;

--- a/src/module.c
+++ b/src/module.c
@@ -109,7 +109,7 @@ static PyObject *vi_str(const char *s)
         Py_RETURN_NONE;
     while (*s == ' ' || *s == '\t')
         s++;
-    return PyText_FromString(s);
+    return PyUnicode_FromString(s);
 }
 
 PYCURL_INTERNAL PyObject *
@@ -188,7 +188,7 @@ insobj2(PyObject *dict1, PyObject *dict2, char *name, PyObject *value)
     if (value == NULL)
         goto error;
 
-    key = PyText_FromString(name);
+    key = PyUnicode_FromString(name);
 
     if (key == NULL)
         goto error;
@@ -227,7 +227,7 @@ insstr(PyObject *d, char *name, char *value)
     PyObject *v;
     int rv;
 
-    v = PyText_FromString(value);
+    v = PyUnicode_FromString(value);
     if (v == NULL)
         return -1;
 

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -320,15 +320,8 @@ PYCURL_INTERNAL PyObject *
 PyListOrTuple_GetItem(PyObject *v, Py_ssize_t i, int which);
 
 /*************************************************************************
-// string compatibility macros
+// string helpers
 **************************************************************************/
-
-#define PyText_FromFormat(format, str) PyUnicode_FromFormat((format), (str))
-#define PyText_FromString(str) PyUnicode_FromString(str)
-#define PyByteStr_FromString(str) PyBytes_FromString(str)
-#define PyByteStr_Check(obj) PyBytes_Check(obj)
-#define PyByteStr_AsStringAndSize(obj, buffer, length) PyBytes_AsStringAndSize((obj), (buffer), (length))
-#define PyText_EncodedDecref(encoded) Py_XDECREF(encoded)
 
 PYCURL_INTERNAL int
 PyText_AsStringAndSize(PyObject *obj, char **buffer, Py_ssize_t *length, PyObject **encoded_obj);

--- a/src/stringcompat.c
+++ b/src/stringcompat.c
@@ -7,9 +7,9 @@
 PYCURL_INTERNAL int
 PyText_AsStringAndSize(PyObject *obj, char **buffer, Py_ssize_t *length, PyObject **encoded_obj)
 {
-    if (PyByteStr_Check(obj)) {
+    if (PyBytes_Check(obj)) {
         *encoded_obj = NULL;
-        return PyByteStr_AsStringAndSize(obj, buffer, length);
+        return PyBytes_AsStringAndSize(obj, buffer, length);
     } else {
         int rv;
         assert(PyUnicode_Check(obj));
@@ -17,7 +17,7 @@ PyText_AsStringAndSize(PyObject *obj, char **buffer, Py_ssize_t *length, PyObjec
         if (*encoded_obj == NULL) {
             return -1;
         }
-        rv = PyByteStr_AsStringAndSize(*encoded_obj, buffer, length);
+        rv = PyBytes_AsStringAndSize(*encoded_obj, buffer, length);
         if (rv != 0) {
             /* If we free the object, pointer must be reset to NULL */
             Py_CLEAR(*encoded_obj);


### PR DESCRIPTION
Replaced passthrough macros (`PyText_FromFormat`, `PyText_FromString`, `PyByteStr_FromString`, `PyByteStr_Check`, `PyByteStr_AsStringAndSize`, `PyText_EncodedDecref`) with direct C API calls