### PR TITLE
Add free-threaded CPython support

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         curl-version: ["macos"]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
         runner: ["macos-15"]
         include:
           - curl-version: "vcpkg"
@@ -82,14 +82,20 @@ jobs:
       if: matrix.curl-version == 'macos'
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
-        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+        pip install flake8
         brew install vsftpd
     - name: Build
       if: matrix.curl-version == 'macos'
       env:
         CFLAGS: -Werror
-      run: python -m pip install .
+      run: python -m pip install . --group dev
+    - name: Verify free-threaded import does not enable the GIL
+      if: matrix.python-version == '3.14t' && matrix.curl-version == 'macos'
+      env:
+        PYTHON_GIL: "0"
+      run: |
+        python -W error -c "import pycurl; print(pycurl.version)"
+        python -c "import sys, pycurl; assert sys._is_gil_enabled() is False, 'pycurl import re-enabled the GIL'"
     - name: Test with pytest
       if: matrix.curl-version == 'macos'
       env:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         os: ["windows-2025"]
         arch: ["x64"]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
         include:
           - os: "windows-11-arm"
             arch: "arm64"
@@ -80,6 +80,13 @@ jobs:
         delvewheel repair --add-path $VCPKG_INSTALLATION_ROOT/installed/${{ matrix.arch }}-windows/bin dist/*.whl
         pip install wheelhouse/*.whl
       shell: bash
+    - name: Verify free-threaded import does not enable the GIL
+      if: matrix.python-version == '3.14t'
+      env:
+        PYTHON_GIL: "0"
+      run: |
+        python -W error -c "import pycurl; print(pycurl.version)"
+        python -c "import sys, pycurl; assert sys._is_gil_enabled() is False, 'pycurl import re-enabled the GIL'"
     - name: Test with pytest
       run: |
         python -c 'import pycurl; print(pycurl.version)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         curl-version: ["ubuntu"]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
         include:
           - curl-version: "vcpkg"
             python-version: "3.12"
@@ -72,8 +72,7 @@ jobs:
       if: matrix.curl-version == 'ubuntu'
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
-        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+        pip install flake8
         sudo apt-get install vsftpd
     - name: Lint with flake8
       if: matrix.curl-version == 'ubuntu'
@@ -86,7 +85,14 @@ jobs:
       if: matrix.curl-version == 'ubuntu'
       env:
         CFLAGS: -Werror
-      run: make
+      run: python -m pip install . --group dev
+    - name: Verify free-threaded import does not enable the GIL
+      if: matrix.python-version == '3.14t' && matrix.curl-version == 'ubuntu'
+      env:
+        PYTHON_GIL: "0"
+      run: |
+        python -W error -c "import pycurl; print(pycurl.version)"
+        python -c "import sys, pycurl; assert sys._is_gil_enabled() is False, 'pycurl import re-enabled the GIL'"
     - name: Test with pytest
       if: matrix.curl-version == 'ubuntu'
       env:

--- a/doc/thread-safety.rst
+++ b/doc/thread-safety.rst
@@ -11,7 +11,9 @@ For Python programs using PycURL, this means:
 * Accessing the same PycURL object from different threads is OK when
   this object is not involved in active transfers, as Python internally
   has a Global Interpreter Lock and only one operating system thread can
-  be executing Python code at a time.
+  be executing Python code at a time. On free-threaded CPython, the
+  GIL is no longer present; the same rules apply, but the caller must
+  serialise concurrent access to a shared PycURL object explicitly.
 
 * Accessing a PycURL object that is involved in an active transfer from
   Python code *inside a libcurl callback for the PycURL object in question*
@@ -21,12 +23,20 @@ For Python programs using PycURL, this means:
   Python code *outside of a libcurl callback for the PycURL object in question*
   is unsafe.
 
+* ``CurlShare`` is thread-safe: different ``Curl`` handles attached
+  to the same share may be used from different threads. Concurrent
+  method calls on the same ``CurlShare`` Python object are not.
+
 * Closing a ``CurlShare`` object with ``detach_on_close=True`` (the
   default) is **not thread-safe** with respect to the associated
   ``Curl`` objects. During ``CurlShare.close()``, PycURL automatically
   detaches all associated ``Curl`` objects by clearing their ``SHARE``
   option. The caller must ensure that no other thread is using the
   associated ``Curl`` objects while ``CurlShare.close()`` is executing.
+
+* Not every kind of libcurl shared data is safe to share across
+  threads. See `CURLSHOPT_SHARE`_ for the list of supported
+  ``CURL_LOCK_DATA_*`` values and their constraints.
 
 * A WebSocket handle (``CONNECT_ONLY=2`` plus ``ws_send`` / ``ws_recv``)
   follows the same one-handle-one-thread rule: do not call ``ws_send``
@@ -45,4 +55,5 @@ work properly in multi-threaded programs. When using PycURL objects from
 multiple Python threads ``NOSIGNAL`` option `must be given`_.
 
 .. _libcurl thread safety documentation: https://curl.haxx.se/libcurl/c/threadsafe.html
+.. _CURLSHOPT_SHARE: https://curl.se/libcurl/c/CURLSHOPT_SHARE.html
 .. _must be given: https://github.com/curl/curl/issues/1003

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Free Threading :: 1 - Unstable",
     "Topic :: Internet :: File Transfer Protocol (FTP)",
     "Topic :: Internet :: WWW/HTTP",
 ]
@@ -49,6 +50,8 @@ dev = [
     "paramiko; sys_platform != 'win32' or platform_machine != 'ARM64'",
     "pyflakes",
     "pytest>=5",
+    "pytest-run-parallel",
+    "pytest-timeout",
     "sphinx",
     "setuptools",
     "websockets>=12",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,8 @@ numpy
 paramiko; sys_platform != 'win32' or platform_machine != 'ARM64'
 pyflakes
 pytest>=5
+pytest-run-parallel
+pytest-timeout
 sphinx
 setuptools
 websockets>=12

--- a/src/module.c
+++ b/src/module.c
@@ -539,6 +539,10 @@ PYCURL_IGNORE_DEPRECATED_END
     if (m == NULL)
         goto error;
 
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+
     /* Add error object to the module */
     d = PyModule_GetDict(m);
     assert(d != NULL);

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from io import BytesIO
+
+import pycurl
+import pytest
+
+from . import util
+
+
+HAS_XFERINFOFUNCTION = hasattr(pycurl, "XFERINFOFUNCTION")
+
+
+def _run_workers(worker, n_workers):
+    with ThreadPoolExecutor(max_workers=n_workers) as ex:
+        futures = [ex.submit(worker) for _ in range(n_workers)]
+        return [f.result() for f in futures]
+
+
+def _drive_multi(m):
+    _, num_handles = m.perform()
+    while num_handles:
+        m.select(0.1)
+        _, num_handles = m.perform()
+    while True:
+        queued, _, err = m.info_read()
+        if err:
+            pytest.fail(f"Multi transfer errors: {err}")
+        if not queued:
+            break
+
+
+@pytest.mark.parallel_threads(4)
+@pytest.mark.timeout(120)
+def test_independent_curl_objects_in_parallel(app):
+    c = util.DefaultCurl()
+    for _ in range(5):
+        buf = BytesIO()
+        c.setopt(pycurl.URL, app + "/success")
+        c.setopt(pycurl.WRITEFUNCTION, buf.write)
+        c.perform()
+        assert buf.getvalue() == b"success"
+
+
+@pytest.mark.timeout(120)
+def test_same_curl_with_user_lock(app):
+    c = util.DefaultCurl()
+    lock = threading.Lock()
+    n_workers = 4
+    iters_per_worker = 5
+    # Barrier aligns worker start so the lock is contended on free-threaded builds.
+    barrier = threading.Barrier(n_workers)
+    results: list[bytes] = []
+
+    def worker():
+        barrier.wait()
+        for _ in range(iters_per_worker):
+            with lock:
+                buf = BytesIO()
+                c.setopt(pycurl.URL, app + "/success")
+                c.setopt(pycurl.WRITEFUNCTION, buf.write)
+                c.perform()
+                results.append(buf.getvalue())
+
+    _run_workers(worker, n_workers)
+
+    assert results == [b"success"] * (n_workers * iters_per_worker)
+
+
+@pytest.mark.parallel_threads(4)
+@pytest.mark.timeout(120)
+def test_independent_curlmulti_objects_in_parallel(app):
+    n_easies = 3
+    m = pycurl.CurlMulti()
+    easies = []
+    for _ in range(n_easies):
+        c = util.DefaultCurl()
+        buf = BytesIO()
+        c.setopt(pycurl.URL, app + "/success")
+        c.setopt(pycurl.WRITEFUNCTION, buf.write)
+        m.add_handle(c)
+        easies.append((c, buf))
+
+    _drive_multi(m)
+
+    assert [buf.getvalue() for _, buf in easies] == [b"success"] * n_easies
+
+
+@pytest.mark.timeout(120)
+def test_shared_curlmulti_with_user_lock(app):
+    m = pycurl.CurlMulti()
+    lock = threading.Lock()
+    n_workers = 2
+    iters_per_worker = 3
+    results: list[bytes] = []
+
+    def worker():
+        for _ in range(iters_per_worker):
+            c = util.DefaultCurl()
+            buf = BytesIO()
+            c.setopt(pycurl.URL, app + "/success")
+            c.setopt(pycurl.WRITEFUNCTION, buf.write)
+
+            with lock:
+                m.add_handle(c)
+                _drive_multi(m)
+                m.remove_handle(c)
+
+            results.append(buf.getvalue())
+
+    _run_workers(worker, n_workers)
+
+    assert results == [b"success"] * (n_workers * iters_per_worker)
+
+
+@pytest.mark.parallel_threads(4)
+@pytest.mark.timeout(120)
+def test_callback_transfers_in_parallel(app):
+    c = util.DefaultCurl()
+    body = bytearray()
+    headers: list[bytes] = []
+    progress_called = False
+
+    c.setopt(pycurl.URL, app + "/header?h=X-Test")
+    c.setopt(pycurl.HTTPHEADER, ["X-Test: hello"])
+    c.setopt(pycurl.WRITEFUNCTION, body.extend)
+    c.setopt(pycurl.HEADERFUNCTION, headers.append)
+    c.setopt(pycurl.NOPROGRESS, False)
+    if HAS_XFERINFOFUNCTION:
+
+        def progress(_dlt, _dln, _ult, _uln):
+            nonlocal progress_called
+            progress_called = True
+            return 0
+
+        c.setopt(pycurl.XFERINFOFUNCTION, progress)
+
+    for _ in range(3):
+        body.clear()
+        headers.clear()
+        progress_called = False
+        c.perform()
+        assert body == b"hello"
+        assert any(h.lower().startswith(b"content-length") for h in headers)
+        if HAS_XFERINFOFUNCTION:
+            assert progress_called
+
+
+@pytest.mark.timeout(120)
+def test_share_with_many_curls_in_parallel(app):
+    s = pycurl.CurlShare()
+    s.setopt(pycurl.SH_SHARE, pycurl.LOCK_DATA_DNS)
+    s.setopt(pycurl.SH_SHARE, pycurl.LOCK_DATA_SSL_SESSION)
+
+    n_workers = 6
+    iters_per_worker = 4
+    results: list[bytes] = []
+    results_lock = threading.Lock()
+
+    def worker():
+        c = util.DefaultCurl()
+        c.setopt(pycurl.SHARE, s)
+        for _ in range(iters_per_worker):
+            buf = BytesIO()
+            c.setopt(pycurl.URL, app + "/success")
+            c.setopt(pycurl.WRITEFUNCTION, buf.write)
+            c.perform()
+            with results_lock:
+                results.append(buf.getvalue())
+
+    _run_workers(worker, n_workers)
+
+    assert results == [b"success"] * (n_workers * iters_per_worker)


### PR DESCRIPTION
- Declare `Py_MOD_GIL_NOT_USED` in `src/module.c` (guarded by `#ifdef Py_GIL_DISABLED`).
- Add `3.14t` to all three CI matrices with an import sanity check.
- Add `tests/test_thread_safety.py` with six concurrency scenarios.
- Update `doc/thread-safety.rst`
- Add [`Free Threading :: 1 - Unstable` classifier](https://py-free-threading.github.io/porting/#define-and-document-thread-safety-guarantees) in `pyproject.toml`
- `cp314t` wheels were already being built.

Closes #996.
