### PR TITLE
Modernize ssh_key_cb_test and use a local SFTP server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
     "flaky",
     "flask",
     "numpy",
+    "paramiko; sys_platform != 'win32' or platform_machine != 'ARM64'",
     "pyflakes",
     "pytest>=5",
     "sphinx",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 flaky
 flask
 numpy
+paramiko; sys_platform != 'win32' or platform_machine != 'ARM64'
 pyflakes
 pytest>=5
 sphinx

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,3 +96,36 @@ def ws_app() -> Generator[str, None, None]:
         yield f"ws://{localhost}:{port}"
     finally:
         server.stop()
+
+
+@pytest.fixture(scope='session')
+def sftp_server():
+    from .sftp import LocalSFTPServer
+    server = LocalSFTPServer()
+    server.start()
+    if not util.wait_for_network_service(('127.0.0.1', server.port), 0.1, 20):
+        pytest.fail('Local SFTP server did not start in time')
+    yield server
+    server.stop()
+
+
+@pytest.fixture(scope='session')
+def known_hosts_file(sftp_server, tmp_path_factory):
+    import paramiko
+    # A mismatched key ensures the keyfunction is always invoked with
+    # CURLKHMATCH_MISMATCH, so the callback return value drives test outcomes.
+    different_key = paramiko.RSAKey.generate(2048)
+    entry = f'[127.0.0.1]:{sftp_server.port} {different_key.get_name()} {different_key.get_base64()}\n'
+    path = tmp_path_factory.mktemp('ssh') / 'known_hosts'
+    path.write_text(entry)
+    return str(path)
+
+
+@pytest.fixture
+def sftp_curl(sftp_server):
+    import pycurl
+    c = util.DefaultCurl()
+    c.setopt(pycurl.URL, f'sftp://127.0.0.1:{sftp_server.port}')
+    c.setopt(pycurl.VERBOSE, True)
+    yield c
+    c.close()

--- a/tests/sftp.py
+++ b/tests/sftp.py
@@ -1,0 +1,81 @@
+import logging
+import socket
+import threading
+
+import pytest
+
+paramiko = pytest.importorskip('paramiko')
+
+logging.getLogger('paramiko').setLevel(logging.CRITICAL)
+
+
+class SFTPServerInterface(paramiko.ServerInterface):
+    """SSH server that rejects all authentication, used to exercise key callbacks."""
+
+    def check_auth_none(self, username):
+        return paramiko.AUTH_FAILED
+
+    def check_auth_password(self, username, password):
+        return paramiko.AUTH_FAILED
+
+    def check_auth_publickey(self, username, key):
+        return paramiko.AUTH_FAILED
+
+    def get_allowed_auths(self, username):
+        return 'password,publickey'
+
+    def check_channel_request(self, kind, chanid):
+        return paramiko.OPEN_FAILED_ADMINISTRATIVELY_PROHIBITED
+
+
+class LocalSFTPServer:
+    """Minimal SSH/SFTP server for testing SSH key callbacks."""
+
+    def __init__(self):
+        self._host_key = paramiko.RSAKey.generate(2048)
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
+        self._sock.bind(('127.0.0.1', 0))
+        self.port = self._sock.getsockname()[1]
+        self._sock.listen(5)
+        self._running = False
+        self._thread = None
+
+    def start(self):
+        self._running = True
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def _serve(self):
+        self._sock.settimeout(0.5)
+        while self._running:
+            try:
+                conn, _ = self._sock.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            threading.Thread(target=self._handle_conn, args=(conn,), daemon=True).start()
+
+    def _handle_conn(self, conn):
+        transport = paramiko.Transport(conn)
+        transport.add_server_key(self._host_key)
+        try:
+            transport.start_server(server=SFTPServerInterface())
+            transport.join(5)
+        except Exception:
+            pass
+        finally:
+            try:
+                transport.close()
+            except Exception:
+                pass
+
+    def stop(self):
+        self._running = False
+        try:
+            self._sock.close()
+        except Exception:
+            pass
+        if self._thread:
+            self._thread.join(2)

--- a/tests/ssh_key_cb_test.py
+++ b/tests/ssh_key_cb_test.py
@@ -1,89 +1,51 @@
-#! /usr/bin/env python
-# vi:ts=4:et
-
-import unittest
-import pycurl
 import pytest
+import pycurl
 
 from . import util
 
