### PR TITLE
Add missing libcurl callbacks: TRAILER, RESOLVER_START, FNMATCH, HSTS

### DIFF
--- a/doc/callbacks.rst
+++ b/doc/callbacks.rst
@@ -7,8 +7,10 @@ For more fine-grained control, libcurl allows a number of callbacks to be
 associated with each connection. In pycurl, callbacks are defined using the
 ``setopt()`` method for Curl objects with options ``WRITEFUNCTION``,
 ``READFUNCTION``, ``HEADERFUNCTION``, ``PROGRESSFUNCTION``,
-``XFERINFOFUNCTION``, ``IOCTLFUNCTION``, ``DEBUGFUNCTION`` or
-``PREREQFUNCTION``. These options correspond to the libcurl options with ``CURLOPT_``
+``XFERINFOFUNCTION``, ``IOCTLFUNCTION``, ``DEBUGFUNCTION``,
+``PREREQFUNCTION``, ``TRAILERFUNCTION``, ``RESOLVER_START_FUNCTION``,
+``FNMATCH_FUNCTION``, ``HSTSREADFUNCTION`` or ``HSTSWRITEFUNCTION``.
+These options correspond to the libcurl options with ``CURLOPT_``
 prefix removed. A callback in pycurl must be either a regular Python
 function, a class method or an extension type function.
 
@@ -458,6 +460,125 @@ PREREQFUNCTION
     `prereq_cb_test.py test`_ shows how to use ``PREREQFUNCTION``.
 
 
+TRAILERFUNCTION
+---------------
+
+.. function:: TRAILERFUNCTION() -> list of strings or None
+
+    Callback for supplying HTTP trailing headers on chunked uploads.
+    Corresponds to `CURLOPT_TRAILERFUNCTION`_ in libcurl.
+
+    The callback takes no arguments and should return either ``None``
+    (no trailing headers) or a list or tuple of header strings in
+    ``"Name: value"`` form. The same rules apply to these strings as
+    do to ``HTTPHEADER`` entries.
+
+    Raising an exception from the callback, or returning any other type,
+    causes the transfer to fail with ``TRAILERFUNC_ABORT``.
+
+    The callback may be unset by calling :ref:`setopt <setopt>` with ``None``
+    as the value or by calling :ref:`unsetopt <unsetopt>`.
+
+
+RESOLVER_START_FUNCTION
+-----------------------
+
+.. function:: RESOLVER_START_FUNCTION() -> int
+
+    Callback invoked before each name resolution. Corresponds to
+    `CURLOPT_RESOLVER_START_FUNCTION`_ in libcurl.
+
+    The callback takes no arguments. Return ``0`` (or ``None``) to let the
+    resolution proceed; return any non-zero value to abort the transfer.
+
+    The callback may be unset by calling :ref:`setopt <setopt>` with ``None``
+    as the value or by calling :ref:`unsetopt <unsetopt>`.
+
+
+FNMATCH_FUNCTION
+----------------
+
+.. function:: FNMATCH_FUNCTION(pattern, string) -> int
+
+    Callback for wildcard matching used by the FTP wildcard transfer
+    feature. Corresponds to `CURLOPT_FNMATCH_FUNCTION`_ in libcurl.
+
+    *pattern* and *string* are both ``bytes``.
+
+    The callback should return one of:
+
+    - ``FNMATCHFUNC_MATCH`` (pattern matched)
+    - ``FNMATCHFUNC_NOMATCH`` (pattern did not match)
+    - ``FNMATCHFUNC_FAIL`` (error during matching; aborts the transfer)
+
+    The callback may be unset by calling :ref:`setopt <setopt>` with ``None``
+    as the value or by calling :ref:`unsetopt <unsetopt>`.
+
+
+HSTSWRITEFUNCTION
+-----------------
+
+.. function:: HSTSWRITEFUNCTION(entry, index) -> int
+
+    Callback for persisting the in-memory HSTS cache. Corresponds to
+    `CURLOPT_HSTSWRITEFUNCTION`_ in libcurl. Requires ``HSTS_CTRL`` to be
+    set to ``CURLHSTS_ENABLE``.
+
+    *entry* is an ``HstsEntry`` `namedtuple`_ with ``host``, ``expire``
+    and ``include_subdomains`` fields::
+
+        HstsEntry = namedtuple('HstsEntry',
+                               ('host', 'expire', 'include_subdomains'))
+
+    *host* is ``bytes``. *expire* is a tz-aware ``datetime`` in UTC, or
+    ``None`` when the entry never expires. *include_subdomains* is ``bool``.
+
+    *index* is an ``HstsIndex`` `namedtuple`_ indicating progress through
+    the cache::
+
+        HstsIndex = namedtuple('HstsIndex', ('index', 'total'))
+
+    The callback should return ``CURLSTS_OK`` (entry accepted),
+    ``CURLSTS_DONE`` (stop iterating) or ``CURLSTS_FAIL`` (error).
+    Returning ``None`` is equivalent to ``CURLSTS_OK``.
+
+    libcurl invokes the callback during ``perform()`` and during handle
+    cleanup; exceptions raised inside the callback while the handle is
+    being cleaned up are written to :py:data:`sys.unraisablehook` and
+    do not propagate.
+
+    The callback may be unset by calling :ref:`setopt <setopt>` with ``None``
+    as the value or by calling :ref:`unsetopt <unsetopt>`.
+
+
+HSTSREADFUNCTION
+----------------
+
+.. function:: HSTSREADFUNCTION() -> HstsEntry or None
+
+    Callback for preloading the in-memory HSTS cache. Corresponds to
+    `CURLOPT_HSTSREADFUNCTION`_ in libcurl. Requires ``HSTS_CTRL`` to be
+    set to ``CURLHSTS_ENABLE``.
+
+    The callback takes no arguments. It is invoked repeatedly until it
+    returns ``None``.
+
+    Return ``None`` to signal there are no more entries
+    (``CURLSTS_DONE``), or an ``HstsEntry`` (or any 3-tuple) where:
+
+    - *host* is ``bytes`` or an ASCII ``str``.
+    - *expire* is a ``datetime`` or ``None``. ``None`` means the entry
+      never expires. Aware datetimes are converted to UTC; naive
+      datetimes are interpreted as UTC.
+    - *include_subdomains* is any truthy/falsy value.
+
+    Raising an exception or returning anything else causes the transfer
+    to fail with ``CURLSTS_FAIL``.
+
+    The callback may be unset by calling :ref:`setopt <setopt>` with ``None``
+    as the value or by calling :ref:`unsetopt <unsetopt>`.
+
+
 .. _CURLOPT_HEADERFUNCTION: https://curl.haxx.se/libcurl/c/CURLOPT_HEADERFUNCTION.html
 .. _CURLOPT_WRITEFUNCTION: https://curl.haxx.se/libcurl/c/CURLOPT_WRITEFUNCTION.html
 .. _CURLOPT_READFUNCTION: https://curl.haxx.se/libcurl/c/CURLOPT_READFUNCTION.html
