### PR TITLE
Automate release tags and draft GitHub releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,36 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot
+  categories:
+    - title: Breaking changes
+      labels:
+        - breaking-change
+    - title: Features
+      labels:
+        - enhancement
+        - feature
+    - title: Bug fixes
+      labels:
+        - bug
+        - fix
+    - title: Packaging and wheels
+      labels:
+        - packaging
+        - wheels
+        - build
+        - cibuildwheel
+    - title: Documentation
+      labels:
+        - documentation
+        - docs
+    - title: Maintenance
+      labels:
+        - maintenance
+        - ci
+        - github-actions
+    - title: Other changes
+      labels:
+        - "*"

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,39 @@
+name: Draft GitHub Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  draft-release:
+    name: Create draft GitHub Release
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate release tag
+        run: |
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid release tag: ${GITHUB_REF_NAME}"
+            echo "Release tags must use the vX.Y.Z schema, for example v7.46.1"
+            exit 1
+          fi
+
+      - name: Create draft GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+
+          gh release create "${GITHUB_REF_NAME}" \
+            --draft \
+            --verify-tag \
+            --title "PycURL ${VERSION}" \
+            --generate-notes

--- a/doc/release-process.rst
+++ b/doc/release-process.rst
@@ -1,6 +1,30 @@
 Release Process
 ===============
 
+Release tag schema
+------------------
+
+Release tags should use the ``vX.Y.Z`` schema, for example ``v7.46.1``.
+The leading ``v`` is required for new release tags.
+
+Older releases used ``REL_X_Y_Z``-style tags (for example ``REL_7_45_7``).
+These historical tags are kept unchanged and continue to be referenced
+from the changelog and from ``git shortlog`` invocations such as the one
+in step 3 below.
+
+Pushing a ``vX.Y.Z`` tag triggers the Draft GitHub Release workflow
+(``.github/workflows/draft-release.yml``), which creates a draft GitHub
+Release with automatically generated release notes. Maintainers should
+review and edit the draft release before publishing it.
+
+The existing manual Build Wheels workflow
+(``.github/workflows/cibuildwheel.yml``) remains the publishing path for
+PyPI and TestPyPI. This first step does not make PyPI publishing
+tag-driven.
+
+Release checklist
+-----------------
+
 1. Ensure changelog is up to date with commits in master.
 2. Run ``python setup.py authors`` and review the updated AUTHORS file.
 3. Run ``git shortlog REL_<previous release>...`` and add new contributors


### PR DESCRIPTION
First step toward a more automated release flow.

Proposal for new release tags use the standard `vX.Y.Z` schema (e.g. `v7.46.1`). Pushing one of those triggers a new workflow that creates a draft GitHub Release with auto-generated notes, maintainers review and edit before publishing. Historical `REL_X_Y_Z` tags stay untouched.

PyPI publishing is unchanged: still manual via the existing `Build Wheels` workflow, with Trusted Publishing / attestation behavior untouched.

Adds `.github/workflows/draft-release.yml`, `.github/release.yml` (notes categorization), and a short section in `doc/release-process.rst`.
