### PR TITLE
Integrate websockets in pycurl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,9 @@ RSYNC_USER = armco@web.sourceforge.net
 # src/module.c is first because it declares global variables
 # which other files reference; important for single source build
 SOURCES = src/easy.c src/easycb.c src/easyinfo.c src/easyopt.c src/easyperform.c \
-	src/mime.c src/module.c src/multi.c src/oscompat.c src/pythoncompat.c \
-	src/share.c src/stringcompat.c src/threadsupport.c src/util.c
+	src/easyws.c src/mime.c src/module.c src/multi.c src/oscompat.c \
+	src/pythoncompat.c src/share.c src/stringcompat.c src/threadsupport.c \
+	src/util.c
 
 GEN_SOURCES = src/docstrings.c src/docstrings.h
 
@@ -64,6 +65,11 @@ DOCSTRINGS_SOURCES = \
 	doc/docstrings/curl_reset.rst \
 	doc/docstrings/curl_send.rst \
 	doc/docstrings/curl_setopt.rst \
+	doc/docstrings/curl_ws_close.rst \
+	doc/docstrings/curl_ws_meta.rst \
+	doc/docstrings/curl_ws_recv.rst \
+	doc/docstrings/curl_ws_recv_into.rst \
+	doc/docstrings/curl_ws_send.rst \
 	doc/docstrings/curl_share.rst \
 	doc/docstrings/curl_unpause.rst \
 	doc/docstrings/curl_unsetopt.rst \

--- a/doc/callbacks.rst
+++ b/doc/callbacks.rst
@@ -579,6 +579,63 @@ HSTSREADFUNCTION
     as the value or by calling :ref:`unsetopt <unsetopt>`.
 
 
+WebSocket callback receive (libcurl 7.86.0 or later)
+----------------------------------------------------
+
+libcurl supports two WebSocket usage models: *detached mode*
+(``CONNECT_ONLY=2`` plus ``ws_send`` / ``ws_recv``, documented on the
+:ref:`Curl object <curlobject>`) and *callback-receive mode*, where
+libcurl drives the transfer and delivers each received frame chunk
+through the ordinary ``WRITEFUNCTION`` callback. No separate callback
+registration is required — set ``WRITEFUNCTION`` on a ``ws://`` /
+``wss://`` URL, leave ``CONNECT_ONLY`` unset, and call
+:ref:`perform <perform>` as you would for any other transfer.
+``perform()`` blocks for the full lifetime of the WebSocket connection
+and returns when the peer closes (or the transfer otherwise terminates),
+so the server side must have a predictable end condition.
+
+Inside the callback, :py:meth:`pycurl.Curl.ws_meta` returns a ``WsFrame``
+namedtuple (``age``, ``flags``, ``offset``, ``bytesleft``, ``len``)
+describing the chunk currently being delivered. The ``flags`` field is
+a bitmask of ``WS_TEXT``, ``WS_BINARY``, ``WS_CONT``, ``WS_PING``,
+``WS_PONG``, ``WS_CLOSE``, and ``WS_OFFSET``.
+
+libcurl's ``curl_ws_meta()`` returns ``NULL`` outside the valid
+callback context; PycURL maps that to Python ``None``. The same
+``ws_meta()`` method is safe to call after ``perform()`` has returned
+(it simply returns ``None``) and in detached mode (likewise).
+
+Calling :py:meth:`ws_send` or :py:meth:`ws_close` from inside the
+``WRITEFUNCTION`` is allowed: libcurl treats the call as a blocking send
+and returns only once the frame has been fully written (or an error
+occurs). ``CURLE_AGAIN`` / ``BlockingIOError`` semantics do not apply in
+this context. That relaxation applies only inside the callback itself;
+calls from another thread while ``perform()`` is running are still
+rejected. :py:meth:`ws_recv` and :py:meth:`ws_recv_into` remain
+detached-only and still raise ``pycurl.error`` while ``perform()`` is
+running.
+
+Example::
+
+    import pycurl
+
+    c = pycurl.Curl()
+
+    def on_ws_chunk(data):
+        meta = c.ws_meta()           # valid only inside this callback
+        if meta is not None and meta.flags & pycurl.WS_TEXT:
+            print("text chunk:", data)
+            c.ws_send(b"ack", pycurl.WS_BINARY)   # blocking send
+        return len(data)
+
+    c.setopt(c.URL, "wss://example.com/socket")
+    c.setopt(c.WRITEFUNCTION, on_ws_chunk)
+    c.perform()                       # blocks until peer closes
+    c.close()
+
+`ws_callback.py example`_ is a complete runnable version.
+
+
 .. _CURLOPT_HEADERFUNCTION: https://curl.haxx.se/libcurl/c/CURLOPT_HEADERFUNCTION.html
 .. _CURLOPT_WRITEFUNCTION: https://curl.haxx.se/libcurl/c/CURLOPT_WRITEFUNCTION.html
 .. _CURLOPT_READFUNCTION: https://curl.haxx.se/libcurl/c/CURLOPT_READFUNCTION.html
@@ -610,3 +667,4 @@ HSTSREADFUNCTION
 .. _CURLOPT_FNMATCH_FUNCTION: https://curl.se/libcurl/c/CURLOPT_FNMATCH_FUNCTION.html
 .. _CURLOPT_HSTSREADFUNCTION: https://curl.se/libcurl/c/CURLOPT_HSTSREADFUNCTION.html
 .. _CURLOPT_HSTSWRITEFUNCTION: https://curl.se/libcurl/c/CURLOPT_HSTSWRITEFUNCTION.html
+.. _ws_callback.py example: https://github.com/pycurl/pycurl/blob/master/examples/ws_callback.py

--- a/doc/curlobject.rst
+++ b/doc/curlobject.rst
@@ -50,3 +50,62 @@ Curl Object
     .. automethod:: pycurl.Curl.errstr_raw
 
     .. automethod:: pycurl.Curl.setopt_string
+
+    WebSocket methods (libcurl 7.86.0 or later):
+
+    .. _ws_send:
+    .. automethod:: pycurl.Curl.ws_send
+
+    .. _ws_recv:
+    .. automethod:: pycurl.Curl.ws_recv
+
+    .. _ws_recv_into:
+    .. automethod:: pycurl.Curl.ws_recv_into
+
+    .. _ws_meta:
+    .. automethod:: pycurl.Curl.ws_meta
+
+    .. _ws_close:
+    .. automethod:: pycurl.Curl.ws_close
+
+    PycURL supports libcurl's two documented WebSocket usage models:
+
+    - **Detached mode.** Set ``CONNECT_ONLY`` to ``2``, call
+      :py:meth:`perform` to drive the handshake, and then drive the
+      connection yourself with :py:meth:`ws_send` and :py:meth:`ws_recv`
+      (or :py:meth:`ws_recv_into`). In this mode, frame metadata is
+      returned as the second element of each receive call's result.
+    - **Callback-receive mode.** Set a ``WRITEFUNCTION`` callback, leave
+      ``CONNECT_ONLY`` unset (or ``0``), and call :py:meth:`perform`.
+      libcurl drives the transfer and delivers each received frame
+      chunk to the write callback. Call :py:meth:`ws_meta` from inside
+      the callback to retrieve the current chunk's ``WsFrame`` metadata;
+      ``ws_meta()`` returns ``None`` outside that context.
+
+    PycURL does not reassemble fragmented messages or manage the
+    WebSocket close handshake. libcurl automatically replies to ping
+    frames unless ``WS_NOAUTOPONG`` or ``WS_RAW_MODE`` is enabled.
+
+    Frame metadata is exposed through the module-level ``WsFrame``
+    namedtuple (``age``, ``flags``, ``offset``, ``bytesleft``, ``len``).
+    The ``flags`` field is a bitmask of the ``WS_*`` constants.
+
+    **Caveats and sharp edges:**
+
+    - **Do not combine ``CONNECT_ONLY=2`` with ``FORBID_REUSE``** —
+      libcurl tears down the connection after the handshake
+      ``perform()`` returns and the first ``ws_send()`` fails with
+      ``CURLE_UNSUPPORTED_PROTOCOL``.
+    - **A WebSocket handle is not thread-safe** — see
+      :ref:`thread-safety`.
+    - **``WS_RAW_MODE`` (via ``CURLOPT_WS_OPTIONS``) changes framing
+      semantics.** libcurl ignores ``ws_send``'s ``flags`` argument and
+      writes bytes verbatim. Raw-mode callers should pass bytes-like
+      data; Python-side ``str``/bytes inference still runs but the
+      flag bits never reach the wire.
+    - **Replying inside a ``WRITEFUNCTION`` is allowed** — see
+      :ref:`callbacks`. ``ws_send``/``ws_close`` behave as blocking
+      sends in that context; ``ws_recv`` / ``ws_recv_into`` remain
+      detached-only.
+    - **Runtime probe**: ``'ws' in pycurl.version_info()[8]``.
+      Compile-time: ``hasattr(pycurl, 'WS_TEXT')``.

--- a/doc/docstrings/curl_ws_close.rst
+++ b/doc/docstrings/curl_ws_close.rst
@@ -1,0 +1,35 @@
+ws_close(code=None, reason=None, encoding='utf-8') -> count
+
+Send a WebSocket close frame. In detached mode this requires
+``CONNECT_ONLY=2``; inside an active ``WRITEFUNCTION`` callback it may
+also be used to send a blocking reply.
+
+Builds an RFC 6455 §5.5.1 close payload — an optional 2-byte big-endian
+status *code* followed by an optional UTF-8 *reason* — and sends it as
+a ``WS_CLOSE`` control frame. Prefer this over
+``ws_send(bytes, WS_CLOSE)``: the payload format is non-obvious.
+
+*code* is the WebSocket close status code. Omitted (``None``) sends an
+empty close payload. When specified, must be a valid wire code per RFC
+6455 §7.4.1: ``1000`` (normal), ``1001`` (going away), ``1002``, ``1003``,
+``1007``-``1014``, or a private-use value in ``3000..4999``. Codes
+``1004``, ``1005``, ``1006``, ``1015`` are RFC-forbidden to send and
+rejected.
+
+*reason* may be a ``str`` or any bytes-like object. ``str`` is encoded
+with *encoding* (UTF-8 by default). The resulting bytes must be valid
+UTF-8 on the wire; invalid UTF-8 raises ``UnicodeDecodeError``,
+non-encodable input raises ``UnicodeEncodeError``. ``reason`` without
+``code`` raises ``ValueError``. The combined payload (2-byte code +
+reason) must not exceed 125 bytes (RFC 6455 §5.5).
+
+Returns the number of bytes accepted by libcurl.
+
+Same blocking / non-blocking semantics as :py:meth:`ws_send`. Calls
+from other threads while ``perform()`` is running are rejected.
+
+Corresponds to `curl_ws_send`_ with ``CURLWS_CLOSE``. Requires libcurl
+7.86.0 or later. Raises ``pycurl.error`` for libcurl failures other
+than ``CURLE_AGAIN``.
+
+.. _curl_ws_send: https://curl.se/libcurl/c/curl_ws_send.html

