### PR TITLE
`CurlMulti`: honor return values from `M_SOCKETFUNCTION` / `M_TIMERFUNCTION`

### DIFF
--- a/doc/callbacks.rst
+++ b/doc/callbacks.rst
@@ -397,7 +397,7 @@ SSH_KEYFUNCTION
 TIMERFUNCTION
 -------------
 
-.. function:: TIMERFUNCTION(timeout_ms) -> None
+.. function:: TIMERFUNCTION(timeout_ms) -> int | None
 
     Callback for installing a timer requested by libcurl. Corresponds to
     `CURLMOPT_TIMERFUNCTION`_.
@@ -405,7 +405,12 @@ TIMERFUNCTION
     The application should arrange for a non-repeating timer to fire in
     ``timeout_ms`` milliseconds, at which point the application should call
     either :ref:`socket_action <multi-socket_action>` or
-    :ref:`perform <multi-perform>`.
+    :ref:`perform <multi-perform>`. See the `CURLMOPT_TIMERFUNCTION`_ docs
+    for the special values of ``timeout_ms``.
+
+    Return ``0`` or ``None`` for success, or ``-1`` to abort all
+    in-progress transfers in the multi handle. Exceptions raised in the
+    callback are printed to stderr and treated as ``-1``.
 
     See ``examples/multi-socket_action-select.py`` for an example program
     that uses the timer function and the socket function.
@@ -414,7 +419,7 @@ TIMERFUNCTION
 SOCKETFUNCTION
 --------------
 
-.. function:: SOCKETFUNCTION(what, sock_fd, multi, socketp) -> None
+.. function:: SOCKETFUNCTION(what, sock_fd, multi, socketp) -> int | None
 
     Callback notifying the application about activity on libcurl sockets.
     Corresponds to `CURLMOPT_SOCKETFUNCTION`_.
@@ -422,6 +427,10 @@ SOCKETFUNCTION
     Note that the PycURL callback takes ``what`` as the first argument and
     ``sock_fd`` as the second argument, whereas the libcurl callback takes
     ``sock_fd`` as the first argument and ``what`` as the second argument.
+
+    *what* is one of ``pycurl.POLL_IN``, ``POLL_OUT``, ``POLL_INOUT`` or
+    ``POLL_REMOVE``; see the `CURLMOPT_SOCKETFUNCTION`_ docs for their
+    meaning.
 
     The ``userp`` ("private callback pointer") argument, as described in the
     ``CURLMOPT_SOCKETFUNCTION`` documentation, is set to the ``CurlMulti``
@@ -431,6 +440,10 @@ SOCKETFUNCTION
     ``CURLMOPT_SOCKETFUNCTION`` documentation, is set to the value provided
     to the :ref:`assign <multi-assign>` method for the corresponding
     ``sock_fd``, or ``None`` if no value was assigned.
+
+    Return ``0`` or ``None`` for success, or ``-1`` to abort all
+    in-progress transfers in the multi handle. Exceptions raised in the
+    callback are printed to stderr and treated as ``-1``.
 
     See ``examples/multi-socket_action-select.py`` for an example program
     that uses the timer function and the socket function.

--- a/doc/docstrings/multi_setopt.rst
+++ b/doc/docstrings/multi_setopt.rst
@@ -25,8 +25,11 @@ values of different types:
     m.setopt(pycurl.M_PIPELINING, 1)
 
 - ``*FUNCTION`` options accept a function. Supported callbacks are
-  ``CURLMOPT_SOCKETFUNCTION`` AND ``CURLMOPT_TIMERFUNCTION``. Please refer to
-  the PycURL test suite for examples on using the callbacks.
+  ``CURLMOPT_SOCKETFUNCTION`` and ``CURLMOPT_TIMERFUNCTION``; see the
+  ``SOCKETFUNCTION`` and ``TIMERFUNCTION`` sections of the
+  :ref:`callbacks <callbacks>` page. ``CURLMOPT_SOCKETDATA`` and
+  ``CURLMOPT_TIMERDATA`` are reserved by PycURL (set internally to the
+  ``CurlMulti`` instance) and cannot be set from Python.
 
 Raises TypeError when the option value is not of a type accepted by the
 respective option, and pycurl.error exception when libcurl rejects the

