### PR TITLE
Fix allow `multi.assign()` inside `M_SOCKETFUNCTION` and add `multi.unassign()`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ DOCSTRINGS_SOURCES = \
 	doc/docstrings/multi_socket_action.rst \
 	doc/docstrings/multi_socket_all.rst \
 	doc/docstrings/multi_timeout.rst \
+	doc/docstrings/multi_unassign.rst \
 	doc/docstrings/pycurl_global_cleanup.rst \
 	doc/docstrings/pycurl_global_init.rst \
 	doc/docstrings/pycurl_module.rst \

--- a/doc/curlmultiobject.rst
+++ b/doc/curlmultiobject.rst
@@ -34,3 +34,5 @@ CurlMulti Object
 
     .. _multi-assign:
     .. automethod:: pycurl.CurlMulti.assign
+
+    .. automethod:: pycurl.CurlMulti.unassign

--- a/doc/docstrings/multi_assign.rst
+++ b/doc/docstrings/multi_assign.rst
@@ -3,7 +3,15 @@ assign(sock_fd, object) -> None
 Creates an association in the multi handle between the given socket and
 a private object in the application.
 Corresponds to `curl_multi_assign`_ in libcurl.
-If object is None, clears any association for the socket.
 The multi handle keeps a strong reference to the assigned object.
+
+``assign()`` may be called from inside the ``M_SOCKETFUNCTION`` callback;
+this is the typical place to attach per-socket state. The new value takes
+effect for *future* callbacks for that socket -- the ``socketp`` argument
+already passed to the in-flight callback is not mutated.
+
+If ``object`` is ``None``, clears any association for the socket.
+For convenience, :py:meth:`pycurl.CurlMulti.unassign` is equivalent to
+``multi.assign(sock_fd, None)``.
 
 .. _curl_multi_assign: https://curl.haxx.se/libcurl/c/curl_multi_assign.html

--- a/doc/docstrings/multi_unassign.rst
+++ b/doc/docstrings/multi_unassign.rst
@@ -1,0 +1,8 @@
+unassign(sock_fd) -> None
+
+Clears the association in the multi handle for the given socket,
+releasing the previously assigned object.
+
+``multi.unassign(sock_fd)`` is equivalent to
+:py:meth:`multi.assign(sock_fd, None) <pycurl.CurlMulti.assign>`.
+Like ``assign()``, it may be called from inside the ``M_SOCKETFUNCTION``.

--- a/src/multi.c
+++ b/src/multi.c
@@ -308,7 +308,6 @@ multi_socket_callback(CURL *easy,
     }
 
     if (socketp == NULL) {
-        Py_INCREF(Py_None);
         socketp = Py_None;
     }
 
@@ -629,31 +628,30 @@ do_multi_timeout(CurlMultiObject *self, PyObject *Py_UNUSED(ignored))
 }
 
 
-/* --------------- assign --------------- */
+/* --------------- assign / unassign --------------- */
 
 static PyObject *
