### PR TITLE
Fix `Curl.reset()` on closed handle and alloc-failure paths

### DIFF
--- a/src/easy.c
+++ b/src/easy.c
@@ -6,16 +6,17 @@
 // CurlSlistObject
 **************************************************************************/
 
-PYCURL_INTERNAL void
+PYCURL_INTERNAL int
 util_curlslist_update(CurlSlistObject **old, struct curl_slist *slist)
 {
-    /* Decref previous object */
+    CurlSlistObject *new_obj = PyObject_New(CurlSlistObject, p_CurlSlist_Type);
+    if (new_obj == NULL) {
+        return -1;
+    }
+    new_obj->slist = slist;
     Py_XDECREF(*old);
-    /* Create a new object */
-    *old = PyObject_New(CurlSlistObject, p_CurlSlist_Type);
-    assert(*old != NULL);
-    /* Store curl_slist into the new object */
-    (*old)->slist = slist;
+    *old = new_obj;
+    return 0;
 }
 
 PYCURL_INTERNAL void
@@ -86,17 +87,18 @@ PYCURL_INTERNAL PyTypeObject CurlSlist_Type = {
 // CurlHttppostObject
 **************************************************************************/
 
-PYCURL_INTERNAL void
+PYCURL_INTERNAL int
 util_curlhttppost_update(CurlObject *obj, struct curl_httppost *httppost, PyObject *reflist)
 {
-    /* Decref previous object */
+    CurlHttppostObject *new_obj = PyObject_New(CurlHttppostObject, p_CurlHttppost_Type);
+    if (new_obj == NULL) {
+        return -1;
+    }
+    new_obj->httppost = httppost;
+    new_obj->reflist = reflist;
     Py_XDECREF(obj->httppost);
-    /* Create a new object */
-    obj->httppost = PyObject_New(CurlHttppostObject, p_CurlHttppost_Type);
-    assert(obj->httppost != NULL);
-    /* Store curl_httppost and reflist into the new object */
-    obj->httppost->httppost = httppost;
-    obj->httppost->reflist = reflist;
+    obj->httppost = new_obj;
+    return 0;
 }
 
 PYCURL_INTERNAL void
@@ -779,6 +781,10 @@ do_curl_reset(CurlObject *self, PyObject *Py_UNUSED(ignored))
 {
     int res;
 
+    if (check_curl_state(self, 1 | 2, "reset") != 0) {
+        return NULL;
+    }
+
     curl_easy_reset(self->handle);
 
     /* Decref easy interface related objects */
@@ -786,7 +792,10 @@ do_curl_reset(CurlObject *self, PyObject *Py_UNUSED(ignored))
 
     res = util_curl_init(self);
     if (res < 0) {
-        Py_DECREF(self);    /* this also closes self->handle */
+        /* util_curl_init failed to re-set the default options; the libcurl
+         * handle is in an inconsistent state. Close it so subsequent calls
+         * fail predictably instead of crashing on NULL derefs inside libcurl. */
+        util_curl_close(self);
         PyErr_SetString(ErrorObject, "resetting curl failed");
         return NULL;
     }

--- a/src/easyinfo.c
+++ b/src/easyinfo.c
@@ -91,11 +91,11 @@ static PyObject *convert_certinfo(struct curl_certinfo *cinfo, int decode)
                         field_tuple = PyBytes_FromString(field);
                     }
                 } else {
-                    /* XXX check */
+                    Py_ssize_t name_len = sep - field;
                     if (decode) {
-                        field_tuple = Py_BuildValue("s#s", field, (int)(sep - field), sep+1);
+                        field_tuple = Py_BuildValue("s#s", field, name_len, sep+1);
                     } else {
-                        field_tuple = Py_BuildValue("y#y", field, (int)(sep - field), sep+1);
+                        field_tuple = Py_BuildValue("y#y", field, name_len, sep+1);
                     }
                 }
                 if (!field_tuple)

--- a/src/easyopt.c
+++ b/src/easyopt.c
@@ -757,7 +757,10 @@ do_curl_setopt_httppost(CurlObject *self, int option, int which, PyObject *obj)
      */
     util_curl_xdecref(self, PYCURL_MEMGROUP_MIMEPOST, NULL);
 #endif