--- a/doc/docstrings/curl_ws_meta.rst
+++ b/doc/docstrings/curl_ws_meta.rst
@@ -1,0 +1,24 @@
+ws_meta() -> WsFrame or None
+
+Return a snapshot of the current WebSocket frame's metadata.
+
+This is a callback-context helper. It is intended to be called from
+inside an active ``WRITEFUNCTION`` callback on a WebSocket transfer,
+where it returns a ``WsFrame`` namedtuple with the metadata of the
+chunk currently being delivered.
+
+Outside that context — including when used in detached mode
+(``CONNECT_ONLY=2``), after ``perform()`` has returned, or on a
+non-WebSocket transfer — libcurl's ``curl_ws_meta()`` returns ``NULL``
+and PycURL maps that ``NULL`` to Python ``None``. No exception is
+raised; callers can use ``if c.ws_meta() is None`` to probe context
+validity.
+
+In detached mode, prefer the metadata returned directly by
+``ws_recv()`` / ``ws_recv_into()`` rather than a separate ``ws_meta()``
+call.
+
+Corresponds to `curl_ws_meta`_ in libcurl. Requires libcurl 7.86.0 or
+later.
+
+.. _curl_ws_meta: https://curl.se/libcurl/c/curl_ws_meta.html

--- a/doc/docstrings/curl_ws_recv.rst
+++ b/doc/docstrings/curl_ws_recv.rst
@@ -1,0 +1,32 @@
+ws_recv(buffersize) -> (data, meta)
+
+Receive a WebSocket frame chunk on a connection established with
+``CONNECT_ONLY=2``.
+
+Receive up to *buffersize* bytes. Returns a 2-tuple ``(data, meta)``
+where *data* is a ``bytes`` object containing the received payload chunk
+and *meta* is a ``WsFrame`` namedtuple carrying the per-frame metadata
+returned by libcurl for this call (``age``, ``flags``, ``offset``,
+``bytesleft``, ``len``).
+
+A single call may return only part of a frame's payload: check
+``meta.bytesleft`` to decide whether to loop. Reassembly of fragmented
+messages is the caller's responsibility.
+
+A *buffersize* of ``0`` performs a zero-length ``curl_ws_recv`` call.
+This returns ``(b"", meta)`` so callers can inspect frame metadata
+without consuming payload bytes. Frames with empty payload are consumed
+by this action.
+
+Raises ``ValueError`` if *buffersize* is negative.
+
+Corresponds to `curl_ws_recv`_ in libcurl. Requires libcurl 7.86.0 or
+later.
+
+Because the underlying socket is used in non-blocking mode internally,
+this method raises ``BlockingIOError`` with ``errno`` set to ``EAGAIN``
+when libcurl returns ``CURLE_AGAIN``.
+
+Raises pycurl.error exception upon failures other than ``CURLE_AGAIN``.
+
+.. _curl_ws_recv: https://curl.se/libcurl/c/curl_ws_recv.html

--- a/doc/docstrings/curl_ws_recv_into.rst
+++ b/doc/docstrings/curl_ws_recv_into.rst
@@ -1,0 +1,33 @@
+ws_recv_into(buffer[, nbytes]) -> (nbytes, meta)
+
+Receive a WebSocket frame chunk on a connection established with
+``CONNECT_ONLY=2`` into a caller-owned writable *buffer*.
+
+*buffer* must be a writable bytes-like object (e.g. ``bytearray``,
+``memoryview``, ``array.array``).
+
+If *nbytes* is ``0`` (the default), receive up to ``len(buffer)`` bytes.
+Otherwise, receive up to *nbytes* bytes.
+
+Returns a 2-tuple ``(nbytes, meta)`` where *nbytes* is the number of
+bytes written into *buffer* and *meta* is a ``WsFrame`` namedtuple with
+the per-frame metadata returned by libcurl for this call.
+
+Raises ``ValueError`` if *nbytes* is negative or larger than
+``len(buffer)``.
+
+If *buffer* has length ``0``, this performs a zero-length
+``curl_ws_recv`` call and returns ``(0, meta)`` so callers can inspect
+frame metadata without consuming payload bytes. Frames with empty
+payload are consumed by this action.
+
+Corresponds to `curl_ws_recv`_ in libcurl. Requires libcurl 7.86.0 or
+later.
+
+Because the underlying socket is used in non-blocking mode internally,
+this method raises ``BlockingIOError`` with ``errno`` set to ``EAGAIN``
+when libcurl returns ``CURLE_AGAIN``.
+
+Raises pycurl.error exception upon failures other than ``CURLE_AGAIN``.
+
+.. _curl_ws_recv: https://curl.se/libcurl/c/curl_ws_recv.html

--- a/doc/docstrings/curl_ws_send.rst
+++ b/doc/docstrings/curl_ws_send.rst
@@ -1,0 +1,35 @@
+ws_send(data, flags=None, fragsize=0, encoding='utf-8') -> count
+
+Send a WebSocket frame. In detached mode this requires ``CONNECT_ONLY=2``;
+inside an active ``WRITEFUNCTION`` callback it may also be used to send
+a blocking reply.
+
+*data* may be a ``str`` or any bytes-like object. ``str`` is encoded
+with *encoding* (UTF-8 by default); characters that are not
+representable in *encoding* raise ``UnicodeEncodeError``. Passing
+``None`` raises ``TypeError`` — use ``b""`` for an empty payload.
+
+*flags* is a bitmask built from the frame-type constants ``WS_TEXT``,
+``WS_BINARY``, ``WS_CONT``, ``WS_CLOSE``, ``WS_PING``, ``WS_PONG``. When
+``flags`` is omitted (``None``), the frame type is inferred: ``str`` ->
+``WS_TEXT``, bytes-like -> ``WS_BINARY``. Explicit flags win. ``str`` +
+``WS_BINARY`` and ``str`` + ``WS_CLOSE`` raise ``TypeError`` (use
+:py:meth:`ws_close` for close frames, or pass bytes-like data).
+
+*fragsize* maps to ``curl_ws_send``'s ``fragsize`` parameter; ``0``
+means "whole message". ``WS_OFFSET`` is the companion flag for
+multi-call fragmented sends; see the libcurl docs for the rules.
+
+Returns the number of bytes accepted by libcurl.
+
+Raises ``BlockingIOError`` (``errno=EAGAIN``) in detached mode when
+libcurl returns ``CURLE_AGAIN``. Inside a ``WRITEFUNCTION`` callback
+libcurl treats the call as blocking and returns only once the frame has
+been fully sent; ``BlockingIOError`` does not apply. Calls from other
+threads while ``perform()`` is running are rejected.
+
+Corresponds to `curl_ws_send`_ in libcurl. Requires libcurl 7.86.0 or
+later. Raises ``pycurl.error`` for libcurl failures other than
+``CURLE_AGAIN``.
+
+.. _curl_ws_send: https://curl.se/libcurl/c/curl_ws_send.html

--- a/doc/thread-safety.rst
+++ b/doc/thread-safety.rst
@@ -28,6 +28,13 @@ For Python programs using PycURL, this means:
   option. The caller must ensure that no other thread is using the
   associated ``Curl`` objects while ``CurlShare.close()`` is executing.
 
+* A WebSocket handle (``CONNECT_ONLY=2`` plus ``ws_send`` / ``ws_recv``)
+  follows the same one-handle-one-thread rule: do not call ``ws_send``
+  from one thread while ``ws_recv`` runs on another. Serialise access
+  with a lock. Calls from another thread while ``perform()`` is running
+  are unsafe unless they happen inside that handle's active
+  ``WRITEFUNCTION`` callback.
+
 PycURL handles the necessary SSL locks for OpenSSL/LibreSSL/BoringSSL,
 GnuTLS, NSS, mbedTLS and wolfSSL.
 

--- a/examples/ws_callback.py
+++ b/examples/ws_callback.py
@@ -1,0 +1,79 @@
+#! /usr/bin/env python
+"""WebSocket client using callback-receive mode.
+
+This example starts a tiny local websocket server with the ``websockets``
+package so the transfer always receives one frame and terminates
+predictably.
+"""
+
+import asyncio
+from pathlib import Path
+import socket
+import sys
+import threading
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pycurl
+import websockets
+
+
+def _free_port():
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _start_server(port):
+    ready = threading.Event()
+    stop = {}
+
+    def run():
+        async def handler(ws):
+            await ws.send("hello")
+            await ws.close()
+
+        async def main():
+            stop["loop"] = asyncio.get_running_loop()
+            stop["future"] = asyncio.get_running_loop().create_future()
+            async with websockets.serve(handler, "127.0.0.1", port):
+                ready.set()
+                await stop["future"]
+
+        asyncio.run(main())
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    if not ready.wait(5.0):
+        raise RuntimeError("server failed to start")
+    return thread, stop
+
+
+port = _free_port()
+thread, stop = _start_server(port)
+c = pycurl.Curl()
+
+
+def on_ws_chunk(data):
+    meta = c.ws_meta()
+    if meta is not None:
+        if meta.flags & pycurl.WS_TEXT:
+            kind = "text"
+        elif meta.flags & pycurl.WS_BINARY:
+            kind = "binary"
+        elif meta.flags & pycurl.WS_CLOSE:
+            kind = "close"
+        else:
+            kind = "control"
+        print("%s chunk len=%d bytesleft=%d" % (kind, len(data), meta.bytesleft))
+    return len(data)
+
+
+try:
+    c.setopt(c.URL, "ws://127.0.0.1:%d" % port)
+    c.setopt(c.WRITEFUNCTION, on_ws_chunk)
+    c.perform()
+finally:
+    c.close()
+    stop["loop"].call_soon_threadsafe(stop["future"].set_result, None)
+    thread.join(timeout=5.0)

--- a/examples/ws_echo.py
+++ b/examples/ws_echo.py
@@ -1,0 +1,16 @@
+#! /usr/bin/env python
+"""Minimal WebSocket echo client (detached mode)."""
+
+import pycurl
+
+c = pycurl.Curl()
+c.setopt(c.URL, "wss://echo.websocket.events/")
+c.setopt(c.CONNECT_ONLY, 2)
+c.perform()
+
+c.ws_send("hello")  # str -> WS_TEXT (UTF-8 encoded)
+data, meta = c.ws_recv(4096)
+print("recv:", data, "flags:", meta.flags)
+
+c.ws_close(1000, "normal closure")
+c.close()