@@ -484,3 +605,8 @@ PREREQFUNCTION
 .. _CURLMOPT_SOCKETFUNCTION: https://curl.se/libcurl/c/CURLMOPT_SOCKETFUNCTION.html
 .. _CURLOPT_PREREQFUNCTION: https://curl.se/libcurl/c/CURLOPT_PREREQFUNCTION.html
 .. _prereq_cb_test.py test: https://github.com/pycurl/pycurl/blob/master/tests/prereq_cb_test.py
+.. _CURLOPT_TRAILERFUNCTION: https://curl.se/libcurl/c/CURLOPT_TRAILERFUNCTION.html
+.. _CURLOPT_RESOLVER_START_FUNCTION: https://curl.se/libcurl/c/CURLOPT_RESOLVER_START_FUNCTION.html
+.. _CURLOPT_FNMATCH_FUNCTION: https://curl.se/libcurl/c/CURLOPT_FNMATCH_FUNCTION.html
+.. _CURLOPT_HSTSREADFUNCTION: https://curl.se/libcurl/c/CURLOPT_HSTSREADFUNCTION.html
+.. _CURLOPT_HSTSWRITEFUNCTION: https://curl.se/libcurl/c/CURLOPT_HSTSWRITEFUNCTION.html

--- a/src/easy.c
+++ b/src/easy.c
@@ -421,6 +421,34 @@ do_curl_duphandle(CurlObject *self, PyObject *Py_UNUSED(ignored))
         curl_easy_setopt(dup->handle, CURLOPT_PREREQDATA, dup);
     }
 #endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 21, 0)
+    if (self->fnmatch_cb != NULL) {
+        dup->fnmatch_cb = Py_NewRef(self->fnmatch_cb);
+        curl_easy_setopt(dup->handle, CURLOPT_FNMATCH_DATA, dup);
+    }
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 59, 0)
+    if (self->resolver_start_cb != NULL) {
+        dup->resolver_start_cb = Py_NewRef(self->resolver_start_cb);
+        curl_easy_setopt(dup->handle, CURLOPT_RESOLVER_START_DATA, dup);
+    }
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 64, 0)
+    if (self->trailer_cb != NULL) {
+        dup->trailer_cb = Py_NewRef(self->trailer_cb);
+        curl_easy_setopt(dup->handle, CURLOPT_TRAILERDATA, dup);
+    }
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 74, 0)
+    if (self->hstsread_cb != NULL) {
+        dup->hstsread_cb = Py_NewRef(self->hstsread_cb);
+        curl_easy_setopt(dup->handle, CURLOPT_HSTSREADDATA, dup);
+    }
+    if (self->hstswrite_cb != NULL) {
+        dup->hstswrite_cb = Py_NewRef(self->hstswrite_cb);
+        curl_easy_setopt(dup->handle, CURLOPT_HSTSWRITEDATA, dup);
+    }
+#endif
 
     /* Assign and incref python file objects */
     dup->readdata_fp = Py_XNewRef(self->readdata_fp);
@@ -514,6 +542,19 @@ util_curl_xdecref(CurlObject *self, int flags, CURL *handle)
         Py_CLEAR(self->ssh_key_cb);
 #if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 80, 0)
         Py_CLEAR(self->prereq_cb);
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 21, 0)
+        Py_CLEAR(self->fnmatch_cb);
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 59, 0)
+        Py_CLEAR(self->resolver_start_cb);
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 64, 0)
+        Py_CLEAR(self->trailer_cb);
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 74, 0)
+        Py_CLEAR(self->hstsread_cb);
+        Py_CLEAR(self->hstswrite_cb);
 #endif
     }
 
@@ -730,6 +771,19 @@ do_curl_traverse(CurlObject *self, visitproc visit, void *arg)
     VISIT(self->ssh_key_cb);
 #if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 80, 0)
     VISIT(self->prereq_cb);
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 21, 0)
+    VISIT(self->fnmatch_cb);
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 59, 0)
+    VISIT(self->resolver_start_cb);
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 64, 0)
+    VISIT(self->trailer_cb);
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 74, 0)
+    VISIT(self->hstsread_cb);
+    VISIT(self->hstswrite_cb);
 #endif
 
     VISIT(self->readdata_fp);

--- a/src/easycb.c
+++ b/src/easycb.c
@@ -949,4 +949,401 @@ verbose_error:
 }
 #endif
 