-    util_curlhttppost_update(self, post, ref_params);
+    if (util_curlhttppost_update(self, post, ref_params) != 0) {
+        (void)curl_easy_setopt(self->handle, CURLOPT_HTTPPOST, NULL);
+        goto error;
+    }
 
     Py_RETURN_NONE;
 
@@ -841,7 +844,11 @@ do_curl_setopt_list(CurlObject *self, int option, int which, PyObject *obj)
     }
     /* Finally, decref previous slist object and replace it with a
      * new one. */
-    util_curlslist_update(old_slist_obj, slist);
+    if (util_curlslist_update(old_slist_obj, slist) != 0) {
+        (void)curl_easy_setopt(self->handle, (CURLoption)option, NULL);
+        curl_slist_free_all(slist);
+        return NULL;
+    }
 
     Py_RETURN_NONE;
 }

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -623,9 +623,9 @@ util_curl_xdecref(CurlObject *self, int flags, CURL *handle);
 PYCURL_INTERNAL PyObject *
 do_curl_setopt_filelike(CurlObject *self, int option, PyObject *obj);
 
-PYCURL_INTERNAL void
+PYCURL_INTERNAL int
 util_curlslist_update(CurlSlistObject **old, struct curl_slist *slist);
-PYCURL_INTERNAL void
+PYCURL_INTERNAL int
 util_curlhttppost_update(CurlObject *obj, struct curl_httppost *httppost, PyObject *reflist);
 
 PYCURL_INTERNAL PyObject *

--- a/tests/reset_test.py
+++ b/tests/reset_test.py
@@ -1,79 +1,27 @@
-#! /usr/bin/env python
-# vi:ts=4:et
-
-from . import localhost
-import pycurl
-import unittest
 from io import BytesIO
 
-from . import appmanager
-from . import util
+import pycurl
+import pytest
 
-setup_module, teardown_module = appmanager.setup(('app', 8380))
 
-class ResetTest(unittest.TestCase):
-    def test_reset(self):
-        c = util.DefaultCurl()
-        c.setopt(pycurl.USERAGENT, 'Phony/42')
-        c.setopt(pycurl.URL, 'http://%s:8380/header?h=user-agent' % localhost)
-        sio = BytesIO()
-        c.setopt(pycurl.WRITEFUNCTION, sio.write)
-        c.perform()
-        user_agent = sio.getvalue().decode()
-        assert user_agent == 'Phony/42'
+def test_reset_preserves_default_useragent(app, curl):
+    curl.setopt(pycurl.USERAGENT, "Phony/42")
+    curl.setopt(pycurl.URL, f"{app}/header?h=user-agent")
+    sio = BytesIO()
+    curl.setopt(pycurl.WRITEFUNCTION, sio.write)
+    curl.perform()
+    assert sio.getvalue().decode() == "Phony/42"
 
+    curl.reset()
+    curl.setopt(pycurl.URL, f"{app}/header?h=user-agent")
+    sio = BytesIO()
+    curl.setopt(pycurl.WRITEFUNCTION, sio.write)
+    curl.perform()
+    assert sio.getvalue().decode().startswith("PycURL")
+
+
+def test_reset_after_close_raises():
+    c = pycurl.Curl()
+    c.close()
+    with pytest.raises(pycurl.error):
         c.reset()