-sftp_server = 'sftp://web.sourceforge.net'
-
-@pytest.mark.online
-@pytest.mark.ssh
-class SshKeyCbTest(unittest.TestCase):
-    '''This test requires Internet access.'''
-
-    def setUp(self):
-        self.curl = util.DefaultCurl()
-        self.curl.setopt(pycurl.URL, sftp_server)
-        self.curl.setopt(pycurl.VERBOSE, True)
-
-    def tearDown(self):
-        self.curl.close()
-
-    @util.min_libcurl(7, 19, 6)
-    # curl compiled with libssh doesn't support
-    # CURLOPT_SSH_KNOWNHOSTS and CURLOPT_SSH_KEYFUNCTION
-    @util.guard_unknown_libcurl_option
-    def test_keyfunction(self):
-        # with keyfunction returning ok
-
-        def keyfunction(known_key, found_key, match):
-            return pycurl.KHSTAT_FINE
-
-        self.curl.setopt(pycurl.SSH_KNOWNHOSTS, '.known_hosts')
-        self.curl.setopt(pycurl.SSH_KEYFUNCTION, keyfunction)
-
-        try:
-            self.curl.perform()
-            self.fail('should have raised')
-        except pycurl.error as e:
-            self.assertEqual(pycurl.E_LOGIN_DENIED, e.args[0])
-
-        # with keyfunction returning not ok
-
-        def keyfunction(known_key, found_key, match):
-            return pycurl.KHSTAT_REJECT
-
-        self.curl.setopt(pycurl.SSH_KNOWNHOSTS, '.known_hosts')
-        self.curl.setopt(pycurl.SSH_KEYFUNCTION, keyfunction)
-
-        try:
-            self.curl.perform()
-            self.fail('should have raised')
-        except pycurl.error as e:
-            self.assertEqual(pycurl.E_PEER_FAILED_VERIFICATION, e.args[0])
-
-    @util.min_libcurl(7, 19, 6)
-    @util.guard_unknown_libcurl_option
-    def test_keyfunction_bogus_return(self):
-        def keyfunction(known_key, found_key, match):
-            return 'bogus'
-
-        self.curl.setopt(pycurl.SSH_KNOWNHOSTS, '.known_hosts')
-        self.curl.setopt(pycurl.SSH_KEYFUNCTION, keyfunction)
-
-        try:
-            self.curl.perform()
-            self.fail('should have raised')
-        except pycurl.error as e:
-            self.assertEqual(pycurl.E_PEER_FAILED_VERIFICATION, e.args[0])
+pytestmark = pytest.mark.ssh
 
 
-@pytest.mark.ssh
-class SshKeyCbUnsetTest(unittest.TestCase):
-    def setUp(self):
-        self.curl = util.DefaultCurl()
-        self.curl.setopt(pycurl.URL, sftp_server)
-        self.curl.setopt(pycurl.VERBOSE, True)
+@util.min_libcurl(7, 19, 6)
+@util.guard_unknown_libcurl_option
+def test_keyfunction_fine(sftp_curl, known_hosts_file):
+    sftp_curl.setopt(pycurl.SSH_KNOWNHOSTS, known_hosts_file)
+    sftp_curl.setopt(pycurl.SSH_KEYFUNCTION, lambda known_key, found_key, match: pycurl.KHSTAT_FINE)
 
-    @util.min_libcurl(7, 19, 6)
-    @util.guard_unknown_libcurl_option
-    def test_keyfunction_none(self):
-        self.curl.setopt(pycurl.SSH_KEYFUNCTION, None)
+    with pytest.raises(pycurl.error) as exc_info:
+        sftp_curl.perform()
+    assert exc_info.value.args[0] == pycurl.E_LOGIN_DENIED
 
-    @util.min_libcurl(7, 19, 6)
-    @util.guard_unknown_libcurl_option
-    def test_keyfunction_unset(self):
-        self.curl.unsetopt(pycurl.SSH_KEYFUNCTION)
+
+@util.min_libcurl(7, 19, 6)
+@util.guard_unknown_libcurl_option
+def test_keyfunction_reject(sftp_curl, known_hosts_file):
+    sftp_curl.setopt(pycurl.SSH_KNOWNHOSTS, known_hosts_file)
+    sftp_curl.setopt(pycurl.SSH_KEYFUNCTION, lambda known_key, found_key, match: pycurl.KHSTAT_REJECT)
+
+    with pytest.raises(pycurl.error) as exc_info:
+        sftp_curl.perform()
+    assert exc_info.value.args[0] == pycurl.E_PEER_FAILED_VERIFICATION
+
+
+@util.min_libcurl(7, 19, 6)
+@util.guard_unknown_libcurl_option
+def test_keyfunction_bogus_return(sftp_curl, known_hosts_file):
+    sftp_curl.setopt(pycurl.SSH_KNOWNHOSTS, known_hosts_file)
+    sftp_curl.setopt(pycurl.SSH_KEYFUNCTION, lambda known_key, found_key, match: 'bogus')
+
+    with pytest.raises(pycurl.error) as exc_info:
+        sftp_curl.perform()
+    assert exc_info.value.args[0] == pycurl.E_PEER_FAILED_VERIFICATION
+
+
+@util.min_libcurl(7, 19, 6)
+@util.guard_unknown_libcurl_option
+def test_keyfunction_set_none(sftp_curl):
+    sftp_curl.setopt(pycurl.SSH_KEYFUNCTION, None)
+
+
+@util.min_libcurl(7, 19, 6)
+@util.guard_unknown_libcurl_option
+def test_keyfunction_unset(sftp_curl):
+    sftp_curl.unsetopt(pycurl.SSH_KEYFUNCTION)


### PR DESCRIPTION
This avoids requiring internet access to run the tests.