+
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 21, 0)
+PYCURL_INTERNAL int
+fnmatch_callback(void *clientp, const char *pattern, const char *string)
+{
+    PyObject *arglist;
+    CurlObject *self;
+    int ret = CURL_FNMATCHFUNC_FAIL;
+    PyObject *ret_obj = NULL;
+    PYCURL_DECLARE_THREAD_STATE;
+
+    self = (CurlObject *)clientp;
+
+    PYCURL_BEGIN_CALLBACK(fnmatch_callback, ret);
+
+    arglist = Py_BuildValue("(yy)", pattern, string);
+    if (arglist == NULL) {
+        goto verbose_error;
+    }
+
+    ret_obj = PyObject_Call(self->fnmatch_cb, arglist, NULL);
+    Py_DECREF(arglist);
+    if (callback_return_value_to_int(ret_obj, "fnmatch", &ret) != 0) {
+        goto silent_error;
+    }
+    goto done;
+
+silent_error:
+    ret = CURL_FNMATCHFUNC_FAIL;
+done:
+    Py_XDECREF(ret_obj);
+    PYCURL_END_CALLBACK(ret);
+verbose_error:
+    print_callback_error_if_regular_exception();
+    goto silent_error;
+}
+#endif
+
+
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 59, 0)
+PYCURL_INTERNAL int
+resolver_start_callback(void *resolver_state, void *reserved, void *clientp)
+{
+    CurlObject *self;
+    int ret = 1;  /* non-zero aborts */
+    PyObject *ret_obj = NULL;
+    PYCURL_DECLARE_THREAD_STATE;
+
+    UNUSED(resolver_state);
+    UNUSED(reserved);
+
+    self = (CurlObject *)clientp;
+
+    PYCURL_BEGIN_CALLBACK(resolver_start_callback, ret);
+
+    ret_obj = PyObject_CallNoArgs(self->resolver_start_cb);
+    if (ret_obj == NULL) {
+        goto verbose_error;
+    }
+    if (ret_obj == Py_None) {
+        ret = 0;
+    } else if (callback_return_value_to_int(ret_obj, "resolver_start", &ret) != 0) {
+        goto silent_error;
+    }
+    goto done;
+
+silent_error:
+    ret = 1;
+done:
+    Py_XDECREF(ret_obj);
+    PYCURL_END_CALLBACK(ret);
+verbose_error:
+    print_callback_error_if_regular_exception();
+    goto silent_error;
+}
+#endif
+
+
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 64, 0)
+PYCURL_INTERNAL int
+trailer_callback(struct curl_slist **list, void *clientp)
+{
+    CurlObject *self;
+    int ret = CURL_TRAILERFUNC_ABORT;
+    PyObject *ret_obj = NULL;
+    PYCURL_DECLARE_THREAD_STATE;
+
+    self = (CurlObject *)clientp;
+
+    /* Initialise early: libcurl passes an uninitialised pointer on entry. */
+    *list = NULL;
+
+    PYCURL_BEGIN_CALLBACK(trailer_callback, ret);
+
+    ret_obj = PyObject_CallNoArgs(self->trailer_cb);
+    if (ret_obj == NULL) {
+        goto verbose_error;
+    }
+
+    if (ret_obj == Py_None) {
+        ret = CURL_TRAILERFUNC_OK;
+        goto done;
+    }
+
+    if (PyList_Check(ret_obj) || PyTuple_Check(ret_obj)) {
+        int which = PyList_Check(ret_obj) ? PYLISTORTUPLE_LIST : PYLISTORTUPLE_TUPLE;
+        Py_ssize_t len = PyListOrTuple_Size(ret_obj, which);
+        /* pycurl_list_or_tuple_to_slist frees any partial slist on error,
+         * so we never own a non-NULL slist once it returns. An empty
+         * list yields a NULL slist with no error set. */
+        *list = pycurl_list_or_tuple_to_slist(which, ret_obj, len);
+        if (*list == NULL && PyErr_Occurred()) {
+            goto verbose_error;
+        }
+        ret = CURL_TRAILERFUNC_OK;
+        goto done;
+    }
+
+    PyErr_SetString(ErrorObject, "trailer callback must return None or a list/tuple of header strings");
+    goto verbose_error;
+
+silent_error:
+    ret = CURL_TRAILERFUNC_ABORT;
+done:
+    Py_XDECREF(ret_obj);
+    PYCURL_END_CALLBACK(ret);
+verbose_error:
+    *list = NULL;
+    print_callback_error_if_regular_exception();
+    goto silent_error;
+}
+#endif
+
+
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 74, 0)
+
+/* Parse libcurl's "YYYYMMDD HH:MM:SS" stamp into a tz-aware
+ * datetime(UTC). The sentinel values "" and "unlimited" (used by
+ * libcurl for never-expires entries) map to Py_None. Returns a new
+ * reference, or NULL with a Python exception set. Parsing is delegated
+ * to datetime.strptime with an appended "+0000" so the result is an
+ * aware UTC datetime in a single call. */
+static PyObject *
+expire_c_str_to_datetime(const char *stamp)
+{
+    char buf[32];
+    int written;
+
+    if (stamp[0] == '\0' || strcmp(stamp, "unlimited") == 0) {
+        Py_RETURN_NONE;
+    }
+    written = snprintf(buf, sizeof(buf), "%s+0000", stamp);
+    if (written < 0 || (size_t)written >= sizeof(buf)) {
+        PyErr_Format(ErrorObject,
+            "libcurl returned an unparsable HSTS expire stamp: %s", stamp);
+        return NULL;
+    }
+    return PyObject_CallMethod(datetime_type, "strptime", "ss",
+                               buf, "%Y%m%d %H:%M:%S%z");
+}
+
+
+/* Convert a Python value (None or datetime) to libcurl's fixed-size
+ * expire buffer. Aware datetimes are normalised to UTC; naive datetimes
+ * are interpreted as UTC (documented). Returns 0 on success, -1 with a
+ * Python exception set. */
+static int
+expire_obj_to_c_str(PyObject *obj, char *buf, size_t buf_size)
+{
+    PyObject *utc_obj = NULL;
+    PyObject *tzinfo = NULL;
+    PyObject *formatted = NULL;
+    Py_ssize_t str_len;
+    const char *str;
+    int is_datetime;
+    int rc = -1;
+
+    if (obj == Py_None) {
+        /* Empty stamp = never expires, per libcurl docs. */
+        buf[0] = '\0';
+        return 0;
+    }
+
+    is_datetime = PyObject_IsInstance(obj, datetime_type);
+    if (is_datetime < 0) {
+        return -1;
+    }
+    if (!is_datetime) {
+        PyErr_SetString(ErrorObject,
+            "hstsread callback: expire must be a datetime or None");
+        return -1;
+    }
+
+    tzinfo = PyObject_GetAttrString(obj, "tzinfo");
+    if (tzinfo == NULL) {
+        goto cleanup;
+    }
+    if (tzinfo != Py_None) {
+        utc_obj = PyObject_CallMethod(obj, "astimezone", "O", utc_tz);
+        if (utc_obj == NULL) {
+            goto cleanup;
+        }
+        obj = utc_obj;
+    }
+
+    formatted = PyObject_CallMethod(obj, "strftime", "s", "%Y%m%d %H:%M:%S");
+    if (formatted == NULL) {
+        goto cleanup;
+    }
+    str = PyUnicode_AsUTF8AndSize(formatted, &str_len);
+    if (str == NULL) {
+        goto cleanup;
+    }
+    if ((size_t)str_len >= buf_size) {
+        PyErr_SetString(ErrorObject,
+            "hstsread callback: formatted expire does not fit in libcurl's buffer");
+        goto cleanup;
+    }
+    memcpy(buf, str, (size_t)str_len);
+    buf[str_len] = '\0';
+    rc = 0;
+
+cleanup:
+    Py_XDECREF(tzinfo);
+    Py_XDECREF(utc_obj);
+    Py_XDECREF(formatted);
+    return rc;
+}
+
+
+PYCURL_INTERNAL CURLSTScode
+hstswrite_callback(CURL *easy, struct curl_hstsentry *e,
+                   struct curl_index *i, void *clientp)
+{
+    CurlObject *self;
+    CURLSTScode ret = CURLSTS_FAIL;
+    PyObject *expire_obj = NULL;
+    PyObject *entry = NULL;
+    PyObject *index = NULL;
+    PyObject *arglist = NULL;
+    PyObject *ret_obj = NULL;
+    int raw_ret;
+    PYCURL_DECLARE_THREAD_STATE;
+
+    UNUSED(easy);
+
+    self = (CurlObject *)clientp;
+
+    PYCURL_BEGIN_CALLBACK(hstswrite_callback, ret);
+
+    expire_obj = expire_c_str_to_datetime(e->expire);
+    if (expire_obj == NULL) {
+        goto verbose_error;
+    }
+
+    /* HstsEntry(host=bytes, expire=datetime|None, include_subdomains=bool) */
+    entry = PyObject_CallFunction(hsts_entry_type, "y#OO",
+                                  e->name, (Py_ssize_t)e->namelen,
+                                  expire_obj,
+                                  e->includeSubDomains ? Py_True : Py_False);
+    Py_DECREF(expire_obj);
+    expire_obj = NULL;
+    if (entry == NULL) {
+        goto verbose_error;
+    }
+
+    /* HstsIndex(index=int, total=int) */
+    index = PyObject_CallFunction(hsts_index_type, "nn",
+                                  (Py_ssize_t)i->index, (Py_ssize_t)i->total);
+    if (index == NULL) {
+        goto verbose_error;
+    }
+
+    arglist = PyTuple_Pack(2, entry, index);
+    if (arglist == NULL) {
+        goto verbose_error;
+    }
+
+    ret_obj = PyObject_Call(self->hstswrite_cb, arglist, NULL);
+    Py_CLEAR(arglist);
+    if (ret_obj == NULL) {
+        goto verbose_error;
+    }
+    if (ret_obj == Py_None) {
+        ret = CURLSTS_OK;
+        goto done;
+    }
+    if (callback_return_value_to_int(ret_obj, "hstswrite", &raw_ret) != 0) {
+        goto silent_error;
+    }
+    if (raw_ret < 0 || raw_ret > CURLSTS_FAIL) {
+        PyErr_SetString(ErrorObject, "hstswrite callback returned an invalid CURLSTScode");
+        goto verbose_error;
+    }
+    ret = (CURLSTScode)raw_ret;
+    goto done;
+
+silent_error:
+    ret = CURLSTS_FAIL;
+done:
+    Py_XDECREF(entry);
+    Py_XDECREF(index);
+    Py_XDECREF(ret_obj);
+    PYCURL_END_CALLBACK(ret);
+verbose_error:
+    Py_XDECREF(expire_obj);
+    Py_XDECREF(arglist);
+    print_callback_error_if_regular_exception();
+    goto silent_error;
+}
+
+
+PYCURL_INTERNAL CURLSTScode
+hstsread_callback(CURL *easy, struct curl_hstsentry *e, void *clientp)
+{
+    CurlObject *self;
+    CURLSTScode ret = CURLSTS_FAIL;
+    PyObject *ret_obj = NULL;
+    PyObject *host_obj = NULL;
+    PyObject *expire_obj = NULL;
+    PyObject *include_obj = NULL;
+    PyObject *host_encoded = NULL;
+    char *host_buf = NULL;
+    Py_ssize_t host_len = 0;
+    int include_subdomains;
+    PYCURL_DECLARE_THREAD_STATE;
+
+    UNUSED(easy);
+
+    self = (CurlObject *)clientp;
+
+    PYCURL_BEGIN_CALLBACK(hstsread_callback, ret);
+
+    ret_obj = PyObject_CallNoArgs(self->hstsread_cb);
+    if (ret_obj == NULL) {
+        goto verbose_error;
+    }
+
+    if (ret_obj == Py_None) {
+        ret = CURLSTS_DONE;
+        goto done;
+    }
+
+    /* Accept HstsEntry (namedtuple) or any 3-tuple. */
+    if (!PyTuple_Check(ret_obj) || PyTuple_GET_SIZE(ret_obj) != 3) {
+        PyErr_SetString(ErrorObject,
+            "hstsread callback must return None or a 3-tuple (host, expire, include_subdomains)");
+        goto verbose_error;
+    }
+
+    host_obj = PyTuple_GET_ITEM(ret_obj, 0);
+    expire_obj = PyTuple_GET_ITEM(ret_obj, 1);
+    include_obj = PyTuple_GET_ITEM(ret_obj, 2);
+
+    if (PyText_AsStringAndSize(host_obj, &host_buf, &host_len, &host_encoded) != 0) {
+        goto verbose_error;
+    }
+
+    /* e->namelen is the max hostname length libcurl accepts (the
+     * backing buffer is e->namelen + 1 bytes, leaving room for the
+     * null terminator we write at position host_len). */
+    if ((size_t)host_len > e->namelen) {
+        PyErr_Format(ErrorObject,
+            "hstsread callback: host length %zd exceeds libcurl maximum %zu",
+            host_len, (size_t)e->namelen);
+        goto verbose_error;
+    }
+
+    if (expire_obj_to_c_str(expire_obj, e->expire, sizeof(e->expire)) != 0) {
+        goto verbose_error;
+    }
+
+    include_subdomains = PyObject_IsTrue(include_obj);
+    if (include_subdomains < 0) {
+        goto verbose_error;
+    }
+
+    memcpy(e->name, host_buf, (size_t)host_len);
+    e->name[host_len] = '\0';
+    e->namelen = (size_t)host_len;
+    e->includeSubDomains = include_subdomains ? 1 : 0;
+
+    ret = CURLSTS_OK;
+    goto done;
+
+silent_error:
+    ret = CURLSTS_FAIL;
+done:
+    Py_XDECREF(host_encoded);
+    Py_XDECREF(ret_obj);
+    PYCURL_END_CALLBACK(ret);
+verbose_error:
+    print_callback_error_if_regular_exception();
+    goto silent_error;
+}
+#endif
+
 #undef PYCURL_BEGIN_CALLBACK

