### PR TITLE
Migrate static metadata to `pyproject.toml` while keeping `setup.py` for native build logic

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -89,7 +89,7 @@ jobs:
       if: matrix.curl-version == 'macos'
       env:
         CFLAGS: -Werror
-      run: python setup.py build
+      run: python -m pip install .
     - name: Test with pytest
       if: matrix.curl-version == 'macos'
       env:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -67,14 +67,14 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install wheel delvewheel
+        pip install build delvewheel
         pip install flake8 pytest -r requirements-dev.txt
     - name: Build
       env:
         PYCURL_SSL_LIBRARY: schannel
         PYCURL_CURL_DIR: 'C:/vcpkg/packages/curl_${{ matrix.arch }}-windows'
       run: |
-        python setup.py bdist_wheel
+        python -m build --wheel
     - name: Repair & install built wheel
       run: |
         delvewheel repair --add-path $VCPKG_INSTALLATION_ROOT/installed/${{ matrix.arch }}-windows/bin dist/*.whl

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -26,8 +26,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libcurl4-gnutls-dev
+      - name: Install build frontend
+        run: python -m pip install --upgrade build
       - name: Build sdist
-        run: python setup.py sdist
+        run: python -m build --sdist
       - name: Upload sdist
         uses: actions/upload-artifact@v7
         with:

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -9,25 +9,25 @@ everything necessary to build pycurl, in which case you need to
 install the developer specific RPM which is usually called curl-dev.
 
 
-Distutils
----------
+From a source distribution
+--------------------------
 
 Build and install pycurl with the following commands::
 
     (if necessary, become root)
     tar -zxvf pycurl-$VER.tar.gz
     cd pycurl-$VER
-    python setup.py install
+    python -m pip install .
 
 $VER should be substituted with the pycurl version number, e.g. 7.10.5.
 
 Note that the installation script assumes that 'curl-config' can be
 located in your path setting.  If curl-config is installed outside
 your path or you want to force installation to use a particular
-version of curl-config, use the '--curl-config' command line option to
-specify the location of curl-config.  Example::
+version of curl-config, set the ``PYCURL_CURL_CONFIG`` environment
+variable to the location of curl-config.  Example::
 
-    python setup.py install --curl-config=/usr/local/bin/curl-config
+    PYCURL_CURL_CONFIG=/usr/local/bin/curl-config python -m pip install .
 
 If libcurl is linked dynamically with pycurl, you may have to alter the
 LD_LIBRARY_PATH environment variable accordingly.  This normally
@@ -51,43 +51,40 @@ It will then fail at runtime as follows::
 
     ImportError: pycurl: libcurl link-time ssl backend (openssl) is different from compile-time ssl backend (none/other)
 
-To fix this, you need to tell ``setup.py`` what SSL backend is used::
+To fix this, set the ``PYCURL_SSL_LIBRARY`` environment variable to the
+SSL backend that libcurl is using::
 
-    python setup.py --with-[openssl|gnutls|nss|mbedtls|wolfssl|sectransp|schannel] install
+    PYCURL_SSL_LIBRARY=openssl python -m pip install .
 
-Note: as of PycURL 7.21.5, setup.py accepts ``--with-openssl`` option to
-indicate that libcurl is built against OpenSSL/LibreSSL/BoringSSL.
-``--with-ssl`` is an alias
-for ``--with-openssl`` and continues to be accepted for backwards compatibility.
+Substitute the appropriate backend name (``openssl``, ``gnutls``, ``nss``,
+``mbedtls``, ``wolfssl``, ``sectransp``, or ``schannel``).
 
-You can also ask ``setup.py`` to obtain SSL backend information from installed
-libcurl shared library, as follows:
-
-    python setup.py --libcurl-dll=libcurl.so
-
-An unqualified ``libcurl.so`` would use the system libcurl, or you can
-specify a full path.
+Advanced users invoking ``python -m build`` or ``setup.py`` directly can
+also have it obtain SSL backend information from an installed libcurl
+shared library by passing ``--libcurl-dll=libcurl.so`` (an unqualified
+``libcurl.so`` would use the system libcurl, or a full path can be
+specified). When installing via ``pip``, prefer ``PYCURL_SSL_LIBRARY``
+above.
 
 
-easy_install / pip
-------------------
+pip
+---
 
 ::
 
-    easy_install pycurl
     pip install pycurl
 
 If you need to specify an alternate curl-config, it can be done via an
 environment variable::
 
     export PYCURL_CURL_CONFIG=/usr/local/bin/curl-config
-    easy_install pycurl
+    pip install pycurl
 
 The same applies to the SSL backend, if you need to specify it (see the SSL
 note above)::
 
     export PYCURL_SSL_LIBRARY=[openssl|gnutls|nss|mbedtls|sectransp|schannel]
-    easy_install pycurl
+    pip install pycurl
 
 
 pip and cached pycurl package

--- a/Makefile
+++ b/Makefile
@@ -139,8 +139,11 @@ strip: build
 	strip -p --strip-unneeded build/lib*/*.so
 	chmod -x build/lib*/*.so
 
-install install_lib:
-	$(PYTHON) setup.py $@
+install:
+	$(PYTHON) -m pip install .
+
+install_lib:
+	$(PYTHON) setup.py install_lib
 
 clean:
 	-rm -rf build dist

--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,25 @@ reports and direct questions to our mailing list instead.
 Automated Tests
 ---------------
 
-PycURL comes with an automated test suite. To run the tests, execute::
+PycURL comes with an automated test suite. To run the tests, set up a
+virtual environment and invoke ``pytest``::
+
+    python3 -m venv .venv
+    source .venv/bin/activate
+    python -m pip install --upgrade pip
+    python -m pip install -e . --group dev
+    python -m pytest tests/
+
+.. note::
+
+    The ``--group`` option requires ``pip`` >= 25.1 (PEP 735).
+
+After modifying C sources under ``src/``, rebuild the extension in place
+with::
+
+    python -m pip install -e .
+
+Alternatively, the suite can be run via ``make``::
 
     make test
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -94,9 +94,8 @@ Installation
 On Unix, PycURL is easiest to install using your operating system's package
 manager. This will also install libcurl and other dependencies as needed.
 
-Installation via easy_install and pip is also supported::
+Installation via pip is also supported::
 
-    easy_install pycurl
     pip install pycurl
 
 If this does not work, please see :ref:`install`.

--- a/doc/release-process.rst
+++ b/doc/release-process.rst
@@ -17,7 +17,7 @@ Release Process
 8. Update copyright years if necessary.
 9. Draft release notes, add to RELEASE-NOTES.rst.
 10. ``make gen docs``.
-11. ``python setup.py sdist``.
+11. ``python -m build --sdist``.
 12. Manually test install the built package.
 13. Build windows packages.
 14. Add sdist and windows packages to downloads repo on github.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,58 @@
+[build-system]
+requires = ["setuptools>=77", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pycurl"
+description = "PycURL -- A Python Interface To The cURL library"
+requires-python = ">=3.10"
+license = "LGPL-2.1-only OR MIT"
+license-files = ["COPYING-LGPL", "COPYING-MIT"]
+keywords = ["curl", "libcurl", "urllib", "wget", "download", "file transfer", "http", "www"]
+authors = [
+    { name = "Kjetil Jacobsen",         email = "kjetilja@gmail.com" },
+    { name = "Markus F.X.J. Oberhumer", email = "markus@oberhumer.com" },
+    { name = "Oleg Pudeyev",            email = "oleg@bsdpower.com" },
+]
+maintainers = [
+    { name = "Oleg Pudeyev", email = "oleg@bsdpower.com" },
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Web Environment",
+    "Intended Audience :: Developers",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Internet :: File Transfer Protocol (FTP)",
+    "Topic :: Internet :: WWW/HTTP",
+]
+dynamic = ["version", "readme"]
+
+[project.urls]
+Homepage      = "http://pycurl.io/"
+Documentation = "http://pycurl.io/docs/latest/"
+Source        = "https://github.com/pycurl/pycurl"
+Issues        = "https://github.com/pycurl/pycurl/issues"
+Changelog     = "https://github.com/pycurl/pycurl/blob/master/ChangeLog"
+
+[dependency-groups]
+dev = [
+    "flaky",
+    "flask",
+    "numpy",
+    "pyflakes",
+    "pytest>=5",
+    "sphinx",
+    "setuptools",
+    "websockets>=12",
+]
+
 [tool.cibuildwheel]
 build = "cp3*"
 skip = ["cp38-*", "*-musllinux*"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+# Mirrored in pyproject.toml [dependency-groups] dev. Keep in sync.
 flaky
 flask
 numpy

--- a/setup.py
+++ b/setup.py
@@ -806,9 +806,8 @@ def gen_docstrings_sources():
 ###############################################################################
 
 setup_args = dict(
-    name=PACKAGE,
     version=VERSION,
-    description='PycURL -- A Python Interface To The cURL library',
+    long_description_content_type='text/x-rst',
     long_description='''\
 PycURL -- A Python Interface To The cURL library
 ================================================
@@ -890,35 +889,8 @@ in COPYING-LGPL_ and COPYING-MIT_ files in the source distribution.
 .. _COPYING-LGPL: https://raw.githubusercontent.com/pycurl/pycurl/master/COPYING-LGPL
 .. _COPYING-MIT: https://raw.githubusercontent.com/pycurl/pycurl/master/COPYING-MIT
 ''',
-    author="Kjetil Jacobsen, Markus F.X.J. Oberhumer, Oleg Pudeyev",
-    author_email="kjetilja@gmail.com, markus@oberhumer.com, oleg@bsdpower.com",
-    maintainer="Oleg Pudeyev",
-    maintainer_email="oleg@bsdpower.com",
-    url="http://pycurl.io/",
-    license="LGPL/MIT",
-    keywords=['curl', 'libcurl', 'urllib', 'wget', 'download', 'file transfer',
-        'http', 'www'],
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: Web Environment',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: Microsoft :: Windows',
-        'Operating System :: POSIX',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.12',
-        'Programming Language :: Python :: 3.13',
-        'Programming Language :: Python :: 3.14',
-        'Topic :: Internet :: File Transfer Protocol (FTP)',
-        'Topic :: Internet :: WWW/HTTP',
-    ],
     packages=[PY_PACKAGE],
     package_dir={ PY_PACKAGE: os.path.join('python', 'curl') },
-    python_requires='>=3.10',
-    platforms='All',
 )
 
 unix_help = '''\

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -9,7 +9,10 @@ test -n "$PYTEST" || PYTEST=pytest
 mkdir -p tests/tmp
 export PYTHONMAJOR=$($PYTHON -V 2>&1 |awk '{print $2}' |awk -F. '{print $1}')
 export PYTHONMINOR=$($PYTHON -V 2>&1 |awk '{print $2}' |awk -F. '{print $2}')
-export PYTHONPATH=$(ls -d build/lib.*$PYTHONMAJOR*$PYTHONMINOR):$PYTHONPATH
+build_lib=$(ls -d build/lib.*$PYTHONMAJOR*$PYTHONMINOR 2>/dev/null || true)
+if [ -n "$build_lib" ]; then
+  export PYTHONPATH="$build_lib:$PYTHONPATH"
+fi
 
 $PYTHON -c 'import pycurl; print(pycurl.version)'
 


### PR DESCRIPTION
- **`pyproject.toml`**: PEP 621 metadata (SPDX license, `dynamic = ["version", "readme"]`), PEP 735 `dev` group; existing `[tool.cibuildwheel]` preserved.
- **`setup.py`**: static metadata removed; libcurl/SSL detection, custom argv flags, `data_files`, and custom subcommands untouched.
- **CI**: `python setup.py sdist|bdist_wheel|build` → `python -m build` / `pip install -e .`.
- **Docs & Makefile**: install examples modernized; `make install` uses `pip` instead of deprecated `setup.py install`.