--- a/examples/ws_fragmented.py
+++ b/examples/ws_fragmented.py
@@ -1,0 +1,27 @@
+#! /usr/bin/env python
+"""WebSocket client that reassembles fragmented frames (detached mode).
+
+Loops ws_recv() with a small buffer until meta.bytesleft == 0.
+"""
+
+import pycurl
+
+c = pycurl.Curl()
+c.setopt(c.URL, "wss://echo.websocket.events/")
+c.setopt(c.CONNECT_ONLY, 2)
+c.perform()
+
+c.ws_send("send me a long reply" * 32)  # str -> WS_TEXT
+
+parts = []
+while True:
+    chunk, meta = c.ws_recv(64)
+    parts.append(chunk)
+    if meta.bytesleft == 0:
+        break
+
+message = b"".join(parts)
+print("reassembled %d bytes, last flags=%#x" % (len(message), meta.flags))
+
+c.ws_close()
+c.close()

--- a/examples/ws_multi.py
+++ b/examples/ws_multi.py
@@ -1,0 +1,55 @@
+#! /usr/bin/env python
+"""Drive several WebSocket connections concurrently with CurlMulti.
+
+The handshake runs through the multi interface; once every handle has
+completed the upgrade, we select() on the underlying sockets and use
+ws_send / ws_recv on whichever handle becomes readable.
+"""
+
+import select
+import pycurl
+
+URLS = ["wss://echo.websocket.events/"] * 3
+
+handles = []
+m = pycurl.CurlMulti()
+for url in URLS:
+    c = pycurl.Curl()
+    c.setopt(c.URL, url)
+    c.setopt(c.CONNECT_ONLY, 2)
+    m.add_handle(c)
+    handles.append(c)
+
+# Drive the handshakes concurrently via the multi interface.
+_, num_handles = m.perform()
+while num_handles:
+    m.select(1.0)
+    _, num_handles = m.perform()
+
+# Every handle has finished the WebSocket upgrade — collect results.
+_, done, failed = m.info_read()
+if failed:
+    raise RuntimeError("WebSocket handshake failed: %r" % (failed,))
+
+fd_to_curl = {c.getinfo(pycurl.ACTIVESOCKET): c for c in handles}
+for c in handles:
+    c.ws_send("hello")
+
+# Read one reply from each handle. A real application would keep
+# looping on select() for as long as it has work to do; this demo
+# simply waits until each connection has produced its echoed frame.
+pending = set(fd_to_curl)
+while pending:
+    readable, _, _ = select.select(list(pending), [], [], 5.0)
+    if not readable:
+        raise TimeoutError("no reply within 5s for handles %r" % (pending,))
+    for fd in readable:
+        data, meta = fd_to_curl[fd].ws_recv(4096)
+        print(fd, data, "flags=", meta.flags)
+        pending.discard(fd)
+
+for c in handles:
+    c.ws_close()
+    m.remove_handle(c)
+    c.close()
+m.close()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pyflakes
 pytest>=5
 sphinx
 setuptools
+websockets>=12

--- a/setup.py
+++ b/setup.py
@@ -622,6 +622,7 @@ def get_extension(argv, split_extension_source=False):
             os.path.join("src", "easyinfo.c"),
             os.path.join("src", "easyopt.c"),
             os.path.join("src", "easyperform.c"),
+            os.path.join("src", "easyws.c"),
             os.path.join("src", "module.c"),
             os.path.join("src", "mime.c"),
             os.path.join("src", "multi.c"),