--- a/src/easyopt.c
+++ b/src/easyopt.c
@@ -1,7 +1,7 @@
 #include "pycurl.h"
 
 
-static struct curl_slist *
+PYCURL_INTERNAL struct curl_slist *
 pycurl_list_or_tuple_to_slist(int which, PyObject *obj, Py_ssize_t len)
 {
     struct curl_slist *slist = NULL;
@@ -138,6 +138,9 @@ util_curl_unsetopt(CurlObject *self, int option)
     case CURLOPT_PROXY_SSLKEY_BLOB:
     case CURLOPT_PROXY_ISSUERCERT_BLOB:
 #endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 74, 0)
+    case CURLOPT_HSTS:
+#endif
         SETOPT((char *) NULL);
         break;
 
@@ -211,6 +214,19 @@ util_curl_unsetopt(CurlObject *self, int option)
     CLEAR_CALLBACK(CURLOPT_SEEKFUNCTION, CURLOPT_SEEKDATA, self->seek_cb);
 #if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 80, 0)
     CLEAR_CALLBACK(CURLOPT_PREREQFUNCTION, CURLOPT_PREREQDATA, self->prereq_cb);
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 21, 0)
+    CLEAR_CALLBACK(CURLOPT_FNMATCH_FUNCTION, CURLOPT_FNMATCH_DATA, self->fnmatch_cb);
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 59, 0)
+    CLEAR_CALLBACK(CURLOPT_RESOLVER_START_FUNCTION, CURLOPT_RESOLVER_START_DATA, self->resolver_start_cb);
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 64, 0)
+    CLEAR_CALLBACK(CURLOPT_TRAILERFUNCTION, CURLOPT_TRAILERDATA, self->trailer_cb);
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 74, 0)
+    CLEAR_CALLBACK(CURLOPT_HSTSREADFUNCTION, CURLOPT_HSTSREADDATA, self->hstsread_cb);
+    CLEAR_CALLBACK(CURLOPT_HSTSWRITEFUNCTION, CURLOPT_HSTSWRITEDATA, self->hstswrite_cb);
 #endif
 
     /* info: we explicitly list unsupported options here */
