### PR TITLE
Fix `CurlMulti.__enter__` signature and document `close()` callback restriction

### DIFF
--- a/doc/docstrings/multi_close.rst
+++ b/doc/docstrings/multi_close.rst
@@ -7,8 +7,13 @@ any references to it, but can also be called explicitly.
 It removes all easy handles from the multi handle before closing the
 multi handle.
 
-If ``closed_handles`` is ``True``, the removed easy handles are closed
-after removal. Otherwise, they remain open.
+If the ``CurlMulti`` was constructed with ``close_handles=True``, the
+removed easy handles are also closed after removal. Otherwise, they
+remain open.
+
+``close()`` may not be called while ``perform()`` or ``socket_action()``
+is on the stack (for example, from inside ``M_SOCKETFUNCTION`` or
+``M_TIMERFUNCTION``); doing so raises ``pycurl.error``.
 
 .. _curl_multi_cleanup:
     https://curl.haxx.se/libcurl/c/curl_multi_cleanup.html

--- a/src/multi.c
+++ b/src/multi.c
@@ -1142,7 +1142,7 @@ static PyObject *do_curlmulti_setstate(CurlMultiObject *self, PyObject *args)
 }
 
 
-static PyObject *do_curlmulti_enter(CurlObject *self, PyObject *Py_UNUSED(ignored))
+static PyObject *do_curlmulti_enter(CurlMultiObject *self, PyObject *Py_UNUSED(ignored))
 {
     Py_INCREF(self);
     return (PyObject *)self;


### PR DESCRIPTION
- Type-correct `do_curlmulti_enter`: `CurlObject *` → `CurlMultiObject *`.
- Fix `multi.close()` docstring: typo `closed_handles` → `close_handles=True`, and note that `close()` cannot be called from inside `M_SOCKETFUNCTION`/`M_TIMERFUNCTION`.
