### PR TITLE
`closed` as property instead a method

### DIFF
--- a/doc/curlmultiobject.rst
+++ b/doc/curlmultiobject.rst
@@ -9,6 +9,8 @@ CurlMulti Object
     
     .. automethod:: pycurl.CurlMulti.close
 
+    .. autoattribute:: pycurl.CurlMulti.closed
+
     .. automethod:: pycurl.CurlMulti.add_handle
 
     .. automethod:: pycurl.CurlMulti.remove_handle

--- a/doc/curlobject.rst
+++ b/doc/curlobject.rst
@@ -9,6 +9,8 @@ Curl Object
 
     .. automethod:: pycurl.Curl.close
 
+    .. autoattribute:: pycurl.Curl.closed
+
     .. _setopt:
     .. automethod:: pycurl.Curl.setopt
 

--- a/doc/curlshareobject.rst
+++ b/doc/curlshareobject.rst
@@ -9,4 +9,6 @@ CurlShare Object
 
     .. automethod:: pycurl.CurlShare.close
 
+    .. autoattribute:: pycurl.CurlShare.closed
+
     .. automethod:: pycurl.CurlShare.setopt

--- a/doc/docstrings/curl_closed.rst
+++ b/doc/docstrings/curl_closed.rst
@@ -1,3 +1,1 @@
-closed() -> bool
-
-Return ``True`` if the ``Curl`` object was already closed, ``False`` otherwise.
+Whether this ``Curl`` object has been closed.

--- a/doc/docstrings/multi_closed.rst
+++ b/doc/docstrings/multi_closed.rst
@@ -1,3 +1,1 @@
-closed() -> bool
-
-Return ``True`` if the ``CurlMulti`` object was already closed, ``False`` otherwise.
+Whether this ``CurlMulti`` object has been closed.

--- a/doc/docstrings/share_closed.rst
+++ b/doc/docstrings/share_closed.rst
@@ -1,3 +1,1 @@
-closed() -> bool
-
-Return ``True`` if the ``CurlShare`` object was already closed, ``False`` otherwise.
+Whether this ``CurlShare`` object has been closed.

--- a/doc/mime.rst
+++ b/doc/mime.rst
@@ -61,7 +61,7 @@ CurlMime
 
     .. automethod:: pycurl.CurlMime.close
 
-    .. automethod:: pycurl.CurlMime.closed
+    .. autoattribute:: pycurl.CurlMime.closed
 
     .. automethod:: pycurl.CurlMime.addpart
 

--- a/src/easy.c
+++ b/src/easy.c
@@ -724,7 +724,7 @@ do_curl_close(CurlObject *self, PyObject *Py_UNUSED(ignored))
 }
 
 