@@ -399,6 +415,9 @@ do_curl_setopt_string_impl(CurlObject *self, int option, PyObject *obj)
 #endif
 #if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 71, 0)
     case CURLOPT_PROXY_ISSUERCERT:
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 74, 0)
+    case CURLOPT_HSTS:
 #endif
 #if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 75, 0)
     case CURLOPT_AWS_SIGV4:
@@ -877,6 +896,19 @@ do_curl_setopt_callable(CurlObject *self, int option, PyObject *obj)
 #if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 80, 0)
     const curl_prereq_callback prereq_cb = prereq_callback;
 #endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 21, 0)
+    const curl_fnmatch_callback fnmatch_cb = fnmatch_callback;
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 59, 0)
+    const curl_resolver_start_callback resolver_start_cb = resolver_start_callback;
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 64, 0)
+    const curl_trailer_callback trailer_cb = trailer_callback;
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 74, 0)
+    const curl_hstsread_callback hstsread_cb = hstsread_callback;
+    const curl_hstswrite_callback hstswrite_cb = hstswrite_callback;
+#endif
 
     switch(option) {
     case CURLOPT_WRITEFUNCTION:
@@ -979,6 +1011,49 @@ do_curl_setopt_callable(CurlObject *self, int option, PyObject *obj)
         self->prereq_cb = obj;
         curl_easy_setopt(self->handle, CURLOPT_PREREQFUNCTION, prereq_cb);
         curl_easy_setopt(self->handle, CURLOPT_PREREQDATA, self);
+        break;
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 21, 0)
+    case CURLOPT_FNMATCH_FUNCTION:
+        Py_INCREF(obj);
+        Py_CLEAR(self->fnmatch_cb);
+        self->fnmatch_cb = obj;
+        curl_easy_setopt(self->handle, CURLOPT_FNMATCH_FUNCTION, fnmatch_cb);
+        curl_easy_setopt(self->handle, CURLOPT_FNMATCH_DATA, self);
+        break;
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 59, 0)
+    case CURLOPT_RESOLVER_START_FUNCTION:
+        Py_INCREF(obj);
+        Py_CLEAR(self->resolver_start_cb);
+        self->resolver_start_cb = obj;
+        curl_easy_setopt(self->handle, CURLOPT_RESOLVER_START_FUNCTION, resolver_start_cb);
+        curl_easy_setopt(self->handle, CURLOPT_RESOLVER_START_DATA, self);
+        break;
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 64, 0)
+    case CURLOPT_TRAILERFUNCTION:
+        Py_INCREF(obj);
+        Py_CLEAR(self->trailer_cb);
+        self->trailer_cb = obj;
+        curl_easy_setopt(self->handle, CURLOPT_TRAILERFUNCTION, trailer_cb);
+        curl_easy_setopt(self->handle, CURLOPT_TRAILERDATA, self);
+        break;
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 74, 0)
+    case CURLOPT_HSTSREADFUNCTION:
+        Py_INCREF(obj);
+        Py_CLEAR(self->hstsread_cb);
+        self->hstsread_cb = obj;
+        curl_easy_setopt(self->handle, CURLOPT_HSTSREADFUNCTION, hstsread_cb);
+        curl_easy_setopt(self->handle, CURLOPT_HSTSREADDATA, self);
+        break;
+    case CURLOPT_HSTSWRITEFUNCTION:
+        Py_INCREF(obj);
+        Py_CLEAR(self->hstswrite_cb);
+        self->hstswrite_cb = obj;
+        curl_easy_setopt(self->handle, CURLOPT_HSTSWRITEFUNCTION, hstswrite_cb);
+        curl_easy_setopt(self->handle, CURLOPT_HSTSWRITEDATA, self);
         break;
 #endif
 

--- a/src/module.c
+++ b/src/module.c
@@ -34,6 +34,12 @@ PYCURL_INTERNAL PyTypeObject *p_CurlMimePart_Type = NULL;
 PYCURL_INTERNAL PyObject *khkey_type = NULL;
 #endif
 PYCURL_INTERNAL PyObject *curl_sockaddr_type = NULL;
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 74, 0)
+PYCURL_INTERNAL PyObject *hsts_entry_type = NULL;
+PYCURL_INTERNAL PyObject *hsts_index_type = NULL;
+PYCURL_INTERNAL PyObject *datetime_type = NULL;
+PYCURL_INTERNAL PyObject *utc_tz = NULL;
+#endif
 
 PYCURL_INTERNAL PyObject *curlobject_constants = NULL;
 PYCURL_INTERNAL PyObject *curlmultiobject_constants = NULL;
@@ -338,6 +344,16 @@ static void do_curlmod_free(void *unused) {
 #endif
     Py_XDECREF(curl_sockaddr_type);
     curl_sockaddr_type = NULL;
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 74, 0)
+    Py_XDECREF(hsts_entry_type);
+    hsts_entry_type = NULL;
+    Py_XDECREF(hsts_index_type);
+    hsts_index_type = NULL;
+    Py_XDECREF(datetime_type);
+    datetime_type = NULL;
+    Py_XDECREF(utc_tz);
+    utc_tz = NULL;
+#endif
 
     Py_XDECREF(curlobject_constants);
     curlobject_constants = NULL;