--- a/doc/docstrings/multi_socket_action.rst
+++ b/doc/docstrings/multi_socket_action.rst
@@ -4,6 +4,11 @@ Returns result from doing a socket_action() on the curl multi file descriptor
 with the given timeout.
 Corresponds to `curl_multi_socket_action`_ in libcurl.
 
+PycURL exposes the relevant constants as ``pycurl.CSELECT_IN``,
+``CSELECT_OUT``, ``CSELECT_ERR`` (for *ev_bitmask*) and
+``pycurl.SOCKET_TIMEOUT`` (for *sock_fd*); refer to the
+`curl_multi_socket_action`_ docs for their meaning.
+
 The return value is a two-element tuple. The first element is the return
 value of the underlying ``curl_multi_socket_action`` function, and it is
 always zero (``CURLE_OK``) because any other return value would cause

--- a/doc/docstrings/multi_timeout.rst
+++ b/doc/docstrings/multi_timeout.rst
@@ -1,6 +1,7 @@
 timeout() -> int
 
-Returns how long to wait for action before proceeding.
+Returns how long to wait for action before proceeding, in milliseconds, or
+``-1`` if libcurl has no timeout currently set.
 Corresponds to `curl_multi_timeout`_ in libcurl.
 
 .. _curl_multi_timeout: https://curl.haxx.se/libcurl/c/curl_multi_timeout.html

--- a/src/easycb.c
+++ b/src/easycb.c
@@ -8,7 +8,7 @@
 #define PYCURL_BEGIN_CALLBACK(callback_name, retval) \
     PYCURL_BEGIN_CALLBACK_COMMON(PYCURL_ACQUIRE_THREAD(), retval, callback_name)
 