-        c.setopt(pycurl.URL, 'http://%s:8380/header?h=user-agent' % localhost)
-        sio = BytesIO()
-        c.setopt(pycurl.WRITEFUNCTION, sio.write)
-        c.perform()
-        user_agent = sio.getvalue().decode()
-        # we also check that the request succeeded after curl
-        # object has been reset
-        assert user_agent.startswith('PycURL')
-
-    # XXX this test was broken when it was test_reset.py
-    def skip_reset_with_multi(self):
-        outf = BytesIO()
-        cm = pycurl.CurlMulti()
-
-        eh = util.DefaultCurl()
-
-        for x in range(1, 20):
-            eh.setopt(pycurl.WRITEFUNCTION, outf.write)
-            eh.setopt(pycurl.URL, 'http://%s:8380/success' % localhost)
-            cm.add_handle(eh)
-
-            _, active_handles = cm.perform()
-
-            while active_handles:
-                ret = cm.select(1.0)
-                if ret == -1:
-                    continue
-                _, active_handles = cm.perform()
-
-            count, good, bad = cm.info_read()
-
-            for h, en, em in bad:
-                print("Transfer to %s failed with %d, %s\n" % \
-                    (h.getinfo(pycurl.EFFECTIVE_URL), en, em))
-                raise RuntimeError
-
-            for h in good:
-                httpcode = h.getinfo(pycurl.RESPONSE_CODE)
-                if httpcode != 200:
-                    print("Transfer to %s failed with code %d\n" %\
-                        (h.getinfo(pycurl.EFFECTIVE_URL), httpcode))
-                    raise RuntimeError
-
-                else:
-                    print("Recd %d bytes from %s" % \
-                        (h.getinfo(pycurl.SIZE_DOWNLOAD),
-                        h.getinfo(pycurl.EFFECTIVE_URL)))
-
-            cm.remove_handle(eh)
-            eh.reset()
-
-        eh.close()
-        cm.close()
-        outf.close()

--- a/tests/setopt_test.py
+++ b/tests/setopt_test.py
@@ -1,137 +1,154 @@
-#! /usr/bin/env python
-# vi:ts=4:et
-
-from . import localhost
-import pycurl
-import pytest
-import unittest
+import sys
 from io import BytesIO
 
-from . import appmanager
+import pycurl
+import pytest
+
 from . import util
 
-setup_module, teardown_module = appmanager.setup(('app', 8380))
 
-class SetoptTest(unittest.TestCase):
-    def setUp(self):
-        self.curl = util.DefaultCurl()
+def test_boolean_value(curl):
+    curl.setopt(pycurl.VERBOSE, True)
 
-    def tearDown(self):
-        self.curl.close()
 
-    def test_boolean_value(self):
-        # expect no exceptions raised
-        self.curl.setopt(pycurl.VERBOSE, True)
+def test_integer_value(curl):
+    curl.setopt(pycurl.VERBOSE, 1)
 
-    def test_integer_value(self):
-        # expect no exceptions raised
-        self.curl.setopt(pycurl.VERBOSE, 1)
 
-    def test_string_value_for_integer_option(self):
-        with pytest.raises(TypeError):
-            self.curl.setopt(pycurl.VERBOSE, "Hello, world!")
+def test_string_value_for_integer_option(curl):
+    with pytest.raises(TypeError):
+        curl.setopt(pycurl.VERBOSE, "Hello, world!")
 
-    def test_string_value(self):
-        # expect no exceptions raised
-        self.curl.setopt(pycurl.URL, 'http://hello.world')
 
-    def test_integer_value_for_string_option(self):
-        with pytest.raises(TypeError):
-            self.curl.setopt(pycurl.URL, 1)
+def test_string_value(curl):
+    curl.setopt(pycurl.URL, "http://hello.world")
 
-    def test_float_value_for_integer_option(self):
-        with pytest.raises(TypeError):
-            self.curl.setopt(pycurl.VERBOSE, 1.0)
 
-    def test_httpheader_list(self):
-        self.curl.setopt(self.curl.HTTPHEADER, ['Accept:'])
+def test_integer_value_for_string_option(curl):
+    with pytest.raises(TypeError):
+        curl.setopt(pycurl.URL, 1)
 
-    def test_httpheader_tuple(self):
-        self.curl.setopt(self.curl.HTTPHEADER, ('Accept:',))
 
-    def test_httpheader_unicode(self):
-        self.curl.setopt(self.curl.HTTPHEADER, (util.u('Accept:'),))
+def test_float_value_for_integer_option(curl):
+    with pytest.raises(TypeError):
+        curl.setopt(pycurl.VERBOSE, 1.0)
 
-    def test_unset_httpheader(self):
-        self.curl.setopt(self.curl.HTTPHEADER, ('x-test: foo',))
-        self.curl.setopt(self.curl.URL, 'http://%s:8380/header?h=x-test' % localhost)
-        io = BytesIO()
-        self.curl.setopt(self.curl.WRITEDATA, io)
-        self.curl.perform()
-        self.assertEqual(util.b('foo'), io.getvalue())
 