--- a/src/easy.c
+++ b/src/easy.c
@@ -964,6 +964,13 @@ PYCURL_INTERNAL PyMethodDef curlobject_methods[] = {
 #if defined(HAVE_CURL_OPENSSL)
     {"set_ca_certs", (PyCFunction)do_curl_set_ca_certs, METH_VARARGS, curl_set_ca_certs_doc},
 #endif
+#ifdef HAVE_CURL_WEBSOCKETS
+    {"ws_send", (PyCFunction)do_curl_ws_send, METH_VARARGS | METH_KEYWORDS, curl_ws_send_doc},
+    {"ws_recv", (PyCFunction)do_curl_ws_recv, METH_VARARGS, curl_ws_recv_doc},
+    {"ws_recv_into", (PyCFunction)do_curl_ws_recv_into, METH_VARARGS | METH_KEYWORDS, curl_ws_recv_into_doc},
+    {"ws_meta", (PyCFunction)do_curl_ws_meta, METH_NOARGS, curl_ws_meta_doc},
+    {"ws_close", (PyCFunction)do_curl_ws_close, METH_VARARGS | METH_KEYWORDS, curl_ws_close_doc},
+#endif
     {"__getstate__", (PyCFunction)do_curl_getstate, METH_NOARGS, NULL},
     {"__setstate__", (PyCFunction)do_curl_setstate, METH_VARARGS, NULL},
     {"__enter__", (PyCFunction)do_curl_enter, METH_NOARGS, NULL},

--- a/src/easycb.c
+++ b/src/easycb.c
@@ -39,6 +39,8 @@ util_write_callback(int flags, char *ptr, size_t size, size_t nmemb, void *strea
     size_t ret = 0;     /* assume error */
     PyObject *cb;
     Py_ssize_t total_size;
+    int track_ws_write_callback;
+    int prev_ws_write_callback = 0;
     PYCURL_DECLARE_THREAD_STATE;
 
     /* acquire thread */
@@ -62,7 +64,15 @@ util_write_callback(int flags, char *ptr, size_t size, size_t nmemb, void *strea
     arglist = Py_BuildValue("(y#)", ptr, total_size);
     if (arglist == NULL)
         goto verbose_error;
+    track_ws_write_callback = (flags == 0);
+    if (track_ws_write_callback) {
+        prev_ws_write_callback = self->ws_write_cb_running;
+        self->ws_write_cb_running = 1;
+    }
     result = PyObject_Call(cb, arglist, NULL);
+    if (track_ws_write_callback) {
+        self->ws_write_cb_running = prev_ws_write_callback;
+    }
     Py_DECREF(arglist);
     if (result == NULL)
         goto verbose_error;

--- a/src/easyperform.c
+++ b/src/easyperform.c
@@ -82,7 +82,7 @@ do_curl_perform_rs(CurlObject *self, PyObject *Py_UNUSED(ignored))
 
 /* --------------- send/recv --------------- */
 
-static PyObject *
+PYCURL_INTERNAL PyObject *
 set_would_block_error(void)
 {
     errno = EAGAIN;
@@ -90,7 +90,7 @@ set_would_block_error(void)
     return NULL;
 }
 
-static int
+PYCURL_INTERNAL int
 check_easy_recv_send_result(CurlObject *self, CURLcode res)
 {
     if (res == CURLE_OK) {

--- a/src/easyws.c
+++ b/src/easyws.c
@@ -1,0 +1,552 @@
+#include "pycurl.h"
+
+#ifdef HAVE_CURL_WEBSOCKETS
+
+#include <errno.h>
+
+/* Build a WsFrame namedtuple snapshot from a libcurl frame struct.
+   Returns None if meta is NULL, a new reference to a WsFrame otherwise.
+   The libcurl-owned pointer is never stored past this call. */
+static PyObject *
+build_ws_frame(const struct curl_ws_frame *meta)
+{
+    if (meta == NULL) {
+        Py_RETURN_NONE;
+    }
+    return PyObject_CallFunction(ws_frame_type, "iiKKK",
+        meta->age,
+        meta->flags,
+        (unsigned long long)meta->offset,
+        (unsigned long long)meta->bytesleft,
+        (unsigned long long)meta->len);
+}
+
+static int
+check_ws_curl_state(const CurlObject *self, int allow_write_callback,
+                    const char *name)
+{
+    PyThreadState *callback_state;
+
+    assert_curl_state(self);
+    if (self->handle == NULL) {
+        PyErr_Format(ErrorObject, "cannot invoke %s() - no curl handle", name);
+        return -1;
+    }
+    callback_state = pycurl_get_thread_state(self);
+    if (callback_state != NULL) {
+        if (allow_write_callback
+            && self->ws_write_cb_running
+            && PyThreadState_Get() == callback_state) {
+            return 0;
+        }
+        if (allow_write_callback) {
+            PyErr_Format(ErrorObject,
+                "cannot invoke %s() - perform() is currently running "
+                "outside WRITEFUNCTION callback", name);
+        } else {
+            PyErr_Format(ErrorObject,
+                "cannot invoke %s() - perform() is currently running", name);
+        }
+        return -1;
+    }
+    return 0;
+}
+
+static int
+is_valid_ws_close_code(long code)
+{
+    switch (code) {
+    case 1000:
+    case 1001:
+    case 1002:
+    case 1003:
+    case 1007:
+    case 1008:
+    case 1009:
+    case 1010:
+    case 1011:
+    case 1012:
+    case 1013:
+    case 1014:
+        return 1;
+    default:
+        return code >= 3000 && code <= 4999;
+    }
+}
+
+static int
+validate_ws_close_reason_utf8(const char *reason_ptr, Py_ssize_t reason_len)
+{
+    PyObject *decoded;
+
+    if (reason_len == 0) {
+        return 0;
+    }
+    decoded = PyUnicode_DecodeUTF8(reason_ptr, reason_len, "strict");
+    if (decoded == NULL) {
+        return -1;
+    }
+    Py_DECREF(decoded);
+    return 0;
+}
+
+/* --------------- ws_send --------------- */
+
+PYCURL_INTERNAL PyObject *
+do_curl_ws_send(CurlObject *self, PyObject *args, PyObject *kwds)
+{
+    static char *kwlist[] = {"data", "flags", "fragsize", "encoding", NULL};
+    PyObject *data_obj = NULL;
+    PyObject *flags_obj = Py_None;
+    Py_ssize_t fragsize = 0;
+    const char *encoding = "utf-8";
+    unsigned int flags;
+    int flags_explicit;
+    int data_is_str;
+    PyObject *encoded_bytes = NULL;  /* owned if we UTF-8 encoded */
+    Py_buffer sendbuf;
+    int have_buffer = 0;
+    size_t sent = 0;
+    CURLcode res;
+    PyObject *result = NULL;
+    PyThreadState *saved_state;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|Ons:ws_send", kwlist,
+                                     &data_obj, &flags_obj, &fragsize, &encoding)) {
+        return NULL;
+    }
+    if (fragsize < 0) {
+        PyErr_SetString(PyExc_ValueError, "negative fragsize in ws_send");
+        return NULL;
+    }
+
+    flags_explicit = (flags_obj != Py_None);
+    if (flags_explicit) {
+        long long f = PyLong_AsLongLong(flags_obj);
+        if (f == -1 && PyErr_Occurred()) {
+            return NULL;
+        }
+        if (f < 0) {
+            PyErr_SetString(PyExc_ValueError, "flags must be non-negative");
+            return NULL;
+        }
+        if ((unsigned long long)f > (unsigned long long)UINT_MAX) {
+            PyErr_SetString(PyExc_OverflowError,
+                "flags out of range for curl_ws_send");
+            return NULL;
+        }
+        flags = (unsigned int)f;
+    } else {
+        flags = 0;
+    }
+
+    if (flags_explicit
+        && (flags & CURLWS_TEXT)
+        && (flags & CURLWS_BINARY)) {
+        PyErr_SetString(PyExc_ValueError,
+            "ws_send: cannot set both WS_TEXT and WS_BINARY");
+        return NULL;
+    }
+
+    if (flags_explicit) {
+        unsigned int control_bits =
+            flags & (CURLWS_PING | CURLWS_PONG | CURLWS_CLOSE);
+        if (control_bits && (flags & CURLWS_CONT)) {
+            PyErr_SetString(PyExc_ValueError,
+                "ws_send: control frames cannot be fragmented "
+                "(WS_CONT forbidden with WS_PING/WS_PONG/WS_CLOSE)");
+            return NULL;
+        }
+        if (control_bits & (control_bits - 1)) {
+            PyErr_SetString(PyExc_ValueError,
+                "ws_send: only one of WS_PING / WS_PONG / WS_CLOSE may be set");
+            return NULL;
+        }
+    }
+
+    if (data_obj == Py_None) {
+        PyErr_SetString(PyExc_TypeError,
+            "ws_send: data must be str or bytes-like, not NoneType "
+            "(use b\"\" for an empty payload)");
+        return NULL;
+    }
+
+    data_is_str = PyUnicode_Check(data_obj);
+    if (data_is_str) {
+        if (flags_explicit && (flags & CURLWS_BINARY)) {
+            PyErr_SetString(PyExc_TypeError,
+                "ws_send: str data is incompatible with WS_BINARY; "
+                "pass bytes-like data for binary frames");
+            return NULL;
+        }
+        if (flags_explicit && (flags & CURLWS_CLOSE)) {
+            PyErr_SetString(PyExc_TypeError,
+                "ws_send: str data is incompatible with WS_CLOSE; "
+                "use ws_close() or pass a bytes-like payload");
+            return NULL;
+        }
+        if (!flags_explicit) {
+            flags = CURLWS_TEXT;
+        }
+        encoded_bytes = PyUnicode_AsEncodedString(data_obj, encoding, "strict");
+        if (encoded_bytes == NULL) {
+            return NULL;
+        }
+        if (PyObject_GetBuffer(encoded_bytes, &sendbuf, PyBUF_SIMPLE) != 0) {
+            Py_DECREF(encoded_bytes);
+            return NULL;
+        }
+        have_buffer = 1;
+    } else {
+        /* bytes-like */
+        if (PyObject_GetBuffer(data_obj, &sendbuf, PyBUF_SIMPLE) != 0) {
+            return NULL;
+        }
+        have_buffer = 1;
+        if (!flags_explicit) {
+            flags = CURLWS_BINARY;
+        }
+    }
+
+    if (check_ws_curl_state(self, 1, "ws_send") != 0) {
+        goto cleanup;
+    }
+
+    /* Preserve the thread state across the libcurl call so nested
+     * Python callbacks (e.g. if we're already inside WRITEFUNCTION)
+     * retain their thread context. Mirrors do_curl_pause. */
+    if (self->multi_stack != NULL) {
+        saved_state = self->multi_stack->state;
+    } else {
+        saved_state = self->state;
+    }
+
+    PYCURL_BEGIN_ALLOW_THREADS_EASY
+    res = curl_ws_send(self->handle, sendbuf.buf, (size_t)sendbuf.len,
+                       &sent, (curl_off_t)fragsize, flags);
+    PYCURL_END_ALLOW_THREADS_EASY
+
+    if (self->multi_stack != NULL) {
+        self->multi_stack->state = saved_state;
+    } else {
+        self->state = saved_state;
+    }
+
+    if (check_pending_python_exception_or_signal() != 0) {
+        goto cleanup;
+    }
+    if (check_easy_recv_send_result(self, res) != 0) {
+        goto cleanup;
+    }
+    result = PyLong_FromSsize_t((Py_ssize_t)sent);
+
+cleanup:
+    if (have_buffer) {
+        PyBuffer_Release(&sendbuf);
+    }
+    Py_XDECREF(encoded_bytes);
+    return result;
+}
+
+/* --------------- ws_recv --------------- */
+
+PYCURL_INTERNAL PyObject *
+do_curl_ws_recv(CurlObject *self, PyObject *args)
+{
+    Py_ssize_t buflen;
+    size_t recvd = 0;
+    const struct curl_ws_frame *meta = NULL;
+    CURLcode res;
+    PyObject *data = NULL, *frame = NULL, *tuple = NULL;
+#if PY_VERSION_HEX >= 0x030F0000
+    PyBytesWriter *writer = NULL;
+    void *buf = NULL;
+#else
+    PyObject *bytes_obj = NULL;
+    char *buf = NULL;
+#endif
+
+    if (!PyArg_ParseTuple(args, "n:ws_recv", &buflen)) {
+        return NULL;
+    }
+    if (buflen < 0) {
+        PyErr_SetString(PyExc_ValueError, "negative buffersize in ws_recv");
+        return NULL;
+    }
+    if (check_curl_state(self, 1 | 2, "ws_recv") != 0) {
+        return NULL;
+    }
+#if PY_VERSION_HEX >= 0x030F0000
+    if (buflen > 0) {
+        writer = PyBytesWriter_Create(buflen);
+        if (writer == NULL) return NULL;
+        buf = PyBytesWriter_GetData(writer);
+    }
+#else
+    if (buflen > 0) {
+        bytes_obj = PyBytes_FromStringAndSize(NULL, buflen);
+        if (bytes_obj == NULL) return NULL;
+        buf = PyBytes_AS_STRING(bytes_obj);
+    }
+#endif
+
+    PYCURL_BEGIN_ALLOW_THREADS
+    res = curl_ws_recv(self->handle, buf, (size_t)buflen, &recvd, &meta);
+    PYCURL_END_ALLOW_THREADS
+
+    if (check_pending_python_exception_or_signal() != 0) {
+#if PY_VERSION_HEX >= 0x030F0000
+        if (writer != NULL) {
+            PyBytesWriter_Discard(writer);
+        }
+#else
+        Py_XDECREF(bytes_obj);
+#endif
+        return NULL;
+    }
+    if (check_easy_recv_send_result(self, res) != 0) {
+#if PY_VERSION_HEX >= 0x030F0000
+        if (writer != NULL) {
+            PyBytesWriter_Discard(writer);
+        }
+#else
+        Py_XDECREF(bytes_obj);
+#endif
+        return NULL;
+    }
+
+#if PY_VERSION_HEX >= 0x030F0000
+    if (writer != NULL) {
+        data = PyBytesWriter_FinishWithSize(writer, (Py_ssize_t)recvd);
+        if (data == NULL) return NULL;
+    } else {
+        data = PyBytes_FromStringAndSize("", 0);
+        if (data == NULL) return NULL;
+    }
+#else
+    if (bytes_obj == NULL) {
+        data = PyBytes_FromStringAndSize("", 0);
+        if (data == NULL) return NULL;
+    } else if ((Py_ssize_t)recvd == buflen) {
+        data = bytes_obj;
+    } else {
+        data = PyBytes_FromStringAndSize(buf, (Py_ssize_t)recvd);
+        Py_DECREF(bytes_obj);
+        if (data == NULL) return NULL;
+    }
+#endif
+
+    frame = build_ws_frame(meta);
+    if (frame == NULL) { Py_DECREF(data); return NULL; }
+    tuple = PyTuple_Pack(2, data, frame);
+    Py_DECREF(data); Py_DECREF(frame);
+    return tuple;
+}
+
+/* --------------- ws_recv_into --------------- */
+
+PYCURL_INTERNAL PyObject *
+do_curl_ws_recv_into(CurlObject *self, PyObject *args, PyObject *kwds)
+{
+    static char *kwlist[] = {"buffer", "nbytes", NULL};
+    Py_buffer recvbuf;
+    Py_ssize_t buflen;
+    Py_ssize_t recvlen = 0;
+    size_t recvd = 0;
+    const struct curl_ws_frame *meta = NULL;
+    CURLcode res;
+    PyObject *frame, *tuple;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "w*|n:ws_recv_into", kwlist,
+                                     &recvbuf, &recvlen)) {
+        return NULL;
+    }
+    buflen = recvbuf.len;
+    if (recvlen < 0) {
+        PyBuffer_Release(&recvbuf);
+        PyErr_SetString(PyExc_ValueError, "negative buffersize in ws_recv_into");
+        return NULL;
+    }
+    /* nbytes=0 (the default) means "use the full buffer". Either way,
+     * recvlen must not exceed the buffer itself. */
+    if (recvlen == 0) {
+        recvlen = buflen;
+    }
+    if (recvlen > buflen) {
+        PyBuffer_Release(&recvbuf);
+        PyErr_SetString(PyExc_ValueError, "buffer too small for requested bytes");
+        return NULL;
+    }
+    if (check_curl_state(self, 1 | 2, "ws_recv_into") != 0) {
+        PyBuffer_Release(&recvbuf);
+        return NULL;
+    }
+    PYCURL_BEGIN_ALLOW_THREADS
+    res = curl_ws_recv(self->handle,
+                       recvlen > 0 ? recvbuf.buf : NULL,
+                       (size_t)recvlen, &recvd, &meta);
+    PYCURL_END_ALLOW_THREADS
+
+    PyBuffer_Release(&recvbuf);
+
+    if (check_pending_python_exception_or_signal() != 0) {
+        return NULL;
+    }
+    if (check_easy_recv_send_result(self, res) != 0) {
+        return NULL;
+    }
+
+    frame = build_ws_frame(meta);
+    if (frame == NULL) return NULL;
+    tuple = Py_BuildValue("(nN)", (Py_ssize_t)recvd, frame);
+    return tuple;
+}
+
+/* --------------- ws_meta --------------- */
+
+PYCURL_INTERNAL PyObject *
+do_curl_ws_meta(CurlObject *self, PyObject *Py_UNUSED(ignored))
+{
+    const struct curl_ws_frame *meta;
+
+    if (check_curl_state(self, 1, "ws_meta") != 0) {
+        return NULL;
+    }
+    meta = curl_ws_meta(self->handle);
+    return build_ws_frame(meta);
+}
+
+/* --------------- ws_close --------------- */
+
+PYCURL_INTERNAL PyObject *
+do_curl_ws_close(CurlObject *self, PyObject *args, PyObject *kwds)
+{
+    static char *kwlist[] = {"code", "reason", "encoding", NULL};
+    PyObject *code_obj = Py_None;
+    PyObject *reason_obj = Py_None;
+    const char *encoding = "utf-8";
+    int code = 0;
+    int have_code = 0;
+    PyObject *encoded_reason = NULL;  /* owned if we UTF-8 encoded */
+    Py_buffer reason_buf;
+    int have_reason_buf = 0;
+    const char *reason_ptr = NULL;
+    Py_ssize_t reason_len = 0;
+    unsigned char payload[125];
+    Py_ssize_t payload_len = 0;
+    size_t sent = 0;
+    CURLcode res;
+    PyObject *result = NULL;
+    PyThreadState *saved_state;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|OOs:ws_close", kwlist,
+                                     &code_obj, &reason_obj, &encoding)) {
+        return NULL;
+    }
+
+    if (code_obj != Py_None) {
+        long c = PyLong_AsLong(code_obj);
+        if (c == -1 && PyErr_Occurred()) {
+            return NULL;
+        }
+        if (!is_valid_ws_close_code(c)) {
+            PyErr_SetString(PyExc_ValueError,
+                "ws_close: code must be a valid wire close status code");
+            return NULL;
+        }
+        code = (int)c;
+        have_code = 1;
+    }
+
+    if (reason_obj != Py_None) {
+        if (!have_code) {
+            PyErr_SetString(PyExc_ValueError,
+                "ws_close: reason requires code (RFC 6455 §5.5.1)");
+            return NULL;
+        }
+        if (PyUnicode_Check(reason_obj)) {
+            encoded_reason = PyUnicode_AsEncodedString(
+                reason_obj, encoding, "strict");
+            if (encoded_reason == NULL) {
+                return NULL;
+            }
+            if (PyObject_GetBuffer(encoded_reason, &reason_buf,
+                                   PyBUF_SIMPLE) != 0) {
+                Py_DECREF(encoded_reason);
+                return NULL;
+            }
+        } else {
+            if (PyObject_GetBuffer(reason_obj, &reason_buf,
+                                   PyBUF_SIMPLE) != 0) {
+                return NULL;
+            }
+        }
+        have_reason_buf = 1;
+        reason_ptr = (const char *)reason_buf.buf;
+        reason_len = reason_buf.len;
+    }
+
+    if (validate_ws_close_reason_utf8(reason_ptr, reason_len) != 0) {
+        goto cleanup;
+    }
+
+    /* Total payload: 2 bytes for code (if any) + reason bytes.
+     * RFC 6455 §5.5 caps control-frame payloads at 125 bytes. */
+    if (have_code) {
+        payload_len = 2 + reason_len;
+    } else {
+        payload_len = 0;  /* empty close */
+    }
+    if (payload_len > (Py_ssize_t)sizeof(payload)) {
+        PyErr_Format(PyExc_ValueError,
+            "ws_close: payload too large (%zd bytes, max 125 including "
+            "2-byte status code)", payload_len);
+        goto cleanup;
+    }
+
+    if (have_code) {
+        payload[0] = (unsigned char)((code >> 8) & 0xff);
+        payload[1] = (unsigned char)(code & 0xff);
+        if (reason_len > 0) {
+            memcpy(payload + 2, reason_ptr, (size_t)reason_len);
+        }
+    }
+
+    if (check_ws_curl_state(self, 1, "ws_close") != 0) {
+        goto cleanup;
+    }
+
+    if (self->multi_stack != NULL) {
+        saved_state = self->multi_stack->state;
+    } else {
+        saved_state = self->state;
+    }
+
+    PYCURL_BEGIN_ALLOW_THREADS_EASY
+    res = curl_ws_send(self->handle, payload, (size_t)payload_len,
+                       &sent, (curl_off_t)0, CURLWS_CLOSE);
+    PYCURL_END_ALLOW_THREADS_EASY
+
+    if (self->multi_stack != NULL) {
+        self->multi_stack->state = saved_state;
+    } else {
+        self->state = saved_state;
+    }
+
+    if (check_pending_python_exception_or_signal() != 0) {
+        goto cleanup;
+    }
+    if (check_easy_recv_send_result(self, res) != 0) {
+        goto cleanup;
+    }
+    result = PyLong_FromSsize_t((Py_ssize_t)sent);
+
+cleanup:
+    if (have_reason_buf) {
+        PyBuffer_Release(&reason_buf);
+    }
+    Py_XDECREF(encoded_reason);
+    return result;
+}
+
+#endif /* HAVE_CURL_WEBSOCKETS */