@@ -1184,6 +1200,40 @@ PyMODINIT_FUNC PyInit_pycurl(void)
     insint_c(d, "PREREQFUNC_ABORT", CURL_PREREQFUNC_ABORT);
 #endif
 
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 21, 0)
+    insint_c(d, "FNMATCH_FUNCTION", CURLOPT_FNMATCH_FUNCTION);
+    insint_c(d, "FNMATCH_DATA", CURLOPT_FNMATCH_DATA);
+    insint_c(d, "FNMATCHFUNC_MATCH", CURL_FNMATCHFUNC_MATCH);
+    insint_c(d, "FNMATCHFUNC_NOMATCH", CURL_FNMATCHFUNC_NOMATCH);
+    insint_c(d, "FNMATCHFUNC_FAIL", CURL_FNMATCHFUNC_FAIL);
+#endif
+
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 59, 0)
+    insint_c(d, "RESOLVER_START_FUNCTION", CURLOPT_RESOLVER_START_FUNCTION);
+    insint_c(d, "RESOLVER_START_DATA", CURLOPT_RESOLVER_START_DATA);
+#endif
+
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 64, 0)
+    insint_c(d, "TRAILERFUNCTION", CURLOPT_TRAILERFUNCTION);
+    insint_c(d, "TRAILERDATA", CURLOPT_TRAILERDATA);
+    insint_c(d, "TRAILERFUNC_OK", CURL_TRAILERFUNC_OK);
+    insint_c(d, "TRAILERFUNC_ABORT", CURL_TRAILERFUNC_ABORT);
+#endif
+
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 74, 0)
+    insint_c(d, "HSTS", CURLOPT_HSTS);
+    insint_c(d, "HSTS_CTRL", CURLOPT_HSTS_CTRL);
+    insint_c(d, "HSTSREADFUNCTION", CURLOPT_HSTSREADFUNCTION);
+    insint_c(d, "HSTSREADDATA", CURLOPT_HSTSREADDATA);
+    insint_c(d, "HSTSWRITEFUNCTION", CURLOPT_HSTSWRITEFUNCTION);
+    insint_c(d, "HSTSWRITEDATA", CURLOPT_HSTSWRITEDATA);
+    insint_c(d, "CURLHSTS_ENABLE", CURLHSTS_ENABLE);
+    insint_c(d, "CURLHSTS_READONLYFILE", CURLHSTS_READONLYFILE);
+    insint_c(d, "CURLSTS_OK", CURLSTS_OK);
+    insint_c(d, "CURLSTS_DONE", CURLSTS_DONE);
+    insint_c(d, "CURLSTS_FAIL", CURLSTS_FAIL);
+#endif
+
     insint_m(d, "M_TIMERFUNCTION", CURLMOPT_TIMERFUNCTION);
     insint_m(d, "M_SOCKETFUNCTION", CURLMOPT_SOCKETFUNCTION);
     insint_m(d, "M_PIPELINING", CURLMOPT_PIPELINING);
@@ -1673,6 +1723,55 @@ PyMODINIT_FUNC PyInit_pycurl(void)
         goto error;
     }
 
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 74, 0)
+    {
+        PyObject *datetime_module = PyImport_ImportModule("datetime");
+        PyObject *timezone_cls = NULL;
+        if (datetime_module == NULL) {
+            goto error;
+        }
+        datetime_type = PyObject_GetAttrString(datetime_module, "datetime");
+        timezone_cls = PyObject_GetAttrString(datetime_module, "timezone");
+        if (datetime_type == NULL || timezone_cls == NULL) {
+            Py_XDECREF(timezone_cls);
+            Py_DECREF(datetime_module);
+            goto error;
+        }
+        utc_tz = PyObject_GetAttrString(timezone_cls, "utc");
+        Py_DECREF(timezone_cls);
+        Py_DECREF(datetime_module);
+        if (utc_tz == NULL) {
+            goto error;
+        }
+
+        arglist = Py_BuildValue("ss", "HstsEntry", "host expire include_subdomains");
+        if (arglist == NULL) {
+            goto error;
+        }
+        hsts_entry_type = PyObject_Call(named_tuple, arglist, NULL);
+        if (hsts_entry_type == NULL) {
+            goto error;
+        }
+        Py_DECREF(arglist);
+        if (PyDict_SetItemString(d, "HstsEntry", hsts_entry_type) < 0) {
+            goto error;
+        }
+
+        arglist = Py_BuildValue("ss", "HstsIndex", "index total");
+        if (arglist == NULL) {
+            goto error;
+        }
+        hsts_index_type = PyObject_Call(named_tuple, arglist, NULL);
+        if (hsts_index_type == NULL) {
+            goto error;
+        }
+        Py_DECREF(arglist);
+        if (PyDict_SetItemString(d, "HstsIndex", hsts_index_type) < 0) {
+            goto error;
+        }
+    }
+#endif
+
 #ifdef PYCURL_AUTODETECT_CA
     pycurl_autodetect_ca();
 #endif
@@ -1698,6 +1797,12 @@ error:
     Py_XDECREF(khkey_type);
     #endif
     Py_XDECREF(curl_sockaddr_type);
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 74, 0)
+    Py_XDECREF(hsts_entry_type);
+    Py_XDECREF(hsts_index_type);
+    Py_XDECREF(datetime_type);
+    Py_XDECREF(utc_tz);
+#endif
     PyMem_Free(g_pycurl_useragent);
     if (!PyErr_Occurred())
         PyErr_SetString(PyExc_ImportError, "curl module init failed");

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -464,6 +464,19 @@ typedef struct CurlObject {
 #if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 80, 0)
     PyObject *prereq_cb;
 #endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 21, 0)
+    PyObject *fnmatch_cb;
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 59, 0)
+    PyObject *resolver_start_cb;
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 64, 0)
+    PyObject *trailer_cb;
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 74, 0)
+    PyObject *hstsread_cb;
+    PyObject *hstswrite_cb;
+#endif
     /* file objects */
     PyObject *readdata_fp;
     PyObject *writedata_fp;
@@ -682,6 +695,28 @@ PYCURL_INTERNAL int
 prereq_callback(void *clientp, char *conn_primary_ip, char *conn_local_ip,
                 int conn_primary_port, int conn_local_port);
 #endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 21, 0)