-do_multi_assign(CurlMultiObject *self, PyObject *args)
+util_multi_assign(CurlMultiObject *self, PyObject *socket_obj,
+                  PyObject *obj, const char *name)
 {
     CURLMcode res;
     curl_socket_t socket;
-    PyObject *socket_obj;
-    PyObject *obj;
     int clear;
-    PyObject *old = NULL;
+    PyObject *old;
 
-    if (!PyArg_ParseTuple(args, "OO:assign", &socket_obj, &obj)) {
-        return NULL;
-    }
     if (PyLong_AsCurlSocket(socket_obj, &socket) != 0) {
         return NULL;
     }
-    if (check_multi_state(self, 1 | 2, "assign") != 0) {
+    /* Flag 1 only: curl_multi_assign() is callback-safe, so we do not block
+     * calls made while multi_perform()/socket_action() is on the stack. */
+    if (check_multi_state(self, 1, name) != 0) {
         return NULL;
     }
 
     clear = (obj == Py_None);
     old = PyDict_GetItem(self->socket_object_dict, socket_obj);
     Py_XINCREF(old);
+
     /* First, update dict keeping previous value */
     if (clear) {
         if (old && PyDict_DelItem(self->socket_object_dict, socket_obj) < 0) {
@@ -669,6 +667,8 @@ do_multi_assign(CurlMultiObject *self, PyObject *args)
 
     res = curl_multi_assign(self->multi_handle, socket, clear ? NULL : (void *)obj);
     if (res != CURLM_OK) {
+        /* Oversized: formatted message is at most "unassign failed". */
+        char err_msg[64];
         /* Restore previous value */
         if (old) {
             if (PyDict_SetItem(self->socket_object_dict, socket_obj, old) < 0) {
@@ -680,12 +680,36 @@ do_multi_assign(CurlMultiObject *self, PyObject *args)
                 PyErr_Clear();
             }
         }
-        CURLERROR_MSG("assign failed");
+        snprintf(err_msg, sizeof(err_msg), "%s failed", name);
+        CURLERROR_MSG(err_msg);
         return NULL;
     }
 
     Py_XDECREF(old);
     Py_RETURN_NONE;
+}
+
+static PyObject *
+do_multi_assign(CurlMultiObject *self, PyObject *args)
+{
+    PyObject *socket_obj;
+    PyObject *obj;
+
+    if (!PyArg_ParseTuple(args, "OO:assign", &socket_obj, &obj)) {
+        return NULL;
+    }
+    return util_multi_assign(self, socket_obj, obj, "assign");
+}
+
+static PyObject *
+do_multi_unassign(CurlMultiObject *self, PyObject *args)
+{
+    PyObject *socket_obj;
+
+    if (!PyArg_ParseTuple(args, "O:unassign", &socket_obj)) {
+        return NULL;
+    }
+    return util_multi_assign(self, socket_obj, Py_None, "unassign");
 }
 
 
@@ -1183,6 +1207,7 @@ PYCURL_INTERNAL PyMethodDef curlmultiobject_methods[] = {
     {"setopt", (PyCFunction)do_multi_setopt, METH_VARARGS, multi_setopt_doc},
     {"timeout", (PyCFunction)do_multi_timeout, METH_NOARGS, multi_timeout_doc},
     {"assign", (PyCFunction)do_multi_assign, METH_VARARGS, multi_assign_doc},
+    {"unassign", (PyCFunction)do_multi_unassign, METH_VARARGS, multi_unassign_doc},
     {"remove_handle", (PyCFunction)do_multi_remove_handle, METH_VARARGS, multi_remove_handle_doc},
     {"select", (PyCFunction)do_multi_select, METH_VARARGS, multi_select_doc},
     {"__getstate__", (PyCFunction)do_curlmulti_getstate, METH_NOARGS, NULL},

--- a/tests/multi_socket_test.py
+++ b/tests/multi_socket_test.py
@@ -1,6 +1,3 @@
-#! /usr/bin/env python
-# vi:ts=4:et
-
 import gc
 import select
 import sys
@@ -89,6 +86,35 @@ def _assert_within_deadline(deadline, label):
         pytest.fail(f"{label} timed out")
 
 
+def _chunks_transfer(app, multi, socket_callback, label):
+    """Drive a /chunks transfer on `multi` with `socket_callback` installed.
+
+    Yields the timer_state once per drive iteration so the caller can do
+    per-iteration work (e.g. assign() from outside the callback). The easy
+    handle is removed and closed on exit.
+    """
+    timer_state = _setup_timer(multi)
+    multi.setopt(pycurl.M_SOCKETFUNCTION, socket_callback)
+
+    c = util.DefaultCurl()
+    c.body = BytesIO()
+    c.setopt(c.URL, f"{app}/chunks?num_chunks=10&delay=0.1")
+    c.setopt(c.WRITEFUNCTION, c.body.write)
+    multi.add_handle(c)
+
+    try:
+        running = 1
+        deadline = time.monotonic() + 10.0
+        while running:
+            _assert_within_deadline(deadline, label)
+            running = _drive_multi(multi, timeout=0.2, timer_state=timer_state)
+            yield timer_state
+            multi.select(0.1)
+    finally:
+        multi.remove_handle(c)
+        c.close()
+
+
 def test_multi_socket(app, multi):
     urls = [
         # not sure why requesting /success produces no events.
@@ -157,8 +183,6 @@ def test_multi_socket(app, multi):
 
 @pytest.mark.parametrize("reassign", [False, True])
 def test_multi_assign_objects(app, multi, reassign):
-    url = f"{app}/chunks?num_chunks=10&delay=0.1"
-
     assigned = False
     assigned_ref = None
     first_ref = None
@@ -172,44 +196,29 @@ def test_multi_assign_objects(app, multi, reassign):
         if data is not None:
             seen_data = data
 
-    timer_state = _setup_timer(multi)
-    multi.setopt(pycurl.M_SOCKETFUNCTION, socket)
-    c = util.DefaultCurl()
-    c.body = BytesIO()
-    c.setopt(c.URL, url)
-    c.setopt(c.WRITEFUNCTION, c.body.write)
-    multi.add_handle(c)
-
-    running = 1
-    deadline = time.monotonic() + 10.0
-    while running:
-        _assert_within_deadline(deadline, "multi assign objects transfer")
-        running = _drive_multi(multi, timeout=0.2, timer_state=timer_state)
-        if not assigned:
-            assigned_sock = _find_socket(multi, timeout=5.0, timer_state=timer_state)
-            assert assigned_sock is not None
-            first = Sentinel()
-            first_ref = weakref.ref(first)
-            rc_before = sys.getrefcount(first)
-            multi.assign(assigned_sock, first)
-            rc_after = sys.getrefcount(first)
-            assert rc_after >= rc_before + 1
-            if reassign:
-                second = Sentinel()
-                rc2_before = sys.getrefcount(second)
-                assigned_ref = weakref.ref(second)
-                multi.assign(assigned_sock, second)
-                rc2_after = sys.getrefcount(second)
-                assert rc2_after >= rc2_before + 1
-                del second
-            else:
-                assigned_ref = first_ref
-            assigned = True
-            del first
-        multi.select(0.1)
-
-    multi.remove_handle(c)
-    c.close()
+    for timer_state in _chunks_transfer(app, multi, socket, "assign objects"):
+        if assigned:
+            continue
+        assigned_sock = _find_socket(multi, timeout=5.0, timer_state=timer_state)
+        assert assigned_sock is not None
+        first = Sentinel()
+        first_ref = weakref.ref(first)
+        rc_before = sys.getrefcount(first)
+        multi.assign(assigned_sock, first)
+        rc_after = sys.getrefcount(first)
+        assert rc_after >= rc_before + 1
+        if reassign:
+            second = Sentinel()
+            rc2_before = sys.getrefcount(second)
+            assigned_ref = weakref.ref(second)
+            multi.assign(assigned_sock, second)
+            rc2_after = sys.getrefcount(second)
+            assert rc2_after >= rc2_before + 1
+            del second
+        else:
+            assigned_ref = first_ref
+        assigned = True
+        del first
 
     assert assigned_ref is not None
     assert first_ref is not None
@@ -227,9 +236,76 @@ def test_multi_assign_objects(app, multi, reassign):
     assert assigned_ref() is None
 
 
-def test_multi_assign_none_clears(app, multi):
-    url = f"{app}/chunks?num_chunks=10&delay=0.1"
+def test_multi_assign_inside_socket_callback(app, multi):
+    class Marker:
+        pass
 
+    marker = Marker()
+    events = []
+    assign_errors = []
+
+    def socket(event, sock_fd, multi_handle, data):
+        events.append((sock_fd, event, data))
+        if event != pycurl.POLL_REMOVE and data is None:
+            try:
+                multi.assign(sock_fd, marker)
+            except pycurl.error as e:
+                assign_errors.append(e)
+
+    for _ in _chunks_transfer(app, multi, socket, "assign in callback"):
+        pass
+
+    assert assign_errors == []
+    assert any(data is marker for _, _, data in events), (
+        "expected at least one callback to receive the assigned marker as socketp"
+    )
+
+
+def test_multi_unassign_inside_socket_callback(app, multi):
+    class Marker:
+        pass
+
+    marker = Marker()
+    events = []
+    errors = []
+    unassigned = False
+
+    def socket(event, sock_fd, multi_handle, data):
+        nonlocal unassigned
+        events.append((sock_fd, event, data))
+        try:
+            if event != pycurl.POLL_REMOVE and data is None and not unassigned:
+                multi.assign(sock_fd, marker)
+            elif data is marker and not unassigned:
+                multi.unassign(sock_fd)
+                unassigned = True
+        except pycurl.error as e:
+            errors.append(e)
+
+    for _ in _chunks_transfer(app, multi, socket, "unassign in callback"):
+        pass
+
+    assert errors == []
+    assert unassigned, "did not reach unassign() in callback"
+    marker_seen = [i for i, (_, _, d) in enumerate(events) if d is marker]
+    assert marker_seen, "expected at least one callback with marker as socketp"
+    # After the last marker-bearing callback, libcurl's slot is cleared, so
+    # at least one subsequent callback should observe socketp as None again.
+    later_none = [d for _, _, d in events[marker_seen[-1] + 1 :] if d is None]
+    assert later_none, "expected socketp to be None again after unassign()"
+
+
+@pytest.mark.parametrize(
+    "clear",
+    [
+        lambda multi, sock: multi.assign(sock, None),
+        lambda multi, sock: multi.unassign(sock),
+    ],
+    ids=["assign_none", "unassign"],
+)
+def test_multi_clear_assignment(app, multi, clear):
+    """assign(fd, None) and unassign(fd) both clear the association and
+    release the strong reference to the previously assigned object."""
     assigned_sock = None
     assigned_ref = None
 
@@ -239,34 +315,19 @@ def test_multi_assign_none_clears(app, multi):
     def socket(event, sock_fd, multi_handle, data):
         pass
 
-    timer_state = _setup_timer(multi)
-    multi.setopt(pycurl.M_SOCKETFUNCTION, socket)
-    c = util.DefaultCurl()
-    c.body = BytesIO()
-    c.setopt(c.URL, url)
-    c.setopt(c.WRITEFUNCTION, c.body.write)
-    multi.add_handle(c)
-
-    running = 1
-    deadline = time.monotonic() + 10.0
-    while running:
-        _assert_within_deadline(deadline, "multi assign none clears transfer")
-        running = _drive_multi(multi, timeout=0.2, timer_state=timer_state)
-        if assigned_sock is None:
-            assigned_sock = _find_socket(multi, timeout=5.0, timer_state=timer_state)
-            assert assigned_sock is not None
-            sentinel = Sentinel()
-            assigned_ref = weakref.ref(sentinel)
-            rc_before = sys.getrefcount(sentinel)
-            multi.assign(assigned_sock, sentinel)
-            rc_after = sys.getrefcount(sentinel)
-            assert rc_after >= rc_before + 1
-            multi.assign(assigned_sock, None)
-            del sentinel
-        multi.select(0.1)
-
-    multi.remove_handle(c)
-    c.close()
+    for timer_state in _chunks_transfer(app, multi, socket, "clear assignment"):
+        if assigned_sock is not None:
+            continue
+        assigned_sock = _find_socket(multi, timeout=5.0, timer_state=timer_state)
+        assert assigned_sock is not None
+        sentinel = Sentinel()
+        assigned_ref = weakref.ref(sentinel)
+        rc_before = sys.getrefcount(sentinel)
+        multi.assign(assigned_sock, sentinel)
+        rc_after = sys.getrefcount(sentinel)
+        assert rc_after >= rc_before + 1
+        clear(multi, assigned_sock)
+        del sentinel
 
     assert assigned_ref is not None
     gc.collect()


### PR DESCRIPTION
Fixes #977 
- Fix: `do_multi_assign()` state guard relaxed from `1 | 2` to `1`; only requires a live multi handle, no longer rejects calls made while `multi_perform()` / `socket_action()` is on the stack.
- New method `CurlMulti.unassign(sock_fd)` convenience equivalent of `assign(sock_fd, None)`.
- Removed leaked `Py_INCREF(Py_None)` in `multi_socket_callback()` (https://peps.python.org/pep-0683/).
- Docs: `multi_assign.rst` clarified and new `multi_unassign.rst`.
- Regressions tests in `tests/multi_socket_test.py` and existing tests refactored to reuse code.