-static int
+PYCURL_INTERNAL int
 callback_return_value_to_int(PyObject *ret_obj, const char *callback_name, int *ret_out)
 {
     if (ret_obj == NULL) {

--- a/src/multi.c
+++ b/src/multi.c
@@ -296,14 +296,16 @@ multi_socket_callback(CURL *easy,
     PyObject *arglist;
     PyObject *py_socket = NULL;
     PyObject *result = NULL;
+    int ret = -1;       /* assume error */
     PYCURL_DECLARE_THREAD_STATE;
 
     /* acquire thread */
     self = (CurlMultiObject *)userp;
-    PYCURL_BEGIN_MULTI_CALLBACK(multi_socket_callback, 0);
+    PYCURL_BEGIN_MULTI_CALLBACK(multi_socket_callback, ret);
 
     /* check args */
     if (self->s_cb == NULL) {
+        ret = 0;
         goto silent_error;
     }
 
@@ -327,11 +329,17 @@ multi_socket_callback(CURL *easy,
         goto verbose_error;
     }
 
-    /* return values from socket callbacks should be ignored */
+    /* None => success; otherwise reuse the easy-callback decode helper.
+     * -1 aborts all in-progress transfers per CURLMOPT_SOCKETFUNCTION. */
+    if (result == Py_None) {
+        ret = 0;
+    } else if (callback_return_value_to_int(result, "multi socket", &ret) != 0) {
+        goto silent_error;
+    }
 
 silent_error:
     Py_XDECREF(result);
-    PYCURL_END_CALLBACK(0);
+    PYCURL_END_CALLBACK(ret);
 verbose_error:
     print_callback_error_if_regular_exception();
     goto silent_error;
@@ -346,7 +354,7 @@ multi_timer_callback(CURLM *multi,
     CurlMultiObject *self;
     PyObject *arglist;
     PyObject *result = NULL;
-    int ret = 0;       /* always success */
+    int ret = -1;       /* assume error */
     PYCURL_DECLARE_THREAD_STATE;
 
     UNUSED(multi);
@@ -356,19 +364,29 @@ multi_timer_callback(CURLM *multi,
     PYCURL_BEGIN_MULTI_CALLBACK(multi_timer_callback, ret);
 
     /* check args */
-    if (self->t_cb == NULL)
+    if (self->t_cb == NULL) {
+        ret = 0;
         goto silent_error;
+    }
 
     /* run callback */
     arglist = Py_BuildValue("(i)", timeout_ms);
-    if (arglist == NULL)
+    if (arglist == NULL) {
         goto verbose_error;
+    }
     result = PyObject_Call(self->t_cb, arglist, NULL);
     Py_DECREF(arglist);
-    if (result == NULL)
+    if (result == NULL) {
         goto verbose_error;
+    }
 
-    /* return values from timer callbacks should be ignored */
+    /* None => success; otherwise reuse the easy-callback decode helper.
+     * -1 aborts all in-progress transfers per CURLMOPT_TIMERFUNCTION. */
+    if (result == Py_None) {
+        ret = 0;
+    } else if (callback_return_value_to_int(result, "multi timer", &ret) != 0) {
+        goto silent_error;
+    }
 
 silent_error:
     Py_XDECREF(result);

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -349,6 +349,9 @@ PyText_Check(PyObject *o);
 PYCURL_INTERNAL PyObject *
 PyText_FromString_Ignore(const char *string);
 
+PYCURL_INTERNAL int
+callback_return_value_to_int(PyObject *ret_obj, const char *callback_name, int *ret_out);
+
 struct CurlObject;
 
 PYCURL_INTERNAL void

--- a/tests/multi_callback_test.py
+++ b/tests/multi_callback_test.py
@@ -1,8 +1,7 @@
-#! /usr/bin/env python
-# vi:ts=4:et
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from io import BytesIO
 from typing import Callable, Generator
 from urllib.parse import urlencode
 import logging
@@ -210,6 +209,118 @@ def test_easy_pause_unpause(multi_ctx: MultiCtx, app):
     assert finished, "Transfer did not finish after sleeping"
     assert multi_ctx.write_calls > calls_before
     assert multi_ctx.bytes_received == 70  # 10 chunks of 7 bytes each
+
+
+@pytest.fixture
+def install_callbacks(app):
+    """Yield make(socket_cb, timer_cb) -> (easy, multi); cleans up on exit."""
+    created: list[tuple[pycurl.Curl, pycurl.CurlMulti]] = []
+
+    def make(socket_cb, timer_cb):
+        easy = util.DefaultCurl()
+        easy.setopt(pycurl.URL, f"{app}/success")
+        easy.setopt(pycurl.WRITEFUNCTION, BytesIO().write)
+        multi = pycurl.CurlMulti()
+        multi.setopt(pycurl.M_SOCKETFUNCTION, socket_cb)
+        multi.setopt(pycurl.M_TIMERFUNCTION, timer_cb)
+        created.append((easy, multi))
+        return easy, multi
+
+    yield make
+
+    for easy, multi in created:
+        try:
+            multi.remove_handle(easy)
+        except pycurl.error:
+            pass
+        multi.close()
+        easy.close()
+
+
+def _drive_to_completion(easy, multi, timeout=5.0):
+    multi.add_handle(easy)
+    multi.socket_action(pycurl.SOCKET_TIMEOUT, 0)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        _, ok_list, err_list = multi.info_read()
+        if ok_list or err_list:
+            return ok_list, err_list
+        rset, wset, xset = multi.fdset()
+        if not (rset or wset or xset):
+            time.sleep(0.01)
+            continue
+        r, w, x = select.select(rset, wset, xset, 0.2)
+        actions: dict[int, int] = {}
+        for s in r:
+            actions[s] = actions.get(s, 0) | pycurl.CSELECT_IN
+        for s in w:
+            actions[s] = actions.get(s, 0) | pycurl.CSELECT_OUT
+        for s in x:
+            actions[s] = actions.get(s, 0) | pycurl.CSELECT_ERR
+        for s, act in actions.items():
+            multi.socket_action(s, act)
+    return None, None
+
+
+def _ok(*_args, **_kwargs):
+    return 0
+
+
+def _none(*_args, **_kwargs):
+    return None
+
+
+def _raises_runtime(*_args, **_kwargs):
+    raise RuntimeError("boom")
+
+
+# Only -1 aborts; any other return (including non-zero ints) continues.
+@pytest.mark.parametrize(
+    "socket_cb,timer_cb",
+    [
+        (_none, _none),
+        (_ok, _ok),
+        (lambda *_: 42, _ok),
+        (_ok, lambda _: 42),
+    ],
+    ids=["return_None", "return_0", "socket_returns_42", "timer_returns_42"],
+)
+def test_callbacks_non_minus_one_return_continues_transfer(
+    install_callbacks, socket_cb, timer_cb
+):
+    easy, multi = install_callbacks(socket_cb, timer_cb)
+    ok, err = _drive_to_completion(easy, multi)
+    assert ok and not err
+
+
+@pytest.mark.parametrize(
+    "socket_cb,timer_cb,expected_stderr",
+    [
+        (lambda *_: -1, _ok, None),
+        (_ok, lambda _: -1, None),
+        (_raises_runtime, _ok, "boom"),
+        (_ok, _raises_runtime, "boom"),
+        (lambda *_: "not an int", _ok, "is not an integer"),
+    ],
+    ids=[
+        "socket_returns_-1",
+        "timer_returns_-1",
+        "socket_raises",
+        "timer_raises",
+        "socket_invalid_type",
+    ],
+)
+def test_callbacks_failure_aborts_transfer(
+    install_callbacks, capfd, socket_cb, timer_cb, expected_stderr
+):
+    easy, multi = install_callbacks(socket_cb, timer_cb)
+    with pytest.raises(pycurl.error):
+        multi.add_handle(easy)
+        multi.socket_action(pycurl.SOCKET_TIMEOUT, 0)
+
+    if expected_stderr is not None:
+        captured = capfd.readouterr()
+        assert expected_stderr in captured.err
 
 
 # (mid-transfer) easy.close() must call SOCKETFUNCTION to remove sockets

--- a/tests/multi_socket_test.py
+++ b/tests/multi_socket_test.py
@@ -295,6 +295,91 @@ def test_multi_unassign_inside_socket_callback(app, multi):
     assert later_none, "expected socketp to be None again after unassign()"
 
 
+def test_socketp_starts_as_none(app, multi):
+    seen_per_fd: dict[int, list] = {}
+
+    def socket(event, sock_fd, multi_handle, data):
+        seen_per_fd.setdefault(sock_fd, []).append(data)
+
+    for _ in _chunks_transfer(app, multi, socket, "socketp starts None"):
+        pass
+
+    assert seen_per_fd, "expected at least one socket callback invocation"
+    for fd, datas in seen_per_fd.items():
+        assert all(d is None for d in datas), (
+            f"fd={fd} received non-None socketp without assign(): {datas!r}"
+        )
+
+
+def test_clear_via_assign_none_inside_callback_resets_socketp(app, multi):
+    class Marker:
+        pass
+
+    marker = Marker()
+    events = []
+    cleared = False
+
+    def socket(event, sock_fd, multi_handle, data):
+        nonlocal cleared
+        events.append((sock_fd, event, data))
+        if event != pycurl.POLL_REMOVE and data is None and not cleared:
+            multi.assign(sock_fd, marker)
+        elif data is marker and not cleared:
+            multi.assign(sock_fd, None)
+            cleared = True
+
+    for _ in _chunks_transfer(app, multi, socket, "assign(None) in callback"):
+        pass
+
+    assert cleared, "did not reach assign(None) inside callback"
+    marker_idx = [i for i, (_, _, d) in enumerate(events) if d is marker]
+    assert marker_idx
+    later_none = [d for _, _, d in events[marker_idx[-1] + 1 :] if d is None]
+    assert later_none, "expected socketp to be None after assign(fd, None)"
+
+
+def _assign_marker_then_close(app):
+    multi = pycurl.CurlMulti()
+    timer_state = _setup_timer(multi)
+
+    class Marker:
+        pass
+
+    marker = Marker()
+    marker_ref = weakref.ref(marker)
+    state = {"assigned": False}
+
+    def socket(event, sock_fd, multi_handle, data):
+        if event != pycurl.POLL_REMOVE and not state["assigned"]:
+            multi.assign(sock_fd, marker)
+            state["assigned"] = True
+
+    multi.setopt(pycurl.M_SOCKETFUNCTION, socket)
+
+    c = util.DefaultCurl()
+    c.body = BytesIO()
+    c.setopt(c.URL, f"{app}/chunks?num_chunks=20&delay=0.05")
+    c.setopt(c.WRITEFUNCTION, c.body.write)
+    multi.add_handle(c)
+
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline and not state["assigned"]:
+        _drive_multi(multi, timeout=0.1, timer_state=timer_state)
+
+    assert state["assigned"], "did not assign marker before timeout"
+
+    multi.remove_handle(c)
+    c.close()
+    multi.close()
+    return marker_ref
+
+
+def test_close_releases_assigned_marker(app):
+    marker_ref = _assign_marker_then_close(app)
+    gc.collect()
+    assert marker_ref() is None, "marker still alive after close()"
+
+
 @pytest.mark.parametrize(
     "clear",
     [

--- a/tests/multi_timer_test.py
+++ b/tests/multi_timer_test.py
@@ -1,88 +1,46 @@
-#! /usr/bin/env python
-# vi:ts=4:et
-
-from . import localhost
-import pycurl
-import unittest
 from io import BytesIO
 
-from . import appmanager
+import pycurl
+
 from . import util
 
-setup_module_1, teardown_module_1 = appmanager.setup(('app', 8380))
-setup_module_2, teardown_module_2 = appmanager.setup(('app', 8381))
-setup_module_3, teardown_module_3 = appmanager.setup(('app', 8382))
 
-def setup_module(mod):
-    setup_module_1(mod)
-    setup_module_2(mod)
-    setup_module_3(mod)
+def _make_easy(app):
+    c = util.DefaultCurl()
+    c.body = BytesIO()
+    c.setopt(c.URL, f"{app}/success")
+    c.setopt(c.WRITEFUNCTION, c.body.write)
+    return c
 
-def teardown_module(mod):
-    teardown_module_3(mod)
-    teardown_module_2(mod)
-    teardown_module_1(mod)
 
-class MultiSocketTest(unittest.TestCase):
-    def test_multi_timer(self):
-        urls = [
-            'http://%s:8380/success' % localhost,
-            'http://%s:8381/success' % localhost,
-            'http://%s:8382/success' % localhost,
-        ]
+def test_multi_timer_perform_loop(app):
+    timers: list[int] = []
 
-        timers = []
+    def timer(timeout_ms):
+        timers.append(timeout_ms)
 
-        # timer callback
-        def timer(msecs):
-            #print('Timer callback msecs:', msecs)
-            timers.append(msecs)
+    multi = pycurl.CurlMulti()
+    multi.setopt(pycurl.M_TIMERFUNCTION, timer)
 
-        # init
-        m = pycurl.CurlMulti()
-        m.setopt(pycurl.M_TIMERFUNCTION, timer)
-        m.handles = []
-        for url in urls:
-            c = util.DefaultCurl()
-            # save info in standard Python attributes
-            c.url = url
-            c.body = BytesIO()
-            c.http_code = -1
-            m.handles.append(c)
-            # pycurl API calls
-            c.setopt(c.URL, c.url)
-            c.setopt(c.WRITEFUNCTION, c.body.write)
-            m.add_handle(c)
+    handles = [_make_easy(app) for _ in range(3)]
+    for c in handles:
+        multi.add_handle(c)
 
-        # get data
-        num_handles = len(m.handles)
+    try:
+        num_handles = len(handles)
         while num_handles:
-            _, num_handles = m.perform()
-            # currently no more I/O is pending, could do something in the meantime
-            # (display a progress bar, etc.)
-            m.select(1.0)
+            _, num_handles = multi.perform()
+            multi.select(1.0)
 
-        for c in m.handles:
-            # save info in standard Python attributes
-            c.http_code = c.getinfo(c.HTTP_CODE)
-
-        # print result
-        for c in m.handles:
-            self.assertEqual('success', c.body.getvalue().decode())
-            self.assertEqual(200, c.http_code)
-
-        assert len(timers) > 0
-        # libcurl 7.23.0 produces a 0 timer
-        assert timers[0] >= 0
-        # this assertion does not appear to hold on older libcurls
-        # or apparently on any linuxes, see
-        # https://github.com/p/pycurl/issues/19
-        #if not util.pycurl_version_less_than(7, 24):
-        #    self.assertEqual(-1, timers[-1])
-
-        # close handles
-        for c in m.handles:
-            # pycurl API calls
-            m.remove_handle(c)
+        for c in handles:
+            assert c.body.getvalue().decode() == "success"
+            assert c.getinfo(c.HTTP_CODE) == 200
+    finally:
+        for c in handles:
+            multi.remove_handle(c)
             c.close()
-        m.close()
+        multi.close()
+
+    assert timers, "expected at least one timer callback"
+    # libcurl 7.23.0 produces a 0 timer; older versions may negative-init.
+    assert timers[0] >= 0


### PR DESCRIPTION
- `M_SOCKETFUNCTION` / `M_TIMERFUNCTION` now honor their Python return value: `None`/`0` continues, `-1` aborts the multi handle (per libcurl), reusing `callback_return_value_to_int` common util function.
- Exceptions raised inside these callbacks now abort the transfer instead of being silently swallowed.
- Docs updated.
- New tests in `multi_callback_test.py`, `multi_socket_test.py` and `multi_timer_test.py`.
- `multi_timer_test.py` modernized.