+PYCURL_INTERNAL int
+fnmatch_callback(void *clientp, const char *pattern, const char *string);
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 59, 0)
+PYCURL_INTERNAL int
+resolver_start_callback(void *resolver_state, void *reserved, void *clientp);
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 64, 0)
+PYCURL_INTERNAL int
+trailer_callback(struct curl_slist **list, void *clientp);
+#endif
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 74, 0)
+PYCURL_INTERNAL CURLSTScode
+hstsread_callback(CURL *easy, struct curl_hstsentry *e, void *clientp);
+PYCURL_INTERNAL CURLSTScode
+hstswrite_callback(CURL *easy, struct curl_hstsentry *e,
+                   struct curl_index *i, void *clientp);
+#endif
+
+PYCURL_INTERNAL struct curl_slist *
+pycurl_list_or_tuple_to_slist(int which, PyObject *obj, Py_ssize_t len);
 
 PYCURL_INTERNAL int share_register_easy(struct CurlShareObject *share, struct CurlObject *easy);
 PYCURL_INTERNAL void share_unregister_easy(struct CurlShareObject *share, struct CurlObject *easy);
@@ -710,6 +745,12 @@ extern PyTypeObject *p_CurlMimePart_Type;
 #endif
 extern PyObject *khkey_type;
 extern PyObject *curl_sockaddr_type;
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 74, 0)
+extern PyObject *hsts_entry_type;
+extern PyObject *hsts_index_type;
+extern PyObject *datetime_type;
+extern PyObject *utc_tz;
+#endif
 
 extern PyObject *curlobject_constants;
 extern PyObject *curlmultiobject_constants;

--- a/tests/option_constants_test.py
+++ b/tests/option_constants_test.py
@@ -742,3 +742,47 @@ def test_xauth_bearer(curl):
 
 def test_cookielist_constants():
     assert pycurl.OPT_COOKIELIST == pycurl.COOKIELIST
+
+
+@util.min_libcurl(7, 21, 0)
+def test_fnmatch_constants():
+    assert hasattr(pycurl, "FNMATCH_FUNCTION")
+    assert hasattr(pycurl, "FNMATCH_DATA")
+    assert pycurl.FNMATCHFUNC_MATCH == 0
+    assert pycurl.FNMATCHFUNC_NOMATCH == 1
+    assert pycurl.FNMATCHFUNC_FAIL == 2
+
+
+@util.min_libcurl(7, 59, 0)
+def test_resolver_start_constants():
+    assert hasattr(pycurl, "RESOLVER_START_FUNCTION")
+    assert hasattr(pycurl, "RESOLVER_START_DATA")
+
+
+@util.min_libcurl(7, 64, 0)
+def test_trailer_constants():
+    assert hasattr(pycurl, "TRAILERFUNCTION")
+    assert hasattr(pycurl, "TRAILERDATA")
+    assert pycurl.TRAILERFUNC_OK == 0
+    assert pycurl.TRAILERFUNC_ABORT == 1
+
+
+@util.min_libcurl(7, 74, 0)
+def test_hsts_constants():
+    for name in (
+        "HSTS",
+        "HSTS_CTRL",
+        "HSTSREADFUNCTION",
+        "HSTSREADDATA",
+        "HSTSWRITEFUNCTION",
+        "HSTSWRITEDATA",
+        "CURLHSTS_ENABLE",
+        "CURLHSTS_READONLYFILE",
+        "CURLSTS_OK",
+        "CURLSTS_DONE",
+        "CURLSTS_FAIL",
+    ):
+        assert hasattr(pycurl, name), name
+    assert pycurl.CURLSTS_OK == 0
+    assert pycurl.CURLSTS_DONE == 1
+    assert pycurl.CURLSTS_FAIL == 2

--- a/tests/test_fnmatch_cb.py
+++ b/tests/test_fnmatch_cb.py
@@ -1,0 +1,34 @@
+import sys
+
+import pycurl
+import pytest
+
+from . import util
+
+
+def _match(pattern, string):
+    return pycurl.FNMATCHFUNC_MATCH
+
+
+def _nomatch(pattern, string):
+    return pycurl.FNMATCHFUNC_NOMATCH
+
+
+@util.min_libcurl(7, 21, 0)
+def test_fnmatch_setopt_and_unset(curl):
+    curl.setopt(pycurl.FNMATCH_FUNCTION, _match)
+    curl.unsetopt(pycurl.FNMATCH_FUNCTION)
+
+
+@util.min_libcurl(7, 21, 0)
+def test_fnmatch_replace_refcount(curl):
+    before = sys.getrefcount(_match)
+    curl.setopt(pycurl.FNMATCH_FUNCTION, _match)
+    curl.setopt(pycurl.FNMATCH_FUNCTION, _nomatch)
+    assert sys.getrefcount(_match) == before
+
+
+@util.min_libcurl(7, 21, 0)
+def test_fnmatch_rejects_noncallable(curl):
+    with pytest.raises(TypeError):
+        curl.setopt(pycurl.FNMATCH_FUNCTION, 42)