-        self.curl.unsetopt(self.curl.HTTPHEADER)
-        io = BytesIO()
-        self.curl.setopt(self.curl.WRITEDATA, io)
-        self.curl.perform()
-        self.assertEqual(util.b(''), io.getvalue())
+def test_httpheader_list(curl):
+    curl.setopt(pycurl.HTTPHEADER, ["Accept:"])
 
-    def test_set_httpheader_none(self):
-        self.curl.setopt(self.curl.HTTPHEADER, ('x-test: foo',))
-        self.curl.setopt(self.curl.URL, 'http://%s:8380/header?h=x-test' % localhost)
-        io = BytesIO()
-        self.curl.setopt(self.curl.WRITEDATA, io)
-        self.curl.perform()
-        self.assertEqual(util.b('foo'), io.getvalue())
 
-        self.curl.setopt(self.curl.HTTPHEADER, None)
-        io = BytesIO()
-        self.curl.setopt(self.curl.WRITEDATA, io)
-        self.curl.perform()
-        self.assertEqual(util.b(''), io.getvalue())
+def test_httpheader_tuple(curl):
+    curl.setopt(pycurl.HTTPHEADER, ("Accept:",))
 
-    @util.min_libcurl(7, 37, 0)
-    def test_proxyheader_list(self):
-        self.curl.setopt(self.curl.PROXYHEADER, ['Accept:'])
 
-    @util.min_libcurl(7, 37, 0)
-    def test_proxyheader_tuple(self):
-        self.curl.setopt(self.curl.PROXYHEADER, ('Accept:',))
+def test_httpheader_unicode(curl):
+    curl.setopt(pycurl.HTTPHEADER, ("Accept:",))
 
-    @util.min_libcurl(7, 37, 0)
-    def test_proxyheader_unicode(self):
-        self.curl.setopt(self.curl.PROXYHEADER, (util.u('Accept:'),))
 
-    @util.min_libcurl(7, 37, 0)
-    def test_unset_proxyheader(self):
-        self.curl.unsetopt(self.curl.PROXYHEADER)
+def _header_echo_url(app):
+    return f"{app}/header?h=x-test"
 
-    @util.min_libcurl(7, 37, 0)
-    def test_set_proxyheader_none(self):
-        self.curl.setopt(self.curl.PROXYHEADER, None)
 
-    def test_unset_encoding(self):
-        self.curl.unsetopt(self.curl.ENCODING)
+def test_unset_httpheader(app, curl):
+    curl.setopt(pycurl.HTTPHEADER, ("x-test: foo",))
+    curl.setopt(pycurl.URL, _header_echo_url(app))
+    io = BytesIO()
+    curl.setopt(pycurl.WRITEDATA, io)
+    curl.perform()
+    assert io.getvalue() == b"foo"
 
-    # github issue #405
-    def test_large_options(self):
-        self.curl.setopt(self.curl.INFILESIZE, 3333858173)
-        self.curl.setopt(self.curl.MAX_RECV_SPEED_LARGE, 3333858173)
-        self.curl.setopt(self.curl.MAX_SEND_SPEED_LARGE, 3333858173)
-        self.curl.setopt(self.curl.MAXFILESIZE, 3333858173)
-        self.curl.setopt(self.curl.POSTFIELDSIZE, 3333858173)
-        self.curl.setopt(self.curl.RESUME_FROM, 3333858173)
+    curl.unsetopt(pycurl.HTTPHEADER)
+    io = BytesIO()
+    curl.setopt(pycurl.WRITEDATA, io)
+    curl.perform()
+    assert io.getvalue() == b""
 
-    def test_set_writefunction_none(self):
-        self.curl.setopt(self.curl.WRITEFUNCTION, None)
 
-    def test_set_headerfunction_none(self):
-        self.curl.setopt(self.curl.HEADERFUNCTION, None)
+def test_set_httpheader_none(app, curl):
+    curl.setopt(pycurl.HTTPHEADER, ("x-test: foo",))
+    curl.setopt(pycurl.URL, _header_echo_url(app))
+    io = BytesIO()
+    curl.setopt(pycurl.WRITEDATA, io)
+    curl.perform()
+    assert io.getvalue() == b"foo"
 