--- a/src/module.c
+++ b/src/module.c
@@ -40,6 +40,9 @@ PYCURL_INTERNAL PyObject *hsts_index_type = NULL;
 PYCURL_INTERNAL PyObject *datetime_type = NULL;
 PYCURL_INTERNAL PyObject *utc_tz = NULL;
 #endif
+#ifdef HAVE_CURL_WEBSOCKETS
+PYCURL_INTERNAL PyObject *ws_frame_type = NULL;
+#endif
 
 PYCURL_INTERNAL PyObject *curlobject_constants = NULL;
 PYCURL_INTERNAL PyObject *curlmultiobject_constants = NULL;
@@ -353,6 +356,10 @@ static void do_curlmod_free(void *unused) {
     datetime_type = NULL;
     Py_XDECREF(utc_tz);
     utc_tz = NULL;
+#endif
+#ifdef HAVE_CURL_WEBSOCKETS
+    Py_XDECREF(ws_frame_type);
+    ws_frame_type = NULL;
 #endif
 
     Py_XDECREF(curlobject_constants);
@@ -1199,6 +1206,22 @@ PyMODINIT_FUNC PyInit_pycurl(void)
     insint_c(d, "PREREQFUNC_OK", CURL_PREREQFUNC_OK);
     insint_c(d, "PREREQFUNC_ABORT", CURL_PREREQFUNC_ABORT);
 #endif
+#ifdef HAVE_CURL_WEBSOCKETS
+    insint_c(d, "WS_OPTIONS", CURLOPT_WS_OPTIONS);
+    /* bits for CURLOPT_WS_OPTIONS */
+    insint_c(d, "WS_RAW_MODE", CURLWS_RAW_MODE);
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(8, 14, 0)
+    insint_c(d, "WS_NOAUTOPONG", CURLWS_NOAUTOPONG);
+#endif
+    /* frame flags used by ws_send() and returned in WsFrame.flags */
+    insint_c(d, "WS_TEXT", CURLWS_TEXT);
+    insint_c(d, "WS_BINARY", CURLWS_BINARY);
+    insint_c(d, "WS_CONT", CURLWS_CONT);
+    insint_c(d, "WS_CLOSE", CURLWS_CLOSE);
+    insint_c(d, "WS_PING", CURLWS_PING);
+    insint_c(d, "WS_PONG", CURLWS_PONG);
+    insint_c(d, "WS_OFFSET", CURLWS_OFFSET);
+#endif
 
 #if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 21, 0)
     insint_c(d, "FNMATCH_FUNCTION", CURLOPT_FNMATCH_FUNCTION);
@@ -1772,6 +1795,21 @@ PyMODINIT_FUNC PyInit_pycurl(void)
     }
 #endif
 
+#ifdef HAVE_CURL_WEBSOCKETS
+    arglist = Py_BuildValue("ss", "WsFrame", "age flags offset bytesleft len");
+    if (arglist == NULL) {
+        goto error;
+    }
+    ws_frame_type = PyObject_Call(named_tuple, arglist, NULL);
+    if (ws_frame_type == NULL) {
+        goto error;
+    }
+    Py_DECREF(arglist);
+    if (PyDict_SetItemString(d, "WsFrame", ws_frame_type) < 0) {
+        goto error;
+    }
+#endif
+
 #ifdef PYCURL_AUTODETECT_CA
     pycurl_autodetect_ca();
 #endif
@@ -1790,6 +1828,10 @@ error:
     Py_XDECREF(collections_module);
     Py_XDECREF(named_tuple);
     Py_XDECREF(xio_module);
+#ifdef HAVE_CURL_WEBSOCKETS
+    Py_XDECREF(ws_frame_type);
+    ws_frame_type = NULL;
+#endif
     Py_XDECREF(bytesio);
     Py_XDECREF(stringio);
     Py_XDECREF(arglist);

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -171,6 +171,11 @@ pycurl_inet_ntop (int family, void *addr, char *string, size_t string_size);
 #define HAVE_CURL_7_67_0_MULTI_STREAMS
 #endif
 
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 86, 0)
+#define HAVE_CURL_WEBSOCKETS
+#include <curl/websockets.h>
+#endif
+
 #undef UNUSED
 #define UNUSED(var)     ((void)&var)
 
@@ -485,6 +490,8 @@ typedef struct CurlObject {
     PyObject *postfields_obj;
     /* reference to the object containing ca certs */
     PyObject *ca_certs_obj;
+    /* true while executing WRITEFUNCTION for this handle */
+    int ws_write_cb_running;
     /* misc */
     char error[CURL_ERROR_SIZE+1];
 } CurlObject;
@@ -629,6 +636,23 @@ do_curl_recv(CurlObject *self, PyObject *args);
 PYCURL_INTERNAL PyObject *
 do_curl_recv_into(CurlObject *self, PyObject *args, PyObject *kwds);
 
+PYCURL_INTERNAL PyObject *set_would_block_error(void);
+PYCURL_INTERNAL int
+check_easy_recv_send_result(CurlObject *self, CURLcode res);
+
+#ifdef HAVE_CURL_WEBSOCKETS
+PYCURL_INTERNAL PyObject *
+do_curl_ws_send(CurlObject *self, PyObject *args, PyObject *kwds);
+PYCURL_INTERNAL PyObject *
+do_curl_ws_recv(CurlObject *self, PyObject *args);
+PYCURL_INTERNAL PyObject *
+do_curl_ws_recv_into(CurlObject *self, PyObject *args, PyObject *kwds);
+PYCURL_INTERNAL PyObject *
+do_curl_ws_meta(CurlObject *self, PyObject *Py_UNUSED(ignored));
+PYCURL_INTERNAL PyObject *
+do_curl_ws_close(CurlObject *self, PyObject *args, PyObject *kwds);
+#endif
+
 PYCURL_INTERNAL int
 check_curl_state(const CurlObject *self, int flags, const char *name);
 PYCURL_INTERNAL void