-static PyObject *do_curl_closed(CurlObject *self, PyObject *Py_UNUSED(ignored))
+static PyObject *do_curl_get_closed(CurlObject *self, void *Py_UNUSED(closure))
 {
     if (self->handle == NULL) {
         Py_RETURN_TRUE;
@@ -945,7 +945,6 @@ do_curl_share(CurlObject *self, PyObject *Py_UNUSED(ignored))
 
 PYCURL_INTERNAL PyMethodDef curlobject_methods[] = {
     {"close", (PyCFunction)do_curl_close, METH_NOARGS, curl_close_doc},
-    {"closed", (PyCFunction)do_curl_closed, METH_NOARGS, curl_closed_doc},
     {"duphandle", (PyCFunction)do_curl_duphandle, METH_NOARGS, curl_duphandle_doc},
     {"errstr", (PyCFunction)do_curl_errstr, METH_NOARGS, curl_errstr_doc},
     {"errstr_raw", (PyCFunction)do_curl_errstr_raw, METH_NOARGS, curl_errstr_raw_doc},
@@ -980,6 +979,14 @@ PYCURL_INTERNAL PyMethodDef curlobject_methods[] = {
     {"__enter__", (PyCFunction)do_curl_enter, METH_NOARGS, NULL},
     {"__exit__", (PyCFunction)do_curl_close, METH_VARARGS, NULL},
     {NULL, NULL, 0, NULL}
+};
+
+
+/* --------------- getsets --------------- */
+
+PYCURL_INTERNAL PyGetSetDef curlobject_getsets[] = {
+    {"closed", (getter)do_curl_get_closed, NULL, curl_closed_doc, NULL},
+    {NULL, NULL, NULL, NULL, NULL}
 };
 
 
@@ -1036,7 +1043,7 @@ PYCURL_INTERNAL PyTypeObject Curl_Type = {
     0,                          /* tp_iternext */
     curlobject_methods,         /* tp_methods */
     0,                          /* tp_members */
-    0,                          /* tp_getset */
+    curlobject_getsets,         /* tp_getset */
     0,                          /* tp_base */
     0,                          /* tp_dict */
     0,                          /* tp_descr_get */

--- a/src/mime.c
+++ b/src/mime.c
@@ -709,7 +709,7 @@ do_curlmime_close(CurlMimeObject *self, PyObject *Py_UNUSED(ignored))
 }
 
 static PyObject *
-do_curlmime_closed(CurlMimeObject *self, PyObject *Py_UNUSED(ignored))
+do_curlmime_get_closed(CurlMimeObject *self, void *Py_UNUSED(closure))
 {
     if (self->mime == NULL) {
         Py_RETURN_TRUE;
@@ -1285,11 +1285,15 @@ static PyMethodDef curlmimeobject_methods[] = {
     {"add_file", (PyCFunction)do_curlmime_add_file, METH_VARARGS | METH_KEYWORDS, "Add a file upload part."},
     {"add_multipart", (PyCFunction)do_curlmime_add_multipart, METH_VARARGS | METH_KEYWORDS, "Add and attach a nested multipart CurlMime."},
     {"close", (PyCFunction)do_curlmime_close, METH_NOARGS, "Release the underlying curl_mime handle."},
-    {"closed", (PyCFunction)do_curlmime_closed, METH_NOARGS, "Return whether this CurlMime object is closed."},
     {"addpart", (PyCFunction)do_curlmime_addpart, METH_NOARGS, "Create and return a new MIME part."},
     {"__enter__", (PyCFunction)do_curlmime_enter, METH_NOARGS, NULL},
     {"__exit__", (PyCFunction)do_curlmime_exit, METH_VARARGS, NULL},
     {NULL, NULL, 0, NULL}
+};
+
+static PyGetSetDef curlmimeobject_getsets[] = {
+    {"closed", (getter)do_curlmime_get_closed, NULL, "Whether this CurlMime object is closed.", NULL},
+    {NULL, NULL, NULL, NULL, NULL}
 };
 
 static PyTypeObject CurlMimeDataCbOwner_Type = {
@@ -1364,7 +1368,7 @@ PYCURL_INTERNAL PyTypeObject CurlMime_Type = {
     0,                          /* tp_iternext */
     curlmimeobject_methods,     /* tp_methods */
     0,                          /* tp_members */
-    0,                          /* tp_getset */
+    curlmimeobject_getsets,     /* tp_getset */
     0,                          /* tp_base */
     0,                          /* tp_dict */
     0,                          /* tp_descr_get */

--- a/src/multi.c
+++ b/src/multi.c
@@ -245,7 +245,7 @@ do_multi_close(CurlMultiObject *self, PyObject *Py_UNUSED(ignored))
 }
 
 
-static PyObject *do_multi_closed(CurlMultiObject *self, PyObject *Py_UNUSED(ignored))
+static PyObject *do_multi_get_closed(CurlMultiObject *self, void *Py_UNUSED(closure))
 {
     if (self->multi_handle == NULL) {
         Py_RETURN_TRUE;
@@ -1222,7 +1222,6 @@ do_multi_sq_contains(PyObject *o, PyObject *obj)
 PYCURL_INTERNAL PyMethodDef curlmultiobject_methods[] = {
     {"add_handle", (PyCFunction)do_multi_add_handle, METH_VARARGS, multi_add_handle_doc},
     {"close", (PyCFunction)do_multi_close, METH_NOARGS, multi_close_doc},
-    {"closed", (PyCFunction)do_multi_closed, METH_NOARGS, multi_closed_doc},
     {"fdset", (PyCFunction)do_multi_fdset, METH_NOARGS, multi_fdset_doc},
     {"info_read", (PyCFunction)do_multi_info_read, METH_VARARGS, multi_info_read_doc},
     {"perform", (PyCFunction)do_multi_perform, METH_NOARGS, multi_perform_doc},
@@ -1239,6 +1238,14 @@ PYCURL_INTERNAL PyMethodDef curlmultiobject_methods[] = {
     {"__enter__", (PyCFunction)do_curlmulti_enter, METH_NOARGS, NULL},
     {"__exit__", (PyCFunction)do_curlmulti_exit, METH_VARARGS, NULL},
     {NULL, NULL, 0, NULL}
+};
+
+
+/* --------------- getsets --------------- */
+
+PYCURL_INTERNAL PyGetSetDef curlmultiobject_getsets[] = {
+    {"closed", (getter)do_multi_get_closed, NULL, multi_closed_doc, NULL},
+    {NULL, NULL, NULL, NULL, NULL}
 };
 
 
@@ -1314,7 +1321,7 @@ PYCURL_INTERNAL PyTypeObject CurlMulti_Type = {
     0,                          /* tp_iternext */
     curlmultiobject_methods,    /* tp_methods */
     0,                          /* tp_members */
-    0,                          /* tp_getset */
+    curlmultiobject_getsets,    /* tp_getset */
     0,                          /* tp_base */
     0,                          /* tp_dict */
     0,                          /* tp_descr_get */

--- a/src/share.c
+++ b/src/share.c
@@ -349,7 +349,7 @@ do_share_close(CurlShareObject *self, PyObject *Py_UNUSED(ignored))
 }
 
 
-static PyObject *do_share_closed(CurlShareObject *self, PyObject *Py_UNUSED(ignored))
+static PyObject *do_share_get_closed(CurlShareObject *self, void *Py_UNUSED(closure))
 {
     if (self->share_handle == NULL) {
         Py_RETURN_TRUE;
@@ -454,13 +454,20 @@ static PyObject *do_share_enter(CurlShareObject *self, PyObject *Py_UNUSED(ignor
 
 PYCURL_INTERNAL PyMethodDef curlshareobject_methods[] = {
     {"close", (PyCFunction)do_share_close, METH_NOARGS, share_close_doc},
-    {"closed", (PyCFunction)do_share_closed, METH_NOARGS, share_closed_doc},
     {"setopt", (PyCFunction)do_share_setopt, METH_VARARGS, share_setopt_doc},
     {"__getstate__", (PyCFunction)do_share_getstate, METH_NOARGS, NULL},
     {"__setstate__", (PyCFunction)do_share_setstate, METH_VARARGS, NULL},
     {"__enter__", (PyCFunction)do_share_enter, METH_NOARGS, NULL},
     {"__exit__", (PyCFunction)do_share_close, METH_VARARGS, NULL},
     {NULL, NULL, 0, 0}
+};
+
+
+/* --------------- getsets --------------- */
+
+PYCURL_INTERNAL PyGetSetDef curlshareobject_getsets[] = {
+    {"closed", (getter)do_share_get_closed, NULL, share_closed_doc, NULL},
+    {NULL, NULL, NULL, NULL, NULL}
 };
 
 
@@ -519,7 +526,7 @@ PYCURL_INTERNAL PyTypeObject CurlShare_Type = {
     0,                          /* tp_iternext */
     curlshareobject_methods,    /* tp_methods */
     0,                          /* tp_members */
-    0,                          /* tp_getset */
+    curlshareobject_getsets,    /* tp_getset */
     0,                          /* tp_base */
     0,                          /* tp_dict */
     0,                          /* tp_descr_get */

--- a/tests/curl_object_test.py
+++ b/tests/curl_object_test.py
@@ -5,30 +5,32 @@ import pycurl
 import pytest
 import unittest
 
+
 class ExplicitConstructionCurlObjectTest(unittest.TestCase):
     def test_close(self):
         c = pycurl.Curl()
-        assert not c.closed()
+        assert not c.closed
         c.close()
-        assert c.closed()
+        assert c.closed
 
     def test_close_twice(self):
         c = pycurl.Curl()
-        assert not c.closed()
+        assert not c.closed
         c.close()
-        assert c.closed()
+        assert c.closed
         c.close()
-        assert c.closed()
+        assert c.closed
 
     # positional arguments are rejected
     def test_positional_arguments(self):
         with pytest.raises(TypeError):
-           pycurl.Curl(1)
+            pycurl.Curl(1)
 
     # keyword arguments are rejected
     def test_keyword_arguments(self):
         with pytest.raises(TypeError):
             pycurl.Curl(a=1)
+
 
 class CurlObjectTest(unittest.TestCase):
     def setUp(self):
@@ -38,49 +40,49 @@ class CurlObjectTest(unittest.TestCase):
         self.curl.close()
 
     def test_set_attribute_curl(self):
-        self.instantiate_and_check(self.check_set_attribute, 'Curl')
+        self.instantiate_and_check(self.check_set_attribute, "Curl")
 
     def test_get_attribute_curl(self):
-        self.instantiate_and_check(self.check_get_attribute, 'Curl')
+        self.instantiate_and_check(self.check_get_attribute, "Curl")
 
     def test_get_missing_attribute_curl(self):
-        self.instantiate_and_check(self.check_get_missing_attribute, 'Curl')
+        self.instantiate_and_check(self.check_get_missing_attribute, "Curl")
 
     def test_delete_attribute_curl(self):
-        self.instantiate_and_check(self.check_delete_attribute, 'Curl')
+        self.instantiate_and_check(self.check_delete_attribute, "Curl")
 
     def test_delete_missing_attribute_curl(self):
-        self.instantiate_and_check(self.check_delete_missing_attribute, 'Curl')
+        self.instantiate_and_check(self.check_delete_missing_attribute, "Curl")
 
     def test_set_attribute_multi(self):
-        self.instantiate_and_check(self.check_set_attribute, 'CurlMulti')
+        self.instantiate_and_check(self.check_set_attribute, "CurlMulti")
 
     def test_get_attribute_multi(self):
-        self.instantiate_and_check(self.check_get_attribute, 'CurlMulti')
+        self.instantiate_and_check(self.check_get_attribute, "CurlMulti")
 
     def test_get_missing_attribute_curl_multi(self):
-        self.instantiate_and_check(self.check_get_missing_attribute, 'CurlMulti')
+        self.instantiate_and_check(self.check_get_missing_attribute, "CurlMulti")
 
     def test_delete_attribute_multi(self):
-        self.instantiate_and_check(self.check_delete_attribute, 'CurlMulti')
+        self.instantiate_and_check(self.check_delete_attribute, "CurlMulti")
 
     def test_delete_missing_attribute_curl_multi(self):
-        self.instantiate_and_check(self.check_delete_missing_attribute, 'CurlMulti')
+        self.instantiate_and_check(self.check_delete_missing_attribute, "CurlMulti")
 
     def test_set_attribute_share(self):
-        self.instantiate_and_check(self.check_set_attribute, 'CurlShare')
+        self.instantiate_and_check(self.check_set_attribute, "CurlShare")
 
     def test_get_attribute_share(self):
-        self.instantiate_and_check(self.check_get_attribute, 'CurlShare')
+        self.instantiate_and_check(self.check_get_attribute, "CurlShare")
 
     def test_get_missing_attribute_curl_share(self):
-        self.instantiate_and_check(self.check_get_missing_attribute, 'CurlShare')
+        self.instantiate_and_check(self.check_get_missing_attribute, "CurlShare")
 
     def test_delete_attribute_share(self):
-        self.instantiate_and_check(self.check_delete_attribute, 'CurlShare')
+        self.instantiate_and_check(self.check_delete_attribute, "CurlShare")
 
     def test_delete_missing_attribute_curl_share(self):
-        self.instantiate_and_check(self.check_delete_missing_attribute, 'CurlShare')
+        self.instantiate_and_check(self.check_delete_missing_attribute, "CurlShare")
 
     def instantiate_and_check(self, fn, cls_name):
         cls = getattr(pycurl, cls_name)
@@ -91,55 +93,55 @@ class CurlObjectTest(unittest.TestCase):
             instance.close()
 
     def check_set_attribute(self, pycurl_obj):
-        assert not hasattr(pycurl_obj, 'attr')
+        assert not hasattr(pycurl_obj, "attr")
         pycurl_obj.attr = 1
-        assert hasattr(pycurl_obj, 'attr')
+        assert hasattr(pycurl_obj, "attr")
 
     def check_get_attribute(self, pycurl_obj):
-        assert not hasattr(pycurl_obj, 'attr')
+        assert not hasattr(pycurl_obj, "attr")
         pycurl_obj.attr = 1
         self.assertEqual(1, pycurl_obj.attr)
 
     def check_get_missing_attribute(self, pycurl_obj):
         try:
-            getattr(pycurl_obj, 'doesnotexist')
-            self.fail('Expected an AttributeError exception to be raised')
+            getattr(pycurl_obj, "doesnotexist")
+            self.fail("Expected an AttributeError exception to be raised")
         except AttributeError:
             pass
 
     def check_delete_attribute(self, pycurl_obj):
-        assert not hasattr(pycurl_obj, 'attr')
+        assert not hasattr(pycurl_obj, "attr")
         pycurl_obj.attr = 1
         self.assertEqual(1, pycurl_obj.attr)
-        assert hasattr(pycurl_obj, 'attr')
+        assert hasattr(pycurl_obj, "attr")
         del pycurl_obj.attr
-        assert not hasattr(pycurl_obj, 'attr')
+        assert not hasattr(pycurl_obj, "attr")
 
     def check_delete_missing_attribute(self, pycurl_obj):
         try:
             del pycurl_obj.doesnotexist
-            self.fail('Expected an AttributeError exception to be raised')
+            self.fail("Expected an AttributeError exception to be raised")
         except AttributeError:
             pass
 
     def test_modify_attribute_curl(self):
-        self.check_modify_attribute(pycurl.Curl, 'READFUNC_PAUSE')
+        self.check_modify_attribute(pycurl.Curl, "READFUNC_PAUSE")
 
     def test_modify_attribute_multi(self):
-        self.check_modify_attribute(pycurl.CurlMulti, 'E_MULTI_OK')
+        self.check_modify_attribute(pycurl.CurlMulti, "E_MULTI_OK")
 
     def test_modify_attribute_share(self):
-        self.check_modify_attribute(pycurl.CurlShare, 'SH_SHARE')
+        self.check_modify_attribute(pycurl.CurlShare, "SH_SHARE")
 
     def check_modify_attribute(self, cls, name):
         obj1 = cls()
         obj2 = cls()
         old_value = getattr(obj1, name)
-        self.assertNotEqual('helloworld', old_value)
+        self.assertNotEqual("helloworld", old_value)
         # value should be identical to pycurl global
         self.assertEqual(old_value, getattr(pycurl, name))
-        setattr(obj1, name, 'helloworld')
-        self.assertEqual('helloworld', getattr(obj1, name))
+        setattr(obj1, name, "helloworld")
+        self.assertEqual("helloworld", getattr(obj1, name))
 
         # change does not affect other existing objects
         self.assertEqual(old_value, getattr(obj2, name))
@@ -149,9 +151,9 @@ class CurlObjectTest(unittest.TestCase):
         self.assertEqual(old_value, getattr(obj3, name))
 
     def test_bogus_attribute_access(self):
-        with pytest.raises(AttributeError, match='trying to obtain.*'):
-           self.curl.foo
+        with pytest.raises(AttributeError, match="trying to obtain.*"):
+            self.curl.foo
 
     def test_bogus_attribute_delete(self):
-        with pytest.raises(AttributeError, match='trying to delete.*'):
+        with pytest.raises(AttributeError, match="trying to delete.*"):
             del self.curl.foo

--- a/tests/multi_test.py
+++ b/tests/multi_test.py
@@ -386,24 +386,24 @@ class MultiTest(unittest.TestCase):
 
     def test_multi_close(self):
         m = pycurl.CurlMulti()
-        assert not m.closed()
+        assert not m.closed
         m.close()
-        assert m.closed()
+        assert m.closed
 
     def test_multi_close_twice(self):
         m = pycurl.CurlMulti()
-        assert not m.closed()
+        assert not m.closed
         m.close()
-        assert m.closed()
+        assert m.closed
         m.close()
-        assert m.closed()
+        assert m.closed
 
         m = pycurl.CurlMulti(close_handles=True)
-        assert not m.closed()
+        assert not m.closed
         m.close()
-        assert m.closed()
+        assert m.closed
         m.close()
-        assert m.closed()
+        assert m.closed
 
     def test_close_handles_false(self):
         easy1 = pycurl.Curl()
@@ -416,9 +416,9 @@ class MultiTest(unittest.TestCase):
         assert m == easy1.multi()
         assert m == easy2.multi()
         m.close()
-        assert m.closed()
-        assert not easy1.closed()
-        assert not easy2.closed()
+        assert m.closed
+        assert not easy1.closed
+        assert not easy2.closed
         assert easy1.multi() is None
         assert easy2.multi() is None
 
@@ -433,10 +433,10 @@ class MultiTest(unittest.TestCase):
         assert m == easy1.multi()
         assert m == easy2.multi()
         m.close()
-        assert easy1.closed()
-        assert easy2.closed()
-        assert easy1.closed()
-        assert easy2.closed()
+        assert easy1.closed
+        assert easy2.closed
+        assert easy1.closed
+        assert easy2.closed
         assert easy1.multi() is None
         assert easy2.multi() is None
 
@@ -468,8 +468,8 @@ class MultiTest(unittest.TestCase):
             assert m == easy1.multi()
             assert m == easy2.multi()
 
-        assert not easy1.closed()
-        assert not easy2.closed()
+        assert not easy1.closed
+        assert not easy2.closed
         assert easy1.multi() is None
         assert easy2.multi() is None
 
@@ -491,8 +491,8 @@ class MultiTest(unittest.TestCase):
             assert m == easy1.multi()
             assert m == easy2.multi()
 
-        assert easy1.closed()
-        assert easy2.closed()
+        assert easy1.closed
+        assert easy2.closed
         assert easy1.multi() is None
         assert easy2.multi() is None
 
@@ -551,5 +551,5 @@ class MultiTest(unittest.TestCase):
         assert easy2 in m
 
         m.close()
-        assert m.closed()
+        assert m.closed
         assert easy2 not in m

--- a/tests/share_test.py
+++ b/tests/share_test.py
@@ -63,18 +63,18 @@ def test_share(app, default_share):
 
 def test_share_close():
     s = pycurl.CurlShare()
-    assert not s.closed()
+    assert not s.closed
     s.close()
-    assert s.closed()
+    assert s.closed
 
 
 def test_share_close_twice():
     s = pycurl.CurlShare()
-    assert not s.closed()
+    assert not s.closed
     s.close()
-    assert s.closed()
+    assert s.closed
     s.close()
-    assert s.closed()
+    assert s.closed
 
 
 # positional arguments are rejected
@@ -92,12 +92,12 @@ def test_keyword_arguments():
 def test_detach_on_close_keyword_argument_accepted():
     s1 = pycurl.CurlShare(detach_on_close=True)
     s2 = pycurl.CurlShare(detach_on_close=False)
-    assert not s1.closed()
-    assert not s2.closed()
+    assert not s1.closed
+    assert not s2.closed
     s1.close()
     s2.close()
-    assert s1.closed()
-    assert s2.closed()
+    assert s1.closed
+    assert s2.closed
 
 
 def test_easy_with_share_closed_before_perform(app, default_share):
@@ -115,11 +115,11 @@ def test_easy_with_share_closed_before_perform(app, default_share):
         easies.append((c, sio))
 
     s.close()
-    assert s.closed()
+    assert s.closed
 
     for c, _ in easies:
         assert c.share() is None
-        assert not c.closed()
+        assert not c.closed
 
 
 def test_easy_with_share_closed_before_perform_no_detach(app, default_share_no_detach):
@@ -138,7 +138,7 @@ def test_easy_with_share_closed_before_perform_no_detach(app, default_share_no_d
 
     with pytest.raises(pycurl.error):
         s.close()
-    assert not s.closed()
+    assert not s.closed
 
     for c, _ in easies:
         assert c.share() == s
@@ -159,17 +159,17 @@ def test_easy_with_share_closed_before_perform_no_detach(app, default_share_no_d
 
     for c, _ in easies[:q1] + easies[q3:]:
         c.close()
-        assert c.closed()
+        assert c.closed
 
     s.close()
-    assert s.closed()
+    assert s.closed
 
 
 def test_easy_set_share_closed_raises(app):
     s = pycurl.CurlShare()
     s.setopt(pycurl.SH_SHARE, pycurl.LOCK_DATA_COOKIE)
     s.close()
-    assert s.closed()
+    assert s.closed
 
     c = util.DefaultCurl()
     c.setopt(pycurl.URL, app + "/success")
@@ -191,7 +191,7 @@ def test_share_context_manager_detaches_by_default(app):
         c.setopt(pycurl.SHARE, s)
         assert c.share() == s
 
-    assert s.closed()
+    assert s.closed
     assert c.share() is None
 
     sio.seek(0)
@@ -213,7 +213,7 @@ def test_share_context_manager_strict_raises_if_live_easies(app):
             c.setopt(pycurl.SHARE, s)
             assert c.share() == s
 
-    assert not s.closed()
+    assert not s.closed
     assert c.share() == s
 
     c.unsetopt(pycurl.SHARE)

--- a/tests/test_memory_mgmt_close_matrix.py
+++ b/tests/test_memory_mgmt_close_matrix.py
@@ -210,7 +210,7 @@ def test_multi_close_and_remove_one_easy_gone_others_not(make_multi):
     for i, r in enumerate(survivor_refs):
         obj = r()
         assert obj is not None, f"survivor[{i}] unexpectedly collected"
-        assert obj.closed() is False, f"survivor[{i}] unexpectedly closed"
+        assert not obj.closed, f"survivor[{i}] unexpectedly closed"
 
     for e in survivors:
         multi.remove_handle(e)
@@ -263,20 +263,20 @@ def test_share_close_matrix(app, make_share_easies, order):
     if order == "close_easies_then_close_share":
         for e in easies:
             e.close()
-            assert e.closed()
+            assert e.closed
         s.close()
-        assert s.closed()
+        assert s.closed
 
     elif order == "close_share_then_perform_then_close_easies":
         with pytest.raises(pycurl.error):
             s.close()
-        assert not s.closed()
+        assert not s.closed
         for e in easies:
             assert e.share() == s
         perform_all(easies)
         for e in easies:
             e.close()
-            assert e.closed()
+            assert e.closed
 
         for sio in sios:
             assert sio.getvalue().decode() == "success"
@@ -284,7 +284,7 @@ def test_share_close_matrix(app, make_share_easies, order):
     elif order == "close_share_then_drop":
         with pytest.raises(pycurl.error):
             s.close()
-        assert not s.closed()
+        assert not s.closed
         for e in easies:
             assert e.share() == s
 
@@ -293,7 +293,7 @@ def test_share_close_matrix(app, make_share_easies, order):
             e.setopt(pycurl.SHARE, None)
             assert e.share() is None
         s.close()
-        assert s.closed()
+        assert s.closed
 
     elif order == "del_share_without_close":
         pass
@@ -323,7 +323,7 @@ def test_share_close_detaches_and_easy_still_succeeds(app, make_share_easies):
 
     with pytest.raises(pycurl.error):
         s.close()
-    assert not s.closed()
+    assert not s.closed
 
     for e in easies:
         assert e.share() == s
@@ -364,7 +364,7 @@ def test_share_close_one_easy_does_not_keep_share_or_others_alive(
     for i, r in enumerate(survivor_refs):
         obj = r()
         assert obj is not None, f"survivor[{i}] unexpectedly collected"
-        assert obj.closed() is False, f"survivor[{i}] unexpectedly closed"
+        assert not obj.closed, f"survivor[{i}] unexpectedly closed"
 
     for e in survivors:
         e.close()

--- a/tests/test_mime.py
+++ b/tests/test_mime.py
@@ -93,18 +93,18 @@ def data_value(request):
 def test_mime_lifecycle_and_context_manager():
     with pycurl.Curl() as curl:
         mime = pycurl.CurlMime(curl)
-        assert mime.closed() is False
+        assert not mime.closed
 
         mime.close()
-        assert mime.closed() is True
+        assert mime.closed
 
         mime.close()
-        assert mime.closed() is True
+        assert mime.closed
 
         with pycurl.CurlMime(curl) as second:
-            assert second.closed() is False
+            assert not second.closed
 
-        assert second.closed() is True
+        assert second.closed
 
 
 def test_mime_exit_requires_exception_tuple():
@@ -554,11 +554,11 @@ def test_mime_subparts_transfers_ownership():
 
         parent_part = parent.addpart()
         parent_part.subparts(child)
-        assert child.closed() is False
+        assert not child.closed
 
         child.addpart()
         parent.close()
-        assert child.closed() is True
+        assert child.closed
 
         with pytest.raises(pycurl.error, match="no mime handle"):
             child.addpart()
@@ -683,10 +683,10 @@ def test_mime_add_multipart_helper():
         child = parent.add_multipart(name="nested")
 
         assert isinstance(child, pycurl.CurlMime)
-        assert child.closed() is False
+        assert not child.closed
 
         child.add_field("inner", "value")
         parent.add_multipart(name="without-type", subtype=None)
 
         parent.close()
-        assert child.closed() is True
+        assert child.closed


### PR DESCRIPTION
Convert the `closed()` method on `Curl`, `CurlMulti`, `CurlShare`, and `CurlMime` to a read-only `closed` property to match Python conventions.