-    def test_set_readfunction_none(self):
-        self.curl.setopt(self.curl.READFUNCTION, None)
+    curl.setopt(pycurl.HTTPHEADER, None)
+    io = BytesIO()
+    curl.setopt(pycurl.WRITEDATA, io)
+    curl.perform()
+    assert io.getvalue() == b""
 
-    def test_set_progressfunction_none(self):
-        self.curl.setopt(self.curl.PROGRESSFUNCTION, None)
 
-    def test_set_xferinfofunction_none(self):
-        self.curl.setopt(self.curl.XFERINFOFUNCTION, None)
+@util.min_libcurl(7, 37, 0)
+def test_proxyheader_list(curl):
+    curl.setopt(pycurl.PROXYHEADER, ["Accept:"])
 
-    def test_set_debugfunction_none(self):
-        self.curl.setopt(self.curl.DEBUGFUNCTION, None)
 
-    def test_set_ioctlfunction_none(self):
-        self.curl.setopt(self.curl.IOCTLFUNCTION, None)
+@util.min_libcurl(7, 37, 0)
+def test_proxyheader_tuple(curl):
+    curl.setopt(pycurl.PROXYHEADER, ("Accept:",))
 
-    def test_set_seekfunction_none(self):
-        self.curl.setopt(self.curl.SEEKFUNCTION, None)
+
+@util.min_libcurl(7, 37, 0)
+def test_proxyheader_unicode(curl):
+    curl.setopt(pycurl.PROXYHEADER, ("Accept:",))
+
+
+@util.min_libcurl(7, 37, 0)
+def test_unset_proxyheader(curl):
+    curl.unsetopt(pycurl.PROXYHEADER)
+
+
+@util.min_libcurl(7, 37, 0)
+def test_set_proxyheader_none(curl):
+    curl.setopt(pycurl.PROXYHEADER, None)
+
+
+def test_unset_encoding(curl):
+    curl.unsetopt(pycurl.ENCODING)
+
+
+# github issue #405
+def test_large_options(curl):
+    curl.setopt(pycurl.INFILESIZE, 3333858173)
+    curl.setopt(pycurl.MAX_RECV_SPEED_LARGE, 3333858173)
+    curl.setopt(pycurl.MAX_SEND_SPEED_LARGE, 3333858173)
+    curl.setopt(pycurl.MAXFILESIZE, 3333858173)
+    curl.setopt(pycurl.POSTFIELDSIZE, 3333858173)
+    curl.setopt(pycurl.RESUME_FROM, 3333858173)
+
+
+@pytest.mark.parametrize(
+    "option",
+    [
+        pycurl.WRITEFUNCTION,
+        pycurl.HEADERFUNCTION,
+        pycurl.READFUNCTION,
+        pycurl.PROGRESSFUNCTION,
+        pycurl.XFERINFOFUNCTION,
+        pycurl.DEBUGFUNCTION,
+        pycurl.IOCTLFUNCTION,
+        pycurl.SEEKFUNCTION,
+    ],
+)
+def test_set_callback_none(curl, option):
+    curl.setopt(option, None)
+
+
+def test_httpheader_replace_cycle(app, curl):
+    curl.setopt(pycurl.URL, _header_echo_url(app))
+    for value in ("a", "b", "c", "d"):
+        curl.setopt(pycurl.HTTPHEADER, [f"x-test: {value}"])
+    io = BytesIO()
+    curl.setopt(pycurl.WRITEDATA, io)
+    curl.perform()
+    assert io.getvalue() == b"d"
+
+
+def test_httpheader_replace_refcount(curl):
+    first = ["x-test: first"]
+    before = sys.getrefcount(first)
+    curl.setopt(pycurl.HTTPHEADER, first)
+    curl.setopt(pycurl.HTTPHEADER, ["x-test: second"])
+    assert sys.getrefcount(first) == before


### PR DESCRIPTION
- `Curl.reset()` now rejects calls after `close()` or during `perform()` instead of crashing, and no longer does a bad `Py_DECREF(self)` on init failure.
- `util_curlslist_update` / `util_curlhttppost_update` propagate `PyObject_New` failures.
- `easyinfo.c` certinfo name length uses `Py_ssize_t` instead of truncating to `int`.
- Modernized `tests/reset_test.py` and `tests/setopt_test.py` and added a reset-after-close and HTTPHEADER replace-cycle/refcount regression tests.
