### PR TITLE
Don't set CFLAGS=-Werror in CI cibuildwheel builds

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -97,8 +97,6 @@ jobs:
       run: make do-test
     - name: Build & test with cibuildwheel
       if: matrix.curl-version == 'vcpkg'
-      env:
-        CFLAGS: -Werror
       run: |
         pip install cibuildwheel
         cibuildwheel --only ${{ matrix.cibw-build }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,6 @@ jobs:
       run: make do-test
     - name: Build & test with cibuildwheel
       if: matrix.curl-version == 'vcpkg'
-      env:
-        CFLAGS: -Werror
       run: |
         pip install cibuildwheel
         cibuildwheel --only ${{ matrix.cibw-build }}


### PR DESCRIPTION
On Linux this wasn't even doing anything, but on macOS this was causing all the vcpkg builds to be done with -Werror which caused some failures. Will try to figure out how to enable this just for the pycurl build portion of cibuildwheel in the future.