### PR TITLE
Fix #985: dynamic SSL ports + modernize affected tests

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -98,8 +98,6 @@ jobs:
           CIBW_ARCHS_WINDOWS: ${{ matrix.arch == 'x86' && 'x86' || matrix.arch == 'arm64' && 'ARM64' || 'AMD64' }}
           CIBW_ENVIRONMENT_WINDOWS: PYCURL_CURL_DIR=C:/vcpkg/packages/curl_${{ matrix.arch }}-windows PYCURL_SSL_LIBRARY=schannel
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair --add-path C:/vcpkg/installed/${{ matrix.arch }}-windows/bin -w {dest_dir} {wheel}
-          # https://github.com/pycurl/pycurl/issues/985
-          CIBW_TEST_SKIP: 'cp*-macosx_x86_64'
         run: |
           python -m cibuildwheel --output-dir wheelhouse
 

--- a/tests/cadata_test.py
+++ b/tests/cadata_test.py
@@ -1,43 +1,37 @@
-#! /usr/bin/env python
-# vi:ts=4:et
-
-import os
-import pycurl
-import unittest
 from io import BytesIO
+from pathlib import Path
 
-from . import appmanager
+import pycurl
+import pytest
+
 from . import util
 
-setup_module, teardown_module = appmanager.setup(('app', 8384, dict(ssl=True)))
 
-class CaCertsTest(unittest.TestCase):
-    def setUp(self):
-        self.curl = util.DefaultCurlLocalhost(8384)
+@util.only_ssl_backends("openssl")
+def test_request_with_verifypeer(ssl_curl, ssl_app):
+    cert_path = Path(__file__).parent / "certs" / "ca.crt"
+    cadata = cert_path.read_bytes().decode("ASCII")
 
-    def tearDown(self):
-        self.curl.close()
+    ssl_curl.setopt(pycurl.URL, f"{ssl_app}/success")
+    sio = BytesIO()
+    ssl_curl.set_ca_certs(cadata)
+    ssl_curl.setopt(pycurl.WRITEFUNCTION, sio.write)
+    # self signed certificate, but ca cert should be loaded
+    ssl_curl.setopt(pycurl.SSL_VERIFYPEER, 1)
+    ssl_curl.perform()
+    assert sio.getvalue().decode() == "success"
 
-    @util.only_ssl_backends('openssl')
-    def test_request_with_verifypeer(self):
-        with open(os.path.join(os.path.dirname(__file__), 'certs', 'ca.crt'), 'rb') as stream:
-            cadata = stream.read().decode('ASCII')
-        self.curl.setopt(pycurl.URL, 'https://localhost:8384/success')
-        sio = BytesIO()
-        self.curl.set_ca_certs(cadata)
-        self.curl.setopt(pycurl.WRITEFUNCTION, sio.write)
-        # self signed certificate, but ca cert should be loaded
-        self.curl.setopt(pycurl.SSL_VERIFYPEER, 1)
-        self.curl.perform()
-        assert sio.getvalue().decode() == 'success'
 
-    @util.only_ssl_backends('openssl')
-    def test_set_ca_certs_bytes(self):
-        self.curl.set_ca_certs(util.b('hello world\x02\xe0'))
+@util.only_ssl_backends("openssl")
+def test_set_ca_certs_bytes(curl):
+    curl.set_ca_certs(util.b("hello world\x02\xe0"))
 
-    @util.only_ssl_backends('openssl')
-    def test_set_ca_certs_bogus_type(self):
-        try:
-            self.curl.set_ca_certs(42)
-        except TypeError as e:
-            self.assertEqual('set_ca_certs argument must be a byte string or a Unicode string with ASCII code points only', str(e))
+
+@util.only_ssl_backends("openssl")
+def test_set_ca_certs_bogus_type(curl):
+    with pytest.raises(TypeError) as exc_info:
+        curl.set_ca_certs(42)
+    assert (
+        str(exc_info.value)
+        == "set_ca_certs argument must be a byte string or a Unicode string with ASCII code points only"
+    )

--- a/tests/certinfo_test.py
+++ b/tests/certinfo_test.py
@@ -1,94 +1,54 @@
-#! /usr/bin/env python
-# vi:ts=4:et
-
-import pycurl
-import unittest
 from io import BytesIO
 
-from . import appmanager
+import pycurl
+import pytest
+
 from . import util
 
-setup_module, teardown_module = appmanager.setup(('app', 8383, dict(ssl=True)))
 
-class CertinfoTest(unittest.TestCase):
-    def setUp(self):
-        self.curl = util.DefaultCurlLocalhost(8383)
+@util.min_libcurl(7, 19, 1)
+def test_certinfo_option():
+    assert hasattr(pycurl, "OPT_CERTINFO")
 