--- a/tests/test_hsts_cb.py
+++ b/tests/test_hsts_cb.py
@@ -1,0 +1,92 @@
+import sys
+
+import pycurl
+import pytest
+
+from . import util
+
+
+def _no_op_read():
+    return None
+
+
+def _no_op_write(entry, index):
+    return pycurl.CURLSTS_OK
+
+
+@util.min_libcurl(7, 74, 0)
+def test_hsts_file_path_setopt_and_unset(curl, tmp_path):
+    cache = tmp_path / "hsts.cache"
+    curl.setopt(pycurl.HSTS, str(cache))
+    curl.unsetopt(pycurl.HSTS)
+
+
+@util.min_libcurl(7, 74, 0)
+def test_hsts_ctrl_setopt(curl):
+    curl.setopt(pycurl.HSTS_CTRL, pycurl.CURLHSTS_ENABLE)
+
+
+@util.min_libcurl(7, 74, 0)
+def test_hstsread_setopt_and_unset(curl):
+    curl.setopt(pycurl.HSTSREADFUNCTION, _no_op_read)
+    curl.unsetopt(pycurl.HSTSREADFUNCTION)
+
+
+@util.min_libcurl(7, 74, 0)
+def test_hstswrite_setopt_and_unset(curl):
+    curl.setopt(pycurl.HSTSWRITEFUNCTION, _no_op_write)
+    curl.unsetopt(pycurl.HSTSWRITEFUNCTION)
+
+
+@util.min_libcurl(7, 74, 0)
+def test_hstsread_rejects_noncallable(curl):
+    with pytest.raises(TypeError):
+        curl.setopt(pycurl.HSTSREADFUNCTION, 42)
+
+
+@util.min_libcurl(7, 74, 0)
+def test_hstswrite_rejects_noncallable(curl):
+    with pytest.raises(TypeError):
+        curl.setopt(pycurl.HSTSWRITEFUNCTION, 42)
+
+
+@util.min_libcurl(7, 74, 0)
+def test_hstsread_set_none_unsets(curl):
+    curl.setopt(pycurl.HSTSREADFUNCTION, _no_op_read)
+    curl.setopt(pycurl.HSTSREADFUNCTION, None)
+
+
+@util.min_libcurl(7, 74, 0)
+def test_hstswrite_set_none_unsets(curl):
+    curl.setopt(pycurl.HSTSWRITEFUNCTION, _no_op_write)
+    curl.setopt(pycurl.HSTSWRITEFUNCTION, None)
+
+
+@util.min_libcurl(7, 74, 0)
+def test_hsts_entry_and_index_are_namedtuples():
+    entry = pycurl.HstsEntry(host=b"example.com", expire=None, include_subdomains=True)
+    assert entry.host == b"example.com"
+    assert entry.expire is None
+    assert entry.include_subdomains is True
+    assert entry == (b"example.com", None, True)
+
+    index = pycurl.HstsIndex(index=0, total=1)
+    assert index.index == 0
+    assert index.total == 1
+    assert index == (0, 1)
+
+
+@util.min_libcurl(7, 74, 0)
+def test_hstsread_replace_refcount(curl):
+    before = sys.getrefcount(_no_op_read)
+    curl.setopt(pycurl.HSTSREADFUNCTION, _no_op_read)
+    curl.setopt(pycurl.HSTSREADFUNCTION, lambda: None)
+    assert sys.getrefcount(_no_op_read) == before
+
+
+@util.min_libcurl(7, 74, 0)
+def test_hstswrite_replace_refcount(curl):
+    before = sys.getrefcount(_no_op_write)
+    curl.setopt(pycurl.HSTSWRITEFUNCTION, _no_op_write)
+    curl.setopt(pycurl.HSTSWRITEFUNCTION, lambda entry, index: pycurl.CURLSTS_OK)
+    assert sys.getrefcount(_no_op_write) == before

--- a/tests/test_resolver_start_cb.py
+++ b/tests/test_resolver_start_cb.py
@@ -1,0 +1,53 @@
+from io import BytesIO
+
+import pycurl
+import pytest
+
+from . import util
+
+
+def _configure(curl, app):
+    curl.setopt(pycurl.URL, f"{app}/success")
+    curl.setopt(pycurl.WRITEFUNCTION, BytesIO().write)
+
+
+@util.min_libcurl(7, 59, 0)
+def test_resolver_start_callback_fires(app, curl):
+    calls = []
+
+    def cb():
+        calls.append(True)
+        return 0
+
+    _configure(curl, app)
+    curl.setopt(pycurl.RESOLVER_START_FUNCTION, cb)
+    curl.perform()
+
+    assert calls  # called at least once
+
+
+@util.min_libcurl(7, 59, 0)
+def test_resolver_start_callback_abort(app, curl):
+    _configure(curl, app)
+    curl.setopt(pycurl.RESOLVER_START_FUNCTION, lambda: 1)
+    with pytest.raises(pycurl.error):
+        curl.perform()
+
+
+@util.min_libcurl(7, 59, 0)
+def test_resolver_start_callback_unset(app, curl):
+    _configure(curl, app)
+    curl.setopt(pycurl.RESOLVER_START_FUNCTION, lambda: 0)
+    curl.unsetopt(pycurl.RESOLVER_START_FUNCTION)
+    curl.perform()
+
+
+@util.min_libcurl(7, 59, 0)
+def test_resolver_start_callback_exception_aborts(app, curl):
+    def cb():
+        raise RuntimeError("boom")
+
+    _configure(curl, app)
+    curl.setopt(pycurl.RESOLVER_START_FUNCTION, cb)
+    with pytest.raises(pycurl.error):
+        curl.perform()

--- a/tests/test_trailer_cb.py
+++ b/tests/test_trailer_cb.py
@@ -1,0 +1,40 @@
+import sys
+
+import pycurl
+import pytest
+
+from . import util
+
+
+def _no_trailers():
+    return None
+
+
+def _some_trailers():
+    return ["X-Test: v"]
+
+
+@util.min_libcurl(7, 64, 0)
+def test_trailer_setopt_and_unset(curl):
+    curl.setopt(pycurl.TRAILERFUNCTION, _no_trailers)
+    curl.unsetopt(pycurl.TRAILERFUNCTION)
+
+
+@util.min_libcurl(7, 64, 0)
+def test_trailer_replace_refcount(curl):
+    before = sys.getrefcount(_no_trailers)
+    curl.setopt(pycurl.TRAILERFUNCTION, _no_trailers)
+    curl.setopt(pycurl.TRAILERFUNCTION, _some_trailers)
+    assert sys.getrefcount(_no_trailers) == before
+
+
+@util.min_libcurl(7, 64, 0)
+def test_trailer_rejects_noncallable(curl):
+    with pytest.raises(TypeError):
+        curl.setopt(pycurl.TRAILERFUNCTION, 42)
+
+
+@util.min_libcurl(7, 64, 0)
+def test_trailer_set_none_unsets(curl):
+    curl.setopt(pycurl.TRAILERFUNCTION, _some_trailers)
+    curl.setopt(pycurl.TRAILERFUNCTION, None)


### PR DESCRIPTION
- Expose `CURLOPT_TRAILERFUNCTION` with `TRAILERFUNC_OK` / `TRAILERFUNC_ABORT` (libcurl 7.64+).
- Expose `CURLOPT_RESOLVER_START_FUNCTION` (7.59+).
- Expose `CURLOPT_FNMATCH_FUNCTION` with `FNMATCHFUNC_MATCH` / `NOMATCH` / `FAIL` (7.21+).
- Expose `CURLOPT_HSTS` (file path) and `CURLOPT_HSTS_CTRL` with `CURLHSTS_ENABLE` / `CURLHSTS_READONLYFILE` (7.74+).
- Expose `CURLOPT_HSTSREADFUNCTION` and `CURLOPT_HSTSWRITEFUNCTION` with `CURLSTS_OK` / `DONE` / `FAIL` (7.74+). Entries are delivered as `pycurl.HstsEntry` / `HstsIndex` namedtuples; `expire` is a tz-aware UTC `datetime` or `None` for never-expires entries.
- Update docs.
- One pytest module per callback family.