@@ -750,6 +774,9 @@ extern PyObject *hsts_entry_type;
 extern PyObject *hsts_index_type;
 extern PyObject *datetime_type;
 extern PyObject *utc_tz;
+#endif
+#ifdef HAVE_CURL_WEBSOCKETS
+extern PyObject *ws_frame_type;
 #endif
 
 extern PyObject *curlobject_constants;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,9 +36,11 @@ def curl():
     yield c
     c.close()
 
+
 @pytest.fixture(scope="session")
 def app() -> Generator[str, None, None]:
     yield from make_app()
+
 
 def make_app() -> Generator[str, None, None]:
     port = _get_free_port()
@@ -59,3 +61,16 @@ def make_app() -> Generator[str, None, None]:
     wait_listening(localhost, port, timeout=10.0)
     yield f"http://{localhost}:{port}"
     teardown(state)
+
+
+@pytest.fixture(scope="session")
+def ws_app() -> Generator[str, None, None]:
+    from . import wsappmanager
+
+    port = _get_free_port()
+    server = wsappmanager.start_server(localhost, port)
+    wait_listening(localhost, port, timeout=10.0)
+    try:
+        yield f"ws://{localhost}:{port}"
+    finally:
+        server.stop()

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,0 +1,434 @@
+import errno
+import select
+import time
+
+import pytest
+
+import pycurl
+
+from . import util
+
+util.skip_module_without_websockets()
+
+
+@pytest.fixture
+def wscurl():
+    # Plain Curl; DefaultCurl sets FORBID_REUSE which breaks CONNECT_ONLY=2.
+    c = pycurl.Curl()
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def connected(wscurl, ws_app):
+    wscurl.setopt(pycurl.URL, ws_app + "/echo")
+    wscurl.setopt(pycurl.CONNECT_ONLY, 2)
+    wscurl.perform()
+    return wscurl
+
+
+def _wait_readable(c, timeout):
+    fd = c.getinfo(pycurl.ACTIVESOCKET)
+    r, _, _ = select.select([fd], [], [], timeout)
+    return bool(r)
+
+
+def _recv(c, bufsize, timeout=5.0):
+    # Try ws_recv() first (libcurl may hold buffered data); fall back to
+    # select() on BlockingIOError / CURLE_AGAIN.
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            return c.ws_recv(bufsize)
+        except BlockingIOError:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise AssertionError("timed out waiting for ws data")
+            _wait_readable(c, remaining)
+
+
+def _recv_into(c, buffer, nbytes=0, timeout=5.0):
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            return c.ws_recv_into(buffer, nbytes)
+        except BlockingIOError:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise AssertionError("timed out waiting for ws data")
+            _wait_readable(c, remaining)
+
+
+def _recv_until(c, predicate, timeout=5.0):
+    # Drain frames until predicate(data, meta) matches. Used by auto-pong tests.
+    deadline = time.monotonic() + timeout
+    frames = []
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise AssertionError("timed out waiting for ws data")
+        data, meta = _recv(c, 4096, remaining)
+        frames.append((data, meta))
+        if predicate(data, meta):
+            return frames
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "WS_TEXT",
+        "WS_BINARY",
+        "WS_CONT",
+        "WS_CLOSE",
+        "WS_PING",
+        "WS_PONG",
+        "WS_OFFSET",
+        "WS_OPTIONS",
+        "WS_RAW_MODE",
+        "WsFrame",
+    ],
+)
+def test_constant_present(name):
+    assert hasattr(pycurl, name), name
+
+
+def test_ws_frame_has_expected_fields():
+    f = pycurl.WsFrame(1, 2, 3, 4, 5)
+    assert (f.age, f.flags, f.offset, f.bytesleft, f.len) == (1, 2, 3, 4, 5)
+
+
+@pytest.mark.parametrize(
+    "payload, flag",
+    [
+        (b"hello", pycurl.WS_TEXT),
+        (bytes(range(32)), pycurl.WS_BINARY),
+    ],
+    ids=["text", "binary"],
+)
+def test_roundtrip(connected, payload, flag):
+    assert connected.ws_send(payload, flag) == len(payload)
+    data, meta = _recv(connected, 4096)
+    assert data == payload
+    assert meta.flags & flag
+    assert meta.bytesleft == 0
+
+
+def test_recv_into_bytearray(connected):
+    connected.ws_send(b"abcdef", pycurl.WS_TEXT)
+    buf = bytearray(4096)
+    n, meta = _recv_into(connected, buf)
+    assert bytes(buf[:n]) == b"abcdef"
+    assert meta.flags & pycurl.WS_TEXT
+
+
+def test_recv_into_memoryview_slice(connected):
+    connected.ws_send(b"slicepayload", pycurl.WS_BINARY)
+    backing = bytearray(256)
+    view = memoryview(backing)[64:128]
+    n, meta = _recv_into(connected, view)
+    assert n == len(b"slicepayload")
+    assert bytes(backing[64 : 64 + n]) == b"slicepayload"
+    # Bytes outside the slice must be untouched.
+    assert backing[:64] == bytes(64)
+    assert backing[128:] == bytes(128)
+    assert meta.flags & pycurl.WS_BINARY
+
+
+@pytest.mark.parametrize(
+    "call, exc",
+    [
+        (lambda c: c.ws_recv(-1), ValueError),
+        (lambda c: c.ws_recv_into(bytearray(8), -1), ValueError),
+        (lambda c: c.ws_recv_into(bytearray(8), 9999), ValueError),
+        (lambda c: c.ws_send(b"x", -1), ValueError),
+        (lambda c: c.ws_send(b"x", 1 << 40), OverflowError),
+        (lambda c: c.ws_send(b"x", pycurl.WS_BINARY, -1), ValueError),
+        (lambda c: c.ws_send(12345), TypeError),
+    ],
+    ids=[
+        "recv_neg_bufsize",
+        "recv_into_neg_nbytes",
+        "recv_into_nbytes_too_large",
+        "send_neg_flags",
+        "send_overflow_flags",
+        "send_neg_fragsize",
+        "send_wrong_data_type",
+    ],
+)
+def test_argument_validation(wscurl, call, exc):
+    with pytest.raises(exc):
+        call(wscurl)
+
+
+def test_recv_zero_bufsize(connected):
+    connected.ws_send(b"hello", pycurl.WS_TEXT)
+    data, meta = _recv(connected, 0)
+    assert data == b""
+    assert isinstance(meta, pycurl.WsFrame)
+    assert meta.flags & pycurl.WS_TEXT
+    data, meta = _recv(connected, 4096)
+    assert data == b"hello"
+    assert meta.flags & pycurl.WS_TEXT
+
+
+def test_recv_into_empty_buffer(connected):
+    connected.ws_send(b"hello", pycurl.WS_TEXT)
+    n, meta = _recv_into(connected, bytearray(0))
+    assert n == 0
+    assert isinstance(meta, pycurl.WsFrame)
+    assert meta.flags & pycurl.WS_TEXT
+    data, meta = _recv(connected, 4096)
+    assert data == b"hello"
+    assert meta.flags & pycurl.WS_TEXT
+
+
+def test_ws_meta_returns_none_outside_callback(wscurl, ws_app):
+    assert wscurl.ws_meta() is None  # before perform
+    wscurl.setopt(pycurl.URL, ws_app + "/echo")
+    wscurl.setopt(pycurl.CONNECT_ONLY, 2)
+    wscurl.perform()
+    assert wscurl.ws_meta() is None  # detached mode, no callback running
+
+
+def test_send_on_closed_handle_raises():
+    c = pycurl.Curl()
+    c.close()
+    with pytest.raises(pycurl.error):
+        c.ws_send(b"x")
+
+
+@pytest.mark.parametrize(
+    "data, expected_flag, expected_bytes",
+    [
+        ("hello", pycurl.WS_TEXT, b"hello"),
+        ("héllo", pycurl.WS_TEXT, "héllo".encode("utf-8")),
+        (b"\x00\xff\x10", pycurl.WS_BINARY, b"\x00\xff\x10"),
+        (bytearray(b"abc"), pycurl.WS_BINARY, b"abc"),
+        (memoryview(b"mview"), pycurl.WS_BINARY, b"mview"),
+    ],
+    ids=["str", "str-utf8", "bytes", "bytearray", "memoryview"],
+)
+def test_send_infers_frame_type(connected, data, expected_flag, expected_bytes):
+    connected.ws_send(data)
+    received, meta = _recv(connected, 4096)
+    assert received == expected_bytes
+    assert meta.flags & expected_flag
+
+
+def test_send_str_custom_encoding(connected):
+    # ASCII content avoids the RFC 6455 UTF-8 wire requirement; the
+    # non-encodable test proves the encoding kwarg is honored.
+    connected.ws_send("hello", encoding="ascii")
+    data, meta = _recv(connected, 4096)
+    assert data == b"hello"
+    assert meta.flags & pycurl.WS_TEXT
+
+
+def test_send_str_encoding_rejects_non_encodable(connected):
+    with pytest.raises(UnicodeEncodeError):
+        connected.ws_send("héllo", encoding="ascii")
+
+
+def test_send_bytes_with_explicit_text_flag(connected):
+    # Explicit WS_TEXT overrides the bytes-like inference to WS_BINARY.
+    connected.ws_send(b"explicit", pycurl.WS_TEXT)
+    data, meta = _recv(connected, 4096)
+    assert data == b"explicit"
+    assert meta.flags & pycurl.WS_TEXT
+
+
+@pytest.mark.parametrize(
+    "flag, match",
+    [(pycurl.WS_BINARY, "WS_BINARY"), (pycurl.WS_CLOSE, "WS_CLOSE")],
+    ids=["WS_BINARY", "WS_CLOSE"],
+)
+def test_send_str_with_incompatible_flag_raises(connected, flag, match):
+    with pytest.raises(TypeError, match=match):
+        connected.ws_send("nope", flag)
+
+
+def test_send_rejects_none_data(wscurl):
+    with pytest.raises(TypeError, match="NoneType"):
+        wscurl.ws_send(None)
+
+
+def test_send_conflicting_text_binary_flags_raises(wscurl):
+    with pytest.raises(ValueError, match="WS_TEXT and WS_BINARY"):
+        wscurl.ws_send(b"x", pycurl.WS_TEXT | pycurl.WS_BINARY)
+
+
+@pytest.mark.parametrize(
+    "data, flag",
+    [
+        ("hello", pycurl.WS_PING),
+        ("hello", pycurl.WS_PONG),
+        (b"probe", pycurl.WS_PING),
+    ],
+    ids=["str+WS_PING", "str+WS_PONG", "bytes+WS_PING"],
+)
+def test_send_control_frame(connected, data, flag):
+    connected.ws_send(data, flag)
+
+
+@pytest.mark.parametrize(
+    "flags",
+    [
+        pycurl.WS_PING | pycurl.WS_CONT,
+        pycurl.WS_PONG | pycurl.WS_CONT,
+        pycurl.WS_CLOSE | pycurl.WS_CONT,
+    ],
+    ids=["PING+CONT", "PONG+CONT", "CLOSE+CONT"],
+)
+def test_send_rejects_fragmented_control_frame(wscurl, flags):
+    # RFC 6455 §5.4: control frames MUST NOT be fragmented.
+    with pytest.raises(ValueError, match="control frames cannot be fragmented"):
+        wscurl.ws_send(b"x", flags)
+
+
+@pytest.mark.parametrize(
+    "flags",
+    [
+        pycurl.WS_PING | pycurl.WS_PONG,
+        pycurl.WS_PING | pycurl.WS_CLOSE,
+        pycurl.WS_PONG | pycurl.WS_CLOSE,
+        pycurl.WS_PING | pycurl.WS_PONG | pycurl.WS_CLOSE,
+    ],
+    ids=["PING+PONG", "PING+CLOSE", "PONG+CLOSE", "PING+PONG+CLOSE"],
+)
+def test_send_rejects_multiple_control_bits(wscurl, flags):
+    with pytest.raises(ValueError, match="only one of WS_PING"):
+        wscurl.ws_send(b"x", flags)
+
+
+def test_ws_close_empty(connected):
+    assert connected.ws_close() == 0
+
+
+@pytest.mark.parametrize(
+    "code, reason, encoding, expected",
+    [
+        (1000, None, "utf-8", b"\x03\xe8"),
+        (1001, "going away", "utf-8", b"\x03\xe9going away"),
+        (1011, b"internal error", "utf-8", b"\x03\xf3internal error"),
+        (1000, "héllo", "utf-8", b"\x03\xe8" + "héllo".encode("utf-8")),
+        (1000, "hello", "ascii", b"\x03\xe8hello"),
+    ],
+    ids=["code-only", "str-reason", "bytes-reason", "str-utf8", "ascii-encoding"],
+)
+def test_ws_close_payload(connected, code, reason, encoding, expected):
+    connected.ws_close(code, reason, encoding=encoding)
+    data, meta = _recv(connected, 4096)
+    assert data == expected
+    assert meta.flags & pycurl.WS_CLOSE
+
+
+@pytest.mark.parametrize("code", [0, 999, 1004, 1005, 1006, 1015, 2000, 5000, -1])
+def test_ws_close_code_out_of_range_raises(wscurl, code):
+    with pytest.raises(ValueError, match="valid wire close status code"):
+        wscurl.ws_close(code)
+
+
+def test_ws_close_reason_without_code_raises(wscurl):
+    with pytest.raises(ValueError, match="reason requires code"):
+        wscurl.ws_close(reason="nope")
+
+
+def test_ws_close_reason_too_long_raises(wscurl):
+    # 2-byte code + 124-byte reason = 126, over the 125-byte control-frame cap.
+    with pytest.raises(ValueError, match="payload too large"):
+        wscurl.ws_close(1000, b"x" * 124)
+
+
+def test_ws_close_reason_exactly_125_bytes(connected):
+    # 2 + 123 = 125, right at the RFC 6455 §5.5 boundary.
+    reason = b"y" * 123
+    connected.ws_close(1000, reason)
+    data, _ = _recv(connected, 4096)
+    assert data == b"\x03\xe8" + reason
+
+
+@pytest.mark.parametrize(
+    "reason, encoding, exc",
+    [
+        ("héllo", "ascii", UnicodeEncodeError),
+        (b"\xff", "utf-8", UnicodeDecodeError),
+        ("héllo", "latin-1", UnicodeDecodeError),
+    ],
+    ids=["str-not-encodable", "bytes-not-utf8", "encoded-not-utf8"],
+)
+def test_ws_close_reason_encoding_errors(wscurl, reason, encoding, exc):
+    with pytest.raises(exc):
+        wscurl.ws_close(1000, reason, encoding=encoding)
+
+
+def test_send_fragsize_equal_to_payload(connected):
+    # One frame, total size announced up front; pins the fragsize
+    # parameter without the multi-call WS_OFFSET dance.
+    payload = b"A" * 20
+    connected.ws_send(payload, pycurl.WS_BINARY, fragsize=len(payload))
+    data, meta = _recv(connected, 4096)
+    assert data == payload
+    assert meta.flags & pycurl.WS_BINARY
+
+
+def test_recv_raises_blocking_io_error_when_no_data(wscurl, ws_app):
+    # /silent never replies; ws_recv returns CURLE_AGAIN -> BlockingIOError.
+    wscurl.setopt(pycurl.URL, ws_app + "/silent")
+    wscurl.setopt(pycurl.CONNECT_ONLY, 2)
+    wscurl.perform()
+    with pytest.raises(BlockingIOError) as exc_info:
+        wscurl.ws_recv(4096)
+    assert exc_info.value.errno == errno.EAGAIN
+
+
+def test_default_mode_autopongs_server_ping(wscurl, ws_app):
+    wscurl.setopt(pycurl.URL, ws_app + "/ping-and-report-pong")
+    wscurl.setopt(pycurl.CONNECT_ONLY, 2)
+    wscurl.perform()
+
+    _recv_until(
+        wscurl,
+        lambda data, meta: (meta.flags & pycurl.WS_TEXT) and data == b"pong-ok",
+    )
+
+
+@pytest.mark.skipif(
+    not hasattr(pycurl, "WS_NOAUTOPONG"),
+    reason="libcurl < 8.14.0",
+)
+def test_ws_noautopong_disables_automatic_pong(wscurl, ws_app):
+    wscurl.setopt(pycurl.URL, ws_app + "/ping-and-report-pong")
+    wscurl.setopt(pycurl.CONNECT_ONLY, 2)
+    wscurl.setopt(pycurl.WS_OPTIONS, pycurl.WS_NOAUTOPONG)
+    wscurl.perform()
+
+    frames = _recv_until(
+        wscurl,
+        lambda data, meta: (meta.flags & pycurl.WS_TEXT) and data == b"pong-missing",
+    )
+
+    # Server's ping must have reached the client (otherwise auto-pong
+    # wasn't disabled — the "pong-missing" signal alone doesn't prove it).
+    assert any(meta.flags & pycurl.WS_PING for _, meta in frames)
+
+
+@pytest.mark.skipif(
+    not hasattr(pycurl, "WS_NOAUTOPONG"),
+    reason="libcurl < 8.14.0",
+)
+def test_ws_noautopong_allows_manual_pong(wscurl, ws_app):
+    wscurl.setopt(pycurl.URL, ws_app + "/ping-and-report-pong")
+    wscurl.setopt(pycurl.CONNECT_ONLY, 2)
+    wscurl.setopt(pycurl.WS_OPTIONS, pycurl.WS_NOAUTOPONG)
+    wscurl.perform()
+
+    data, meta = _recv(wscurl, 4096)
+    assert data == b"probe"
+    assert meta.flags & pycurl.WS_PING
+
+    assert wscurl.ws_send(data, pycurl.WS_PONG) == len(data)
+
+    _recv_until(
+        wscurl,
+        lambda chunk, frame: (frame.flags & pycurl.WS_TEXT) and chunk == b"pong-ok",
+    )