-    def tearDown(self):
-        self.curl.close()
 
-    # CURLOPT_CERTINFO was introduced in libcurl-7.19.1
-    @util.min_libcurl(7, 19, 1)
-    def test_certinfo_option(self):
-        assert hasattr(pycurl, 'OPT_CERTINFO')
+@util.min_libcurl(7, 19, 1)
+@util.only_ssl
+def test_request_without_certinfo(ssl_curl, ssl_app):
+    ssl_curl.setopt(pycurl.URL, f"{ssl_app}/success")
+    sio = BytesIO()
+    ssl_curl.setopt(pycurl.WRITEFUNCTION, sio.write)
+    # self signed certificate
+    ssl_curl.setopt(pycurl.SSL_VERIFYPEER, 0)
+    ssl_curl.perform()
+    assert sio.getvalue().decode() == "success"
 
-    # CURLOPT_CERTINFO was introduced in libcurl-7.19.1
-    @util.min_libcurl(7, 19, 1)
-    @util.only_ssl
-    def test_request_without_certinfo(self):
-        self.curl.setopt(pycurl.URL, 'https://localhost:8383/success')
-        sio = BytesIO()
-        self.curl.setopt(pycurl.WRITEFUNCTION, sio.write)
-        # self signed certificate
-        self.curl.setopt(pycurl.SSL_VERIFYPEER, 0)
-        self.curl.perform()
-        assert sio.getvalue().decode() == 'success'
+    certinfo = ssl_curl.getinfo(pycurl.INFO_CERTINFO)
+    assert certinfo == []
 
-        certinfo = self.curl.getinfo(pycurl.INFO_CERTINFO)
-        self.assertEqual([], certinfo)
 
-    # CURLOPT_CERTINFO was introduced in libcurl-7.19.1
-    @util.min_libcurl(7, 19, 1)
-    @util.only_ssl
-    def test_request_with_certinfo(self):
-        # CURLOPT_CERTINFO only works with OpenSSL
-        if 'openssl' not in pycurl.version.lower():
-            raise unittest.SkipTest('libcurl does not use openssl')
+@pytest.mark.parametrize(
+    "getter,coerce",
+    [
+        (pycurl.Curl.getinfo, util.u),
+        (pycurl.Curl.getinfo_raw, util.b),
+    ],
+    ids=["getinfo", "getinfo_raw"],
+)
+@util.min_libcurl(7, 19, 1)
+@util.only_ssl_backends("openssl")
+def test_certinfo_returns_subject(ssl_curl, ssl_app, getter, coerce):
+    ssl_curl.setopt(pycurl.URL, f"{ssl_app}/success")
+    sio = BytesIO()
+    ssl_curl.setopt(pycurl.WRITEFUNCTION, sio.write)
+    ssl_curl.setopt(pycurl.OPT_CERTINFO, 1)
+    # self signed certificate
+    ssl_curl.setopt(pycurl.SSL_VERIFYPEER, 0)
+    ssl_curl.perform()
+    assert sio.getvalue().decode() == "success"
 
-        self.curl.setopt(pycurl.URL, 'https://localhost:8383/success')
-        sio = BytesIO()
-        self.curl.setopt(pycurl.WRITEFUNCTION, sio.write)
-        self.curl.setopt(pycurl.OPT_CERTINFO, 1)
-        # self signed certificate
-        self.curl.setopt(pycurl.SSL_VERIFYPEER, 0)
-        self.curl.perform()
-        assert sio.getvalue().decode() == 'success'
-
-        certinfo = self.curl.getinfo(pycurl.INFO_CERTINFO)
-        # self signed certificate, one certificate in chain
-        assert len(certinfo) == 1
-        certinfo = certinfo[0]
-        # convert to a dictionary
-        certinfo_dict = {}
-        for entry in certinfo:
-            certinfo_dict[entry[0]] = entry[1]
-        assert util.u('Subject') in certinfo_dict
-        assert util.u('PycURL test suite') in certinfo_dict[util.u('Subject')]
-
-    # CURLOPT_CERTINFO was introduced in libcurl-7.19.1
-    @util.min_libcurl(7, 19, 1)
-    @util.only_ssl
-    def test_getinfo_raw_certinfo(self):
-        # CURLOPT_CERTINFO only works with OpenSSL
-        if 'openssl' not in pycurl.version.lower():
-            raise unittest.SkipTest('libcurl does not use openssl')
-
-        self.curl.setopt(pycurl.URL, 'https://localhost:8383/success')
-        sio = BytesIO()
-        self.curl.setopt(pycurl.WRITEFUNCTION, sio.write)
-        self.curl.setopt(pycurl.OPT_CERTINFO, 1)
-        # self signed certificate
-        self.curl.setopt(pycurl.SSL_VERIFYPEER, 0)
-        self.curl.perform()
-        assert sio.getvalue().decode() == 'success'
-
-        certinfo = self.curl.getinfo_raw(pycurl.INFO_CERTINFO)
-        # self signed certificate, one certificate in chain
-        assert len(certinfo) == 1
-        certinfo = certinfo[0]
-        # convert to a dictionary
-        certinfo_dict = {}
-        for entry in certinfo:
-            certinfo_dict[entry[0]] = entry[1]
-        assert util.b('Subject') in certinfo_dict
-        assert util.b('PycURL test suite') in certinfo_dict[util.b('Subject')]
+    certinfo = getter(ssl_curl, pycurl.INFO_CERTINFO)
+    # self signed certificate, one certificate in chain
+    assert len(certinfo) == 1
+    certinfo_dict = dict(certinfo[0])
+    assert coerce("Subject") in certinfo_dict
+    assert coerce("PycURL test suite") in certinfo_dict[coerce("Subject")]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,19 @@
+from __future__ import annotations
+
 import socket
