### PR TITLE
Convert pycurl into a Python package (C extension at `pycurl._pycurl`)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -38,7 +38,6 @@ include src/share.c
 include src/stringcompat.c
 include src/threadsupport.c
 include src/util.c
-include python/curl/*.py
 include requirements*.txt
 include tests/*.py
 include tests/certs/*.crt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,10 @@ dev = [
     "websockets>=12",
 ]
 
+[tool.setuptools.packages.find]
+# Two roots: pycurl lives in src/, the legacy curl wrapper still lives in python/.
+where = ["src", "python"]
+
 [tool.cibuildwheel]
 build = "cp3*"
 skip = ["cp38-*", "*-musllinux*"]

--- a/python/curl/__init__.py
+++ b/python/curl/__init__.py
@@ -4,10 +4,17 @@
 #    combination with a non-existent file name. See the libcurl docs
 #    for more info.
 
-import sys, pycurl
+import sys, warnings, pycurl
 import urllib.parse as urllib_parse
 from urllib.parse import urljoin
 from io import BytesIO
+
+warnings.warn(
+    "The 'curl' high-level wrapper module is deprecated and will be removed "
+    "in a future release. Use 'pycurl' directly instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 # We should ignore SIGPIPE when using pycurl.NOSIGNAL - see
 # the libcurl tutorial for more info.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 """Setup script for the PycURL module distribution."""
 
-PACKAGE = "pycurl"
+PROJECT_NAME = "pycurl"
+EXTENSION_NAME = "pycurl._pycurl"
 PY_PACKAGE = "curl"
 VERSION = "7.46.0"
 
@@ -649,7 +650,7 @@ def get_extension(argv, split_extension_source=False):
         print('Not using an SSL library')
 
     ext = Extension(
-        name=PACKAGE,
+        name=EXTENSION_NAME,
         sources=sources,
         depends=depends,
         include_dirs=ext_config.include_dirs,
@@ -673,9 +674,9 @@ def get_data_files():
     # a list of tuples with (path to install to, a list of local files)
     data_files = []
     if sys.platform == "win32":
-        datadir = os.path.join("doc", PACKAGE)
+        datadir = os.path.join("doc", PROJECT_NAME)
     else:
-        datadir = os.path.join("share", "doc", PACKAGE)
+        datadir = os.path.join("share", "doc", PROJECT_NAME)
     #
     files = ["AUTHORS", "ChangeLog", "COPYING-LGPL", "COPYING-MIT",
         "INSTALL.rst", "README.rst", "RELEASE-NOTES.rst"]
@@ -889,8 +890,6 @@ in COPYING-LGPL_ and COPYING-MIT_ files in the source distribution.
 .. _COPYING-LGPL: https://raw.githubusercontent.com/pycurl/pycurl/master/COPYING-LGPL
 .. _COPYING-MIT: https://raw.githubusercontent.com/pycurl/pycurl/master/COPYING-MIT
 ''',
-    packages=[PY_PACKAGE],
-    package_dir={ PY_PACKAGE: os.path.join('python', 'curl') },
 )
 
 unix_help = '''\

--- a/src/module.c
+++ b/src/module.c
@@ -375,7 +375,7 @@ static void do_curlmod_free(void *unused) {
 
 static PyModuleDef curlmodule = {
     PyModuleDef_HEAD_INIT,
-    "pycurl",           /* m_name */
+    "pycurl._pycurl",   /* m_name */
     pycurl_module_doc,  /* m_doc */
     -1,                 /* m_size */
     curl_methods,       /* m_methods */
@@ -386,7 +386,7 @@ static PyModuleDef curlmodule = {
 };
 
 
-PyMODINIT_FUNC PyInit_pycurl(void)
+PyMODINIT_FUNC PyInit__pycurl(void)
 {
     PyObject *m, *d;
     const curl_version_info_data *vi;

--- a/src/pycurl/__init__.py
+++ b/src/pycurl/__init__.py
@@ -1,0 +1,4 @@
+from pycurl import _pycurl
+from pycurl._pycurl import *  # noqa: F401, F403
+
+__all__ = [name for name in dir(_pycurl) if not name.startswith("_")]


### PR DESCRIPTION
Turn `pycurl` into a real Python package with the C extension renamed to `pycurl._pycurl` and a thin `src/pycurl/__init__.py` re-exporting its public API.