--- a/tests/test_websocket_callback.py
+++ b/tests/test_websocket_callback.py
@@ -1,0 +1,297 @@
+import time
+import threading
+
+import pytest
+
+import pycurl
+
+from . import util
+
+util.skip_module_without_websockets()
+
+
+def _run_with_cb(url):
+    c = pycurl.Curl()
+    chunks = []
+    metas = []
+
+    def write_cb(data):
+        chunks.append(bytes(data))
+        metas.append(c.ws_meta())
+        return len(data)
+
+    try:
+        c.setopt(pycurl.URL, url)
+        c.setopt(pycurl.WRITEFUNCTION, write_cb)
+        c.perform()
+        after = c.ws_meta()
+    finally:
+        c.close()
+
+    return chunks, metas, after
+
+
+def _run_with_multi_cb(c, timeout=5.0):
+    m = pycurl.CurlMulti()
+    errors = []
+
+    try:
+        m.add_handle(c)
+
+        deadline = time.monotonic() + timeout
+        running = True
+        while running:
+            _, running = m.perform()
+            if running:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise AssertionError("timed out waiting for multi ws transfer")
+                m.select(min(0.1, remaining))
+
+        while True:
+            queued, _, err = m.info_read()
+            errors.extend(err)
+            if not queued:
+                break
+    finally:
+        # Handle may already be detached if the transfer errored out.
+        try:
+            m.remove_handle(c)
+        except pycurl.error:
+            pass
+        c.close()
+        m.close()
+
+    return errors
+
+
+def _assert_only_write_error(errors):
+    assert errors
+    assert all(err_code == pycurl.E_WRITE_ERROR for _, err_code, _ in errors)
+
+
+@pytest.mark.parametrize(
+    "path, expected_payload, expected_flag",
+    [
+        ("/echo-on-connect", b"hello", pycurl.WS_TEXT),
+        ("/binary-on-connect", b"\x01\x02\x03", pycurl.WS_BINARY),
+    ],
+    ids=["text", "binary"],
+)
+def test_write_callback_receives_frame(ws_app, path, expected_payload, expected_flag):
+    chunks, metas, after = _run_with_cb(ws_app + path)
+    assert chunks[0] == expected_payload
+    assert isinstance(metas[0], pycurl.WsFrame)
+    assert metas[0].flags & expected_flag
+    assert after is None  # ws_meta() is callback-context only
+
+
+def test_fragmented_callback_receive(ws_app):
+    chunks, metas, _ = _run_with_cb(ws_app + "/fragmented-on-connect")
+
+    # Drop the trailing close frame.
+    data_metas = [
+        (c, m) for c, m in zip(chunks, metas) if m and not (m.flags & pycurl.WS_CLOSE)
+    ]
+    payload = b"".join(c for c, _ in data_metas)
+    assert payload == b"one-two-three"
+
+    # Server sends three wire-level fragments; at least one must carry WS_CONT.
+    if len(data_metas) > 1:
+        assert any(m.flags & pycurl.WS_CONT for _, m in data_metas)
+
+
+def test_close_frame_visible_in_callback(ws_app):
+    _, metas, _ = _run_with_cb(ws_app + "/echo-on-connect")
+    assert any(m and (m.flags & pycurl.WS_CLOSE) for m in metas)
+
+
+def test_raw_mode_callback_receives_wire_bytes(ws_app):
+    c = pycurl.Curl()
+    chunks = []
+    metas = []
+
+    def cb(data):
+        chunks.append(bytes(data))
+        metas.append(c.ws_meta())
+        return len(data)
+
+    try:
+        c.setopt(pycurl.URL, ws_app + "/echo-on-connect")
+        c.setopt(pycurl.WS_OPTIONS, pycurl.WS_RAW_MODE)
+        c.setopt(pycurl.WRITEFUNCTION, cb)
+        c.perform()
+    finally:
+        c.close()
+
+    assert b"".join(chunks) == b"\x81\x05hello\x88\x02\x03\xe8"
+    assert metas
+    assert all(m is None for m in metas)
+
+
+def test_ws_meta_none_in_http_callback(app):
+    # Non-WebSocket transfer: curl_ws_meta() returns NULL -> None.
+    _, metas, _ = _run_with_cb(app + "/success")
+    assert metas
+    assert all(m is None for m in metas)
+
+
+def test_write_callback_can_ws_send_reply(ws_app):
+    c = pycurl.Curl()
+    sent = []
+
+    def cb(data):
+        if data == b"hi":
+            sent.append(c.ws_send(b"ack", pycurl.WS_BINARY))
+        return len(data)
+
+    try:
+        c.setopt(pycurl.URL, ws_app + "/greet-and-echo-reply")
+        c.setopt(pycurl.WRITEFUNCTION, cb)
+        c.perform()
+    finally:
+        c.close()
+
+    assert sent == [3]
+
+
+def test_write_callback_can_ws_close(ws_app):
+    c = pycurl.Curl()
+    closed = []
+
+    def cb(data):
+        if data == b"hi":
+            closed.append(c.ws_close(1000))
+        return len(data)
+
+    try:
+        c.setopt(pycurl.URL, ws_app + "/greet-and-wait-close")
+        c.setopt(pycurl.WRITEFUNCTION, cb)
+        c.perform()
+    finally:
+        c.close()
+
+    assert closed == [2]  # 2-byte status-code payload
+
+
+def test_multi_write_callback_receives_frame(ws_app):
+    c = pycurl.Curl()
+    chunks = []
+    metas = []
+
+    def cb(data):
+        chunks.append(bytes(data))
+        metas.append(c.ws_meta())
+        return 0
+
+    c.setopt(pycurl.URL, ws_app + "/echo-on-connect")
+    c.setopt(pycurl.WRITEFUNCTION, cb)
+    errors = _run_with_multi_cb(c)
+
+    _assert_only_write_error(errors)
+    assert chunks[0] == b"hello"
+    assert isinstance(metas[0], pycurl.WsFrame)
+    assert metas[0].flags & pycurl.WS_TEXT
+
+
+def test_multi_write_callback_can_ws_send_reply(ws_app):
+    c = pycurl.Curl()
+    sent = []
+
+    def cb(data):
+        if data == b"hi":
+            sent.append(c.ws_send(b"ack", pycurl.WS_BINARY))
+            return 0
+        return len(data)
+
+    c.setopt(pycurl.URL, ws_app + "/greet-and-echo-reply")
+    c.setopt(pycurl.WRITEFUNCTION, cb)
+    errors = _run_with_multi_cb(c)
+
+    _assert_only_write_error(errors)
+    assert sent == [3]
+
+
+def test_multi_write_callback_can_ws_close(ws_app):
+    c = pycurl.Curl()
+    closed = []
+
+    def cb(data):
+        if data == b"hi":
+            closed.append(c.ws_close(1000))
+            return 0
+        return len(data)
+
+    c.setopt(pycurl.URL, ws_app + "/greet-and-wait-close")
+    c.setopt(pycurl.WRITEFUNCTION, cb)
+    errors = _run_with_multi_cb(c)
+
+    _assert_only_write_error(errors)
+    assert closed == [2]
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda c: c.ws_send(b"ack", pycurl.WS_BINARY),
+        lambda c: c.ws_close(1000),
+    ],
+    ids=["ws_send", "ws_close"],
+)
+def test_write_callback_relaxation_does_not_allow_other_threads(ws_app, call):
+    c = pycurl.Curl()
+    saw_data = threading.Event()
+    release_cb = threading.Event()
+    results = []
+
+    def cb(data):
+        if data == b"hi":
+            saw_data.set()
+            release_cb.wait(5.0)
+            return 0  # abort the transfer; no need to wait for close handshake
+        return len(data)
+
+    def run():
+        try:
+            c.setopt(pycurl.URL, ws_app + "/greet-and-close")
+            c.setopt(pycurl.WRITEFUNCTION, cb)
+            c.perform()
+            results.append("ok")
+        except Exception as e:
+            results.append(repr(e))
+
+    t = threading.Thread(target=run)
+    t.start()
+    assert saw_data.wait(5.0)
+    try:
+        with pytest.raises(pycurl.error, match="outside WRITEFUNCTION callback"):
+            call(c)
+    finally:
+        release_cb.set()
+    t.join(5.0)
+    assert not t.is_alive()
+    assert len(results) == 1
+    c.close()
+
+
+def test_write_callback_ws_recv_still_rejected(ws_app):
+    # Callback-context relaxation is send-only; libcurl doesn't document recv.
+    c = pycurl.Curl()
+    errors = []
+
+    def cb(data):
+        try:
+            c.ws_recv(4096)
+        except pycurl.error as e:
+            errors.append(e)
+        return len(data)
+
+    try:
+        c.setopt(pycurl.URL, ws_app + "/echo-on-connect")
+        c.setopt(pycurl.WRITEFUNCTION, cb)
+        c.perform()
+    finally:
+        c.close()
+
+    assert errors
+    assert "perform" in str(errors[0])