-import pytest
 import time
-from typing import Generator
+from typing import TYPE_CHECKING, Generator
+from urllib.parse import urlparse
+
+import pytest
 
 from . import appmanager, localhost, util
+
+if TYPE_CHECKING:
+    import pycurl
+
+
+DEFAULT_WAIT_TIMEOUT = 30.0
 
 
 def _get_free_port() -> int:
@@ -12,7 +22,7 @@ def _get_free_port() -> int:
         return s.getsockname()[1]
 
 
-def wait_listening(host: str, port: int, timeout: float = 5.0) -> None:
+def wait_listening(host: str, port: int, timeout: float = DEFAULT_WAIT_TIMEOUT) -> None:
     deadline = time.monotonic() + timeout
 
     while time.monotonic() < deadline:
@@ -42,14 +52,24 @@ def app() -> Generator[str, None, None]:
     yield from make_app()
 
 
-def make_app() -> Generator[str, None, None]:
+@pytest.fixture(scope="session")
+def ssl_app() -> Generator[str, None, None]:
+    yield from make_app(ssl=True)
+
+
+@pytest.fixture
+def ssl_curl(ssl_app: str) -> Generator[pycurl.Curl, None, None]:
+    port = urlparse(ssl_app).port
+    assert port is not None
+    c = util.DefaultCurlLocalhost(port)
+    yield c
+    c.close()
+
+
+def make_app(ssl: bool = False) -> Generator[str, None, None]:
     port = _get_free_port()
-    setup, teardown = appmanager.setup(
-        (
-            "app",
-            port,
-        )
-    )
+    kwargs = {"ssl": True} if ssl else {}
+    setup, teardown = appmanager.setup(("app", port, kwargs))
 
     # appmanager.setup() stores server state on the object passed to setup/teardown.
     # At session scope we don't have a module object, so use a tiny holder.
@@ -58,8 +78,10 @@ def make_app() -> Generator[str, None, None]:
 
     state = _AppState()
     setup(state)
-    wait_listening(localhost, port, timeout=10.0)
-    yield f"http://{localhost}:{port}"
+    wait_listening(localhost, port, timeout=DEFAULT_WAIT_TIMEOUT)
+    # SSL tests need the URL hostname to match the cert SAN (DNS:localhost).
+    scheme, host = ("https", "localhost") if ssl else ("http", localhost)
+    yield f"{scheme}://{host}:{port}"
     teardown(state)
 
 
@@ -69,7 +91,7 @@ def ws_app() -> Generator[str, None, None]:
 
     port = _get_free_port()
     server = wsappmanager.start_server(localhost, port)
-    wait_listening(localhost, port, timeout=10.0)
+    wait_listening(localhost, port, timeout=DEFAULT_WAIT_TIMEOUT)
     try:
         yield f"ws://{localhost}:{port}"
     finally:

--- a/tests/runwsgi.py
+++ b/tests/runwsgi.py
@@ -62,11 +62,11 @@ def start_bottle_server(app, port, server, **kwargs):
     server_thread.daemon = True
     server_thread.start()
 
-    ok = util.wait_for_network_service(("127.0.0.1", port), 0.1, 10)
+    ok = util.wait_for_network_service(("127.0.0.1", port), 0.1, 300)
     if not ok:
         import warnings
 
-        warnings.warn("Server did not start after 1 second")
+        warnings.warn("Server did not start after 30 seconds")
 
     return server_thread.server
 


### PR DESCRIPTION
Fixes #985 

- Add session-scoped `ssl_app` + `ssl_curl` fixtures in `conftest.py`.
- Modernize tests.
- Align server timeouts to 30 seconds.
- Remove `CIBW_TEST_SKIP=cp*-macosx_x86_64` from `cibuildwheel.yml`.