--- a/tests/util.py
+++ b/tests/util.py
@@ -87,6 +87,20 @@ def skip_in_libcurl_versions(*versions):
 
     return decorator
 
+def skip_module_without_websockets():
+    """Call at module level (via :func:`pytest.skip(allow_module_level=True)`)
+    in WS test files. Requires both libcurl >= 7.86.0 AND the runtime
+    library built with WebSocket support — distro libcurl often ships
+    with ``--disable-websockets``."""
+    import pycurl
+    import pytest
+
+    if pycurl_version_less_than(7, 86, 0) or "ws" not in pycurl.version_info()[8]:
+        pytest.skip(
+            "libcurl built without WebSocket support", allow_module_level=True
+        )
+
+
 def only_ssl(fn):
     import pycurl
 

--- a/tests/wsappmanager.py
+++ b/tests/wsappmanager.py
@@ -1,0 +1,129 @@
+"""Lightweight asyncio websockets test server used by ws tests."""
+
+import asyncio
+import threading
+import warnings
+from typing import Optional
+
+
+class WsServer:
+    def __init__(self, host: str, port: int):
+        self.host = host
+        self.port = port
+        self.loop: Optional[asyncio.AbstractEventLoop] = None
+        self._thread: Optional[threading.Thread] = None
+        self._ready = threading.Event()
+        self._stop: Optional[asyncio.Future] = None
+
+    def start(self) -> None:
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+        if not self._ready.wait(timeout=10.0):
+            raise RuntimeError("ws test server failed to start")
+
+    def stop(self) -> None:
+        if self.loop is None or self._stop is None:
+            return
+        self.loop.call_soon_threadsafe(self._stop.set_result, None)
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+            if self._thread.is_alive():
+                warnings.warn(
+                    "ws test server thread did not exit within 5s; "
+                    "a background asyncio task may be stuck",
+                    ResourceWarning,
+                    stacklevel=2,
+                )
+
+    def _run(self) -> None:
+        import websockets
+
+        async def echo(ws):
+            try:
+                async for msg in ws:
+                    await ws.send(msg)
+            except Exception:
+                pass
+
+        async def echo_on_connect(ws):
+            await ws.send("hello")
+            await ws.close()
+
+        async def binary_on_connect(ws):
+            await ws.send(b"\x01\x02\x03")
+            await ws.close()
+
+        async def fragmented_on_connect(ws):
+            await ws.send(["one-", "two-", "three"])
+            await ws.close()
+
+        async def silent(ws):
+            try:
+                async for _ in ws:
+                    pass
+            except Exception:
+                pass
+
+        async def greet_and_echo_reply(ws):
+            await ws.send(b"hi")
+            reply = await ws.recv()
+            assert reply == b"ack", f"expected b'ack', got {reply!r}"
+            await ws.close()
+
+        async def greet_and_wait_close(ws):
+            await ws.send(b"hi")
+            try:
+                async for _ in ws:
+                    pass
+            except Exception:
+                pass
+
+        async def greet_and_close(ws):
+            await ws.send(b"hi")
+            await ws.close()
+
+        async def ping_and_report_pong(ws):
+            pong_waiter = await ws.ping(b"probe")
+            try:
+                await asyncio.wait_for(pong_waiter, timeout=0.5)
+                await ws.send("pong-ok")
+            except asyncio.TimeoutError:
+                await ws.send("pong-missing")
+            await ws.close()
+
+        routes = {
+            "/echo": echo,
+            "/echo-on-connect": echo_on_connect,
+            "/binary-on-connect": binary_on_connect,
+            "/fragmented-on-connect": fragmented_on_connect,
+            "/silent": silent,
+            "/greet-and-echo-reply": greet_and_echo_reply,
+            "/greet-and-wait-close": greet_and_wait_close,
+            "/greet-and-close": greet_and_close,
+            "/ping-and-report-pong": ping_and_report_pong,
+        }
+
+        async def dispatch(ws):
+            path = ws.request.path
+            handler = routes.get(path, echo)
+            await handler(ws)
+
+        async def main():
+            self._stop = asyncio.get_running_loop().create_future()
+            async with websockets.serve(dispatch, self.host, self.port):
+                self._ready.set()
+                await self._stop
+
+        try:
+            self.loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self.loop)
+            self.loop.run_until_complete(main())
+        finally:
+            if self.loop is not None:
+                self.loop.close()
+
+
+def start_server(host: str, port: int) -> WsServer:
+    s = WsServer(host, port)
+    s.start()
+    return s


### PR DESCRIPTION
Add libcurl WebSocket support:

- Five new methods on `Curl`: `ws_send`, `ws_recv`, `ws_recv_into`, `ws_meta`, `ws_close`.
- A `WsFrame` namedtuple (`age, flags, offset, bytesleft, len`) for per-frame metadata, shared across both modes.
- Module constants: `WS_TEXT`, `WS_BINARY`, `WS_CONT`, `WS_CLOSE`, `WS_PING`, `WS_PONG`, `WS_OFFSET`, `WS_OPTIONS`, `WS_RAW_MODE`, and `WS_NOAUTOPONG` (on libcurl ≥ 8.14).
- Tests covering both modes
