### PR TITLE
Fix flaky `memory_mgmt` callback

### DIFF
--- a/tests/memory_mgmt_test.py
+++ b/tests/memory_mgmt_test.py
@@ -1,384 +1,239 @@
-#! /usr/bin/env python
-# vi:ts=4:et
-
+import gc
 import sys
 import weakref
+
 import pycurl
 import pytest
-import unittest
-import gc
-import flaky
+
 from . import util
+from .util import LiveTracker, gc_collect_hard
 
-debug = False
 
-if sys.platform == 'win32':
-    devnull = 'NUL'
-else:
-    devnull = '/dev/null'
+devnull = "NUL" if sys.platform == "win32" else "/dev/null"
 
-@flaky.flaky(max_runs=3)
-class MemoryMgmtTest(unittest.TestCase):
-    def maybe_enable_debug(self):
-        if debug:
-            flags = gc.DEBUG_COLLECTABLE | gc.DEBUG_UNCOLLECTABLE
-            # python 3 has no DEBUG_OBJECTS
-            if hasattr(gc, 'DEBUG_OBJECTS'):
-                flags |= gc.DEBUG_OBJECTS
-                flags |= gc.DEBUG_STATS
-            gc.set_debug(flags)
-            gc.collect()
 
-            print("Tracked objects:", len(gc.get_objects()))
-
-    def maybe_print_objects(self):
-        if debug:
-            print("Tracked objects:", len(gc.get_objects()))
-
-    def tearDown(self):
-        gc.set_debug(0)
-
-    def test_multi_collection(self):
-        gc.collect()
-        self.maybe_enable_debug()
-
-        multi = pycurl.CurlMulti()
-        t = []
-        searches = []
-        for a in range(100):
-            curl = util.DefaultCurl()
-            multi.add_handle(curl)
-            t.append(curl)
-
-            c_id = id(curl)
-            searches.append(c_id)
-        m_id = id(multi)
-        searches.append(m_id)
-
-        self.maybe_print_objects()
-
-        for curl in t:
-            curl.close()
-            multi.remove_handle(curl)
-
-        self.maybe_print_objects()
-
-        del curl
-        del t
-        del multi
-
-        self.maybe_print_objects()
-        gc.collect()
-        self.maybe_print_objects()
-
-        objects = gc.get_objects()
-        for search in searches:
-            for object in objects:
-                assert search != id(object)
-
-    def test_multi_cycle(self):
-        gc.collect()
-        self.maybe_enable_debug()
-
-        multi = pycurl.CurlMulti()
-        t = []
-        searches = []
-        for a in range(100):
-            curl = util.DefaultCurl()
-            multi.add_handle(curl)
-            t.append(curl)
-
-            c_id = id(curl)
-            searches.append(c_id)
-        m_id = id(multi)
-        searches.append(m_id)
-
-        self.maybe_print_objects()
-
-        del curl
-        del t
-        del multi
-
-        self.maybe_print_objects()
-        gc.collect()
-        self.maybe_print_objects()
-
-        objects = gc.get_objects()
-        for search in searches:
-            for object in objects:
-                assert search != id(object)
-
-    def test_share_collection(self):
-        gc.collect()
-        self.maybe_enable_debug()
-
-        share = pycurl.CurlShare()
-        t = []
-        searches = []
-        for a in range(100):
-            curl = util.DefaultCurl()
-            curl.setopt(curl.SHARE, share)
-            t.append(curl)
-
-            c_id = id(curl)
-            searches.append(c_id)
-        m_id = id(share)
-        searches.append(m_id)
-
-        self.maybe_print_objects()
-
-        for curl in t:
-            curl.unsetopt(curl.SHARE)
-            curl.close()
-
-        self.maybe_print_objects()
-
-        del curl
-        del t
-        del share
-
-        self.maybe_print_objects()
-        gc.collect()
-        self.maybe_print_objects()
-
-        objects = gc.get_objects()
-        for search in searches:
-            for object in objects:
-                assert search != id(object)
-
-    def test_share_cycle(self):
-        gc.collect()
-        self.maybe_enable_debug()
-
-        share = pycurl.CurlShare()
-        t = []
-        searches = []
-        for a in range(100):
-            curl = util.DefaultCurl()
-            curl.setopt(curl.SHARE, share)
-            t.append(curl)
-
-            c_id = id(curl)
-            searches.append(c_id)
-        m_id = id(share)
-        searches.append(m_id)
-
-        self.maybe_print_objects()
-
-        del curl
-        del t
-        del share
-
-        self.maybe_print_objects()
-        gc.collect()
-        self.maybe_print_objects()
-
-        objects = gc.get_objects()
-        for search in searches:
-            for object in objects:
-                assert search != id(object)
-
-    # basic check of reference counting (use a memory checker like valgrind)
-    def test_reference_counting(self):
+def _populate_multi(multi, count):
+    tr = LiveTracker()
+    tr.track("multi", multi)
+    handles = []
+    for i in range(count):
         c = util.DefaultCurl()
-        m = pycurl.CurlMulti()
-        m.add_handle(c)
-        del m
-        m = pycurl.CurlMulti()
+        tr.track(f"easy[{i}]", c)
+        multi.add_handle(c)
+        handles.append(c)
+    return tr, handles
+
+
+def _populate_share(share, count):
+    tr = LiveTracker()
+    tr.track("share", share)
+    handles = []
+    for i in range(count):
+        c = util.DefaultCurl()
+        tr.track(f"easy[{i}]", c)
+        c.setopt(c.SHARE, share)
+        handles.append(c)
+    return tr, handles
+
+
+def test_multi_releases_easies_after_close_and_remove():
+    multi = pycurl.CurlMulti()
+    tr, handles = _populate_multi(multi, 100)
+
+    for c in handles:
         c.close()
-        del m, c
+        multi.remove_handle(c)
 
-    def test_cyclic_gc(self):
-        gc.collect()
-        c = util.DefaultCurl()
-        c.m = pycurl.CurlMulti()
-        c.m.add_handle(c)
-        # create some nasty cyclic references
-        c.c = c
-        c.c.c1 = c
-        c.c.c2 = c
-        c.c.c3 = c.c
-        c.c.c4 = c.m
-        c.m.c = c
-        c.m.m = c.m
-        c.m.c = c
-        # delete
-        gc.collect()
-        self.maybe_enable_debug()
-        ##print gc.get_referrers(c)
-        ##print gc.get_objects()
-        #if opts.verbose >= 1:
-            #print("Tracked objects:", len(gc.get_objects()))
-        c_id = id(c)
-        # The `del' below should delete these 4 objects:
-        #   Curl + internal dict, CurlMulti + internal dict
-        del c
-        gc.collect()
-        objects = gc.get_objects()
-        for object in objects:
-            assert id(object) != c_id
-        #if opts.verbose >= 1:
-            #print("Tracked objects:", len(gc.get_objects()))
+    del c, handles, multi
+    tr.assert_all_gone()
 
-    def test_refcounting_bug_in_reset(self):
-        if sys.platform == 'win32':
-            iters = 10000
-        else:
-            iters = 100000
 
-        # Ensure that the refcounting error in "reset" is fixed:
-        for i in range(iters):
-            c = util.DefaultCurl()
-            c.reset()
-            c.close()
+def test_multi_cycle_collected_by_gc():
+    multi = pycurl.CurlMulti()
+    tr, handles = _populate_multi(multi, 100)
 
-    def test_writefunction_collection(self):
-        self.check_callback(pycurl.WRITEFUNCTION)
+    del handles, multi
+    tr.assert_all_gone()
 
-    def test_headerfunction_collection(self):
-        self.check_callback(pycurl.HEADERFUNCTION)
 
-    def test_readfunction_collection(self):
-        self.check_callback(pycurl.READFUNCTION)
+def test_share_releases_easies_after_unsetopt_and_close():
+    share = pycurl.CurlShare()
+    tr, handles = _populate_share(share, 100)
 
-    def test_progressfunction_collection(self):
-        self.check_callback(pycurl.PROGRESSFUNCTION)
-
-    @util.min_libcurl(7, 32, 0)
-    def test_xferinfofunction_collection(self):
-        self.check_callback(pycurl.XFERINFOFUNCTION)
-
-    def test_debugfunction_collection(self):
-        self.check_callback(pycurl.DEBUGFUNCTION)
-
-    def test_ioctlfunction_collection(self):
-        self.check_callback(pycurl.IOCTLFUNCTION)
-
-    def test_opensocketfunction_collection(self):
-        self.check_callback(pycurl.OPENSOCKETFUNCTION)
-
-    def test_seekfunction_collection(self):
-        self.check_callback(pycurl.SEEKFUNCTION)
-
-    # This is failing too much on appveyor
-    @util.only_unix
-    def check_callback(self, callback):
-        # Note: extracting a context manager seems to result in
-        # everything being garbage collected even if the C code
-        # does not clear the callback
-        object_count = 0
-        gc.collect()
-        object_count = len(gc.get_objects())
-
-        c = util.DefaultCurl()
-        if callback == pycurl.IOCTLFUNCTION:
-            with pytest.warns(DeprecationWarning, match="IOCTLFUNCTION is deprecated; use SEEKFUNCTION"):
-                c.setopt(callback, lambda x: True)
-        elif callback == pycurl.PROGRESSFUNCTION:
-            with pytest.warns(DeprecationWarning, match="PROGRESSFUNCTION is deprecated; use XFERINFOFUNCTION"):
-                c.setopt(callback, lambda x: True)
-        else:
-            c.setopt(callback, lambda x: True)
-        del c
-
-        gc.collect()
-        new_object_count = len(gc.get_objects())
-        # it seems that GC sometimes collects something that existed
-        # before this test ran, GH issues #273/#274
-        self.assertIn(new_object_count, (object_count, object_count-1))
-
-    def test_postfields_unicode_memory_leak_gh252(self):
-        # this test passed even before the memory leak was fixed,
-        # not sure why.
-
-        c = util.DefaultCurl()
-        gc.collect()
-        before_object_count = len(gc.get_objects())
-
-        for i in range(100000):
-            c.setopt(pycurl.POSTFIELDS, util.u('hello world'))
-
-        gc.collect()
-        after_object_count = len(gc.get_objects())
-        self.assertTrue(after_object_count <= before_object_count + 1000, 'Grew from %d to %d objects' % (before_object_count, after_object_count))
+    for c in handles:
+        c.unsetopt(c.SHARE)
         c.close()
 
-    def test_form_bufferptr_memory_leak_gh267(self):
+    del c, handles, share
+    tr.assert_all_gone()
+
+
+def test_share_cycle_collected_by_gc():
+    share = pycurl.CurlShare()
+    tr, handles = _populate_share(share, 100)
+
+    del handles, share
+    tr.assert_all_gone()
+
+
+def test_reference_counting():
+    c = util.DefaultCurl()
+    m = pycurl.CurlMulti()
+    m.add_handle(c)
+    del m
+    m = pycurl.CurlMulti()
+    c.close()
+    del m, c
+
+
+def test_self_referential_curl_collected_via_gc():
+    c = util.DefaultCurl()
+    c.m = pycurl.CurlMulti()
+    c.m.add_handle(c)
+    c.c = c
+    c.c.c1 = c
+    c.c.c2 = c
+    c.c.c3 = c.c
+    c.c.c4 = c.m
+    c.m.c = c
+    c.m.m = c.m
+
+    ref = weakref.ref(c)
+    del c
+    gc_collect_hard()
+    assert ref() is None
+
+
+def test_refcounting_bug_in_reset():
+    iters = 10000 if sys.platform == "win32" else 100000
+    for _ in range(iters):
         c = util.DefaultCurl()
-        gc.collect()
-        before_object_count = len(gc.get_objects())
-
-        for i in range(100000):
-            with pytest.warns(DeprecationWarning, match="HTTPPOST is deprecated; use MIMEPOST"):
-                c.setopt(pycurl.HTTPPOST, [
-                    # Newer versions of libcurl accept FORM_BUFFERPTR
-                    # without FORM_BUFFER and reproduce the memory leak;
-                    # libcurl 7.19.0 requires FORM_BUFFER to be given before
-                    # FORM_BUFFERPTR.
-                    ("post1", (pycurl.FORM_BUFFER, 'foo.txt', pycurl.FORM_BUFFERPTR, "data1")),
-                    ("post2", (pycurl.FORM_BUFFER, 'bar.txt', pycurl.FORM_BUFFERPTR, "data2")),
-                ])
-
-        gc.collect()
-        after_object_count = len(gc.get_objects())
-        self.assertTrue(after_object_count <= before_object_count + 1000, 'Grew from %d to %d objects' % (before_object_count, after_object_count))
+        c.reset()
         c.close()
 
-    def do_data_refcounting(self, option):
-        c = util.DefaultCurl()
-        f = open(devnull, 'a+')
-        c.setopt(option, f)
-        ref = weakref.ref(f)
-        del f
-        gc.collect()
-        assert ref()
 
-        for i in range(100):
-            assert ref()
-            c.setopt(option, ref())
-        gc.collect()
-        assert ref()
+def test_postfields_unicode_memory_leak_gh252():
+    c = util.DefaultCurl()
+    gc.collect()
+    before = len(gc.get_objects())
 
-        c.close()
-        gc.collect()
-        assert ref() is None
+    for _ in range(100000):
+        c.setopt(pycurl.POSTFIELDS, util.u("hello world"))
 
-    def test_readdata_refcounting(self):
-        self.do_data_refcounting(pycurl.READDATA)
+    gc.collect()
+    after = len(gc.get_objects())
+    assert after <= before + 1000, f"object count grew {before} -> {after}"
+    c.close()
 
-    def test_writedata_refcounting(self):
-        self.do_data_refcounting(pycurl.WRITEDATA)
 
-    def test_writeheader_refcounting(self):
-        self.do_data_refcounting(pycurl.WRITEHEADER)
+def test_form_bufferptr_memory_leak_gh267():
+    c = util.DefaultCurl()
+    gc.collect()
+    before = len(gc.get_objects())
 
-    # Python < 3.5 cannot create weak references to functions
-    @util.min_python(3, 5)
-    def do_function_refcounting(self, option, method_name):
-        c = util.DefaultCurl()
-        f = open(devnull, 'a+')
-        fn = getattr(f, method_name)
-        c.setopt(option, fn)
-        ref = weakref.ref(fn)
-        del f, fn
-        gc.collect()
-        assert ref()
+    for _ in range(100000):
+        with pytest.warns(
+            DeprecationWarning, match="HTTPPOST is deprecated; use MIMEPOST"
+        ):
+            # libcurl 7.19.0 requires FORM_BUFFER before FORM_BUFFERPTR;
+            # newer versions accept FORM_BUFFERPTR alone and reproduce the leak.
+            c.setopt(
+                pycurl.HTTPPOST,
+                [
+                    (
+                        "post1",
+                        (pycurl.FORM_BUFFER, "foo.txt", pycurl.FORM_BUFFERPTR, "data1"),
+                    ),
+                    (
+                        "post2",
+                        (pycurl.FORM_BUFFER, "bar.txt", pycurl.FORM_BUFFERPTR, "data2"),
+                    ),
+                ],
+            )
 
-        for i in range(100):
-            assert ref()
-            c.setopt(option, ref())
-        gc.collect()
-        assert ref()
+    gc.collect()
+    after = len(gc.get_objects())
+    assert after <= before + 1000, f"object count grew {before} -> {after}"
+    c.close()
 
-        c.close()
-        gc.collect()
-        assert ref() is None
 
-    def test_readfunction_refcounting(self):
-        self.do_function_refcounting(pycurl.READFUNCTION, 'read')
+@pytest.mark.parametrize(
+    "option,target",
+    [
+        pytest.param(pycurl.READDATA, lambda f: f, id="READDATA"),
+        pytest.param(pycurl.WRITEDATA, lambda f: f, id="WRITEDATA"),
+        pytest.param(pycurl.WRITEHEADER, lambda f: f, id="WRITEHEADER"),
+        pytest.param(pycurl.READFUNCTION, lambda f: f.read, id="READFUNCTION"),
+        pytest.param(pycurl.WRITEFUNCTION, lambda f: f.write, id="WRITEFUNCTION"),
+        pytest.param(pycurl.HEADERFUNCTION, lambda f: f.write, id="HEADERFUNCTION"),
+    ],
+)
+def test_option_refcounting(option, target):
+    c = util.DefaultCurl()
+    f = open(devnull, "a+")
+    obj = target(f)
+    c.setopt(option, obj)
+    ref = weakref.ref(obj)
+    del f, obj
+    gc.collect()
+    assert ref() is not None
 
-    def test_writefunction_refcounting(self):
-        self.do_function_refcounting(pycurl.WRITEFUNCTION, 'write')
+    for _ in range(100):
+        assert ref() is not None
+        c.setopt(option, ref())
+    gc.collect()
+    assert ref() is not None
 
-    def test_headerfunction_refcounting(self):
-        self.do_function_refcounting(pycurl.HEADERFUNCTION, 'write')
+    c.close()
+    gc.collect()
+    assert ref() is None
+
+
+_CALLBACK_RELEASE_PARAMS = [
+    pytest.param(pycurl.WRITEFUNCTION, None, id="WRITEFUNCTION"),
+    pytest.param(pycurl.HEADERFUNCTION, None, id="HEADERFUNCTION"),
+    pytest.param(pycurl.READFUNCTION, None, id="READFUNCTION"),
+    pytest.param(
+        pycurl.PROGRESSFUNCTION,
+        "PROGRESSFUNCTION is deprecated; use XFERINFOFUNCTION",
+        id="PROGRESSFUNCTION",
+    ),
+    pytest.param(
+        pycurl.XFERINFOFUNCTION,
+        None,
+        id="XFERINFOFUNCTION",
+        marks=pytest.mark.skipif(
+            util.pycurl_version_less_than(7, 32, 0),
+            reason="libcurl < 7.32.0",
+        ),
+    ),
+    pytest.param(pycurl.DEBUGFUNCTION, None, id="DEBUGFUNCTION"),
+    pytest.param(
+        pycurl.IOCTLFUNCTION,
+        "IOCTLFUNCTION is deprecated; use SEEKFUNCTION",
+        id="IOCTLFUNCTION",
+    ),
+    pytest.param(pycurl.OPENSOCKETFUNCTION, None, id="OPENSOCKETFUNCTION"),
+    pytest.param(pycurl.SEEKFUNCTION, None, id="SEEKFUNCTION"),
+]
+
+
+@pytest.mark.parametrize("callback,deprecation_match", _CALLBACK_RELEASE_PARAMS)
+def test_callback_released_on_close(callback, deprecation_match):
+    def cb(x):
+        return True
+
+    ref = weakref.ref(cb)
+
+    c = util.DefaultCurl()
+    if deprecation_match:
+        with pytest.warns(DeprecationWarning, match=deprecation_match):
+            c.setopt(callback, cb)
+    else:
+        c.setopt(callback, cb)
+    del cb
+    assert ref() is not None, "C extension should still hold the callback"
+
+    del c
+    gc.collect()
+    assert ref() is None, "callback should be released after handle is destroyed"

--- a/tests/multi_memory_mgmt_test.py
+++ b/tests/multi_memory_mgmt_test.py
@@ -1,88 +1,69 @@
-#! /usr/bin/env python
-# vi:ts=4:et
+import gc
+import sys
+import weakref
 
 import pycurl
-import unittest
-import gc
-import flaky
-import weakref
+import pytest
 
 from . import util
 
-debug = False
+
+_MULTI_CALLBACKS = [
+    pytest.param(pycurl.M_SOCKETFUNCTION, id="M_SOCKETFUNCTION"),
+    pytest.param(pycurl.M_TIMERFUNCTION, id="M_TIMERFUNCTION"),
+]
 
 
-@flaky.flaky(max_runs=3)
-class MultiMemoryMgmtTest(unittest.TestCase):
-    def test_opensocketfunction_collection(self):
-        self.check_callback(pycurl.M_SOCKETFUNCTION)
+@pytest.mark.parametrize("callback", _MULTI_CALLBACKS)
+def test_callback_released_on_close(callback):
+    def cb(x):
+        return True
 
-    def test_seekfunction_collection(self):
-        self.check_callback(pycurl.M_TIMERFUNCTION)
+    ref = weakref.ref(cb)
 
-    def check_callback(self, callback):
-        # Note: extracting a context manager seems to result in
-        # everything being garbage collected even if the C code
-        # does not clear the callback
-        object_count = 0
-        gc.collect()
-        # gc.collect() can create new objects... running it again here
-        # settles tracked object count for the actual test below
-        gc.collect()
-        object_count = len(gc.get_objects())
+    m = pycurl.CurlMulti()
+    m.setopt(callback, cb)
+    del cb
+    assert ref() is not None, "C extension should still hold the callback"
 
-        c = pycurl.CurlMulti()
-        c.setopt(callback, lambda x: True)
-        del c
+    del m
+    gc.collect()
+    assert ref() is None, "callback should be released after handle is destroyed"
 
-        gc.collect()
-        new_object_count = len(gc.get_objects())
-        # it seems that GC sometimes collects something that existed
-        # before this test ran, GH issues #273/#274
-        self.assertIn(new_object_count, (object_count, object_count - 1))
 
-    def test_socketfunction_reassignment(self):
-        self.check_callback_reassignment(pycurl.M_SOCKETFUNCTION)
+@pytest.mark.parametrize("callback", _MULTI_CALLBACKS)
+def test_callback_reassignment_releases_old(callback):
+    def first_cb(x):
+        return True
 
-    def test_timerfunction_reassignment(self):
-        self.check_callback_reassignment(pycurl.M_TIMERFUNCTION)
+    m = pycurl.CurlMulti()
+    m.setopt(callback, first_cb)
+    refcount_before = sys.getrefcount(first_cb)
 
-    def check_callback_reassignment(self, callback):
-        """Setting a multi callback twice must not leak the old callback."""
-        import sys
+    def second_cb(x):
+        return False
 
-        def first_cb(x):
-            return True
+    m.setopt(callback, second_cb)
+    refcount_after = sys.getrefcount(first_cb)
 
-        m = pycurl.CurlMulti()
-        m.setopt(callback, first_cb)
-        refcount_before = sys.getrefcount(first_cb)
+    assert refcount_after == refcount_before - 1, "old callback not released"
 
-        def second_cb(x):
-            return False
+    del m
+    gc.collect()
 
-        m.setopt(callback, second_cb)
-        refcount_after = sys.getrefcount(first_cb)
 
-        # After reassignment the old callback should have been released,
-        # so its refcount should have dropped by 1.
-        self.assertEqual(refcount_after, refcount_before - 1)
+def test_curl_kept_alive_while_added_to_multi():
+    c = util.DefaultCurl()
+    m = pycurl.CurlMulti()
 
-        del m
-        gc.collect()
+    ref = weakref.ref(c)
+    m.add_handle(c)
+    del c
 
-    def test_curl_ref(self):
-        c = util.DefaultCurl()
-        m = pycurl.CurlMulti()
+    assert ref() is not None
+    gc.collect()
+    assert ref() is not None
 
-        ref = weakref.ref(c)
-        m.add_handle(c)
-        del c
-
-        assert ref()
-        gc.collect()
-        assert ref()
-
-        m.remove_handle(ref())
-        gc.collect()
-        assert ref() is None
+    m.remove_handle(ref())
+    gc.collect()
+    assert ref() is None

--- a/tests/test_memory_mgmt_close_matrix.py
+++ b/tests/test_memory_mgmt_close_matrix.py
@@ -6,6 +6,7 @@ import pycurl
 from io import BytesIO
 
 from . import util
+from .util import LiveTracker, gc_collect_hard
 
 logger = logging.getLogger(__name__)
 
@@ -16,43 +17,6 @@ def default_share() -> pycurl.CurlShare:
     s.setopt(pycurl.SH_SHARE, pycurl.LOCK_DATA_DNS)
     s.setopt(pycurl.SH_SHARE, pycurl.LOCK_DATA_SSL_SESSION)
     return s
-
-
-def gc_collect_hard(rounds: int = 3) -> None:
-    for _ in range(rounds):
-        gc.collect()
-
-
-class Tracker:
-    """
-    Tracks python object liveness via weakref + optional gc.get_objects scan.
-    """
-
-    def __init__(self) -> None:
-        self._items: list[tuple[str, weakref.ref, int]] = []
-
-    def track(self, name: str, obj):
-        r = weakref.ref(obj)
-        self._items.append((name, r, id(obj)))
-        return obj
-
-    def assert_all_gone(self, *, also_check_gc_objects: bool = True) -> None:
-        gc_collect_hard()
-
-        # Only use gc.get_objects for live refs; ids can be reused after free.
-        live_ids: set[int] | None = None
-        if also_check_gc_objects:
-            live_ids = {id(o) for o in gc.get_objects()}
-
-        for name, r, obj_id in self._items:
-            obj = r()
-            if obj is None:
-                continue
-
-            tracked = (
-                " (gc-tracked)" if live_ids is not None and obj_id in live_ids else ""
-            )
-            raise AssertionError(f"{name} still alive{tracked} (id={obj_id})")
 
 
 @pytest.fixture(autouse=True)
@@ -142,7 +106,7 @@ def perform_all(easies: list[pycurl.Curl]) -> None:
 )
 @pytest.mark.parametrize("phase", ["idle", "in_flight"])
 def test_multi_close_matrix(app, make_multi, order, phase):
-    tr = Tracker()
+    tr = LiveTracker()
 
     url = f"{app}/long_pause"
 
@@ -246,7 +210,7 @@ def test_multi_close_and_remove_one_easy_gone_others_not(make_multi):
     ],
 )
 def test_share_close_matrix(app, make_share_easies, order):
-    tr = Tracker()
+    tr = LiveTracker()
     s = default_share()
     tr.track("share", s)
 
@@ -487,7 +451,7 @@ def test_mimepart_does_not_keep_parent_alive_after_parent_close():
     reason="libcurl without CURLOPT_MIMEPOST support",
 )
 def test_mimepost_cycle_gc_without_explicit_close():
-    tr = Tracker()
+    tr = LiveTracker()
 
     curl = tr.track("curl", pycurl.Curl())
     mime = tr.track("mime", _make_tracking_mime(curl))

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,18 +1,24 @@
 # vi:ts=4:et
 
+import gc
 import tempfile
-import sys, socket
+import sys
+import socket
 import time as _time
 import functools
 import unittest
+import weakref
+
 
 def b(s):
-    '''Byte literal'''
+    """Byte literal"""
     return s.encode("latin-1")
 
+
 def u(s):
-    '''Text literal'''
+    """Text literal"""
     return s
+
 
 def version_less_than_spec(version_tuple, spec_tuple):
     # spec_tuple may have 2 elements, expect version_tuple to have 3 elements
@@ -24,6 +30,7 @@ def version_less_than_spec(version_tuple, spec_tuple):
             return False
     return False
 
+
 def pycurl_version_less_than(*spec):
     import pycurl
 
@@ -31,44 +38,48 @@ def pycurl_version_less_than(*spec):
     version = [c >> 16 & 0xFF, c >> 8 & 0xFF, c & 0xFF]
     return version_less_than_spec(version, spec)
 
+
 def min_python(major, minor):
     def decorator(fn):
         @functools.wraps(fn)
         def decorated(*args, **kwargs):
             if sys.version_info[0:2] < (major, minor):
-                raise unittest.SkipTest('python < %d.%d' % (major, minor))
+                raise unittest.SkipTest("python < %d.%d" % (major, minor))
 
             return fn(*args, **kwargs)
 
         return decorated
 
     return decorator
+
 
 def min_libcurl(major, minor, patch):
     def decorator(fn):
         @functools.wraps(fn)
         def decorated(*args, **kwargs):
             if pycurl_version_less_than(major, minor, patch):
-                raise unittest.SkipTest('libcurl < %d.%d.%d' % (major, minor, patch))
+                raise unittest.SkipTest("libcurl < %d.%d.%d" % (major, minor, patch))
 
             return fn(*args, **kwargs)
 
         return decorated
 
     return decorator
+
 
 def removed_in_libcurl(major, minor, patch):
     def decorator(fn):
         @functools.wraps(fn)
         def decorated(*args, **kwargs):
             if not pycurl_version_less_than(major, minor, patch):
-                raise unittest.SkipTest('libcurl >= %d.%d.%d' % (major, minor, patch))
+                raise unittest.SkipTest("libcurl >= %d.%d.%d" % (major, minor, patch))
 
             return fn(*args, **kwargs)
 
         return decorated
 
     return decorator
+
 
 def skip_in_libcurl_versions(*versions):
     import pycurl
@@ -79,13 +90,14 @@ def skip_in_libcurl_versions(*versions):
             c = pycurl.COMPILE_LIBCURL_VERSION_NUM
             version = (c >> 16 & 0xFF, c >> 8 & 0xFF, c & 0xFF)
             if version in versions:
-                raise unittest.SkipTest('libcurl == %d.%d.%d' % version)
+                raise unittest.SkipTest("libcurl == %d.%d.%d" % version)
 
             return fn(*args, **kwargs)
 
         return decorated
 
     return decorator
+
 
 def skip_module_without_websockets():
     """Call at module level (via :func:`pytest.skip(allow_module_level=True)`)
@@ -96,9 +108,7 @@ def skip_module_without_websockets():
     import pytest
 
     if pycurl_version_less_than(7, 86, 0) or "ws" not in pycurl.version_info()[8]:
-        pytest.skip(
-            "libcurl built without WebSocket support", allow_module_level=True
-        )
+        pytest.skip("libcurl built without WebSocket support", allow_module_level=True)
 
 
 def only_ssl(fn):
@@ -109,12 +119,13 @@ def only_ssl(fn):
         # easier to check that pycurl supports https, although
         # theoretically it is not the same test.
         # pycurl.version_info()[8] is a tuple of protocols supported by libcurl
-        if 'https' not in pycurl.version_info()[8]:
-            raise unittest.SkipTest('libcurl does not support ssl')
+        if "https" not in pycurl.version_info()[8]:
+            raise unittest.SkipTest("libcurl does not support ssl")
 
         return fn(*args, **kwargs)
 
     return decorated
+
 
 def only_telnet(fn):
     import pycurl
@@ -122,12 +133,13 @@ def only_telnet(fn):
     @functools.wraps(fn)
     def decorated(*args, **kwargs):
         # pycurl.version_info()[8] is a tuple of protocols supported by libcurl
-        if 'telnet' not in pycurl.version_info()[8]:
-            raise unittest.SkipTest('libcurl does not support telnet')
+        if "telnet" not in pycurl.version_info()[8]:
+            raise unittest.SkipTest("libcurl does not support telnet")
 
         return fn(*args, **kwargs)
 
     return decorated
+
 
 def only_ssl_backends(*backends):
     def decorator(fn):
@@ -138,18 +150,22 @@ def only_ssl_backends(*backends):
             # easier to check that pycurl supports https, although
             # theoretically it is not the same test.
             # pycurl.version_info()[8] is a tuple of protocols supported by libcurl
-            if 'https' not in pycurl.version_info()[8]:
-                raise unittest.SkipTest('libcurl does not support ssl')
+            if "https" not in pycurl.version_info()[8]:
+                raise unittest.SkipTest("libcurl does not support ssl")
 
             if pycurl.COMPILE_SSL_LIB not in backends:
-                raise unittest.SkipTest('SSL backend is %s' % pycurl.COMPILE_SSL_LIB)
+                raise unittest.SkipTest("SSL backend is %s" % pycurl.COMPILE_SSL_LIB)
 
             return fn(*args, **kwargs)
 
         return decorated
+
     return decorator
 
-def only_ssl_backends_with_min_libcurl(backend_versions: dict[str, tuple[int, int, int]]):
+
+def only_ssl_backends_with_min_libcurl(
+    backend_versions: dict[str, tuple[int, int, int]],
+):
     import pytest
 
     def decorator(fn):
@@ -157,22 +173,25 @@ def only_ssl_backends_with_min_libcurl(backend_versions: dict[str, tuple[int, in
 
         @functools.wraps(fn)
         def decorated(*args, **kwargs):
-            if 'https' not in pycurl.version_info()[8]:
-                pytest.skip('libcurl does not support ssl')
+            if "https" not in pycurl.version_info()[8]:
+                pytest.skip("libcurl does not support ssl")
 
             backend = pycurl.COMPILE_SSL_LIB
             if backend not in backend_versions:
-                pytest.skip('SSL backend is %s' % backend)
+                pytest.skip("SSL backend is %s" % backend)
 
             min_ver = backend_versions[backend]
             if pycurl_version_less_than(*min_ver):
                 pytest.skip(
-                    'SSL backend %s requires libcurl >= %d.%d.%d' % (backend, *min_ver))
+                    "SSL backend %s requires libcurl >= %d.%d.%d" % (backend, *min_ver)
+                )
 
             return fn(*args, **kwargs)
 
         return decorated
+
     return decorator
+
 
 def only_ssl_ech(fn):
     import pycurl
@@ -182,18 +201,19 @@ def only_ssl_ech(fn):
         # easier to check that pycurl supports https, although
         # theoretically it is not the same test.
         # pycurl.version_info()[8] is a tuple of protocols supported by libcurl
-        if 'https' not in pycurl.version_info()[8]:
-            raise unittest.SkipTest('libcurl does not support ssl')
+        if "https" not in pycurl.version_info()[8]:
+            raise unittest.SkipTest("libcurl does not support ssl")
 
         # CURLOPT_ECH is experimental not yet supported by OpenSSL.
-        supported = ['BoringSSL', 'wolfSSL']
+        supported = ["BoringSSL", "wolfSSL"]
         ssl_lib = pycurl.version_info()[5]
         if not any(ssl_lib.startswith(lib) for lib in supported):
-            raise unittest.SkipTest('SSL runtime library is %s' % ssl_lib)
+            raise unittest.SkipTest("SSL runtime library is %s" % ssl_lib)
 
         return fn(*args, **kwargs)
 
     return decorated
+
 
 def only_ipv6(fn):
     import pycurl
@@ -201,21 +221,23 @@ def only_ipv6(fn):
     @functools.wraps(fn)
     def decorated(*args, **kwargs):
         if not pycurl.version_info()[4] & pycurl.VERSION_IPV6:
-            raise unittest.SkipTest('libcurl does not support ipv6')
+            raise unittest.SkipTest("libcurl does not support ipv6")
 
         return fn(*args, **kwargs)
 
     return decorated
+
 
 def only_unix(fn):
     @functools.wraps(fn)
     def decorated(*args, **kwargs):
-        if sys.platform == 'win32':
-            raise unittest.SkipTest('Unix only')
+        if sys.platform == "win32":
+            raise unittest.SkipTest("Unix only")
 
         return fn(*args, **kwargs)
 
     return decorated
+
 
 def only_http2(fn):
     import pycurl
@@ -223,11 +245,12 @@ def only_http2(fn):
     @functools.wraps(fn)
     def decorated(*args, **kwargs):
         if not pycurl.version_info()[4] & pycurl.VERSION_HTTP2:
-            raise unittest.SkipTest('libcurl does not support HTTP version 2')
+            raise unittest.SkipTest("libcurl does not support HTTP version 2")
 
         return fn(*args, **kwargs)
 
     return decorated
+
 
 def only_http3(fn):
     import pycurl
@@ -235,11 +258,12 @@ def only_http3(fn):
     @functools.wraps(fn)
     def decorated(*args, **kwargs):
         if not pycurl.version_info()[4] & pycurl.VERSION_HTTP3:
-            raise unittest.SkipTest('libcurl does not support HTTP version 3')
+            raise unittest.SkipTest("libcurl does not support HTTP version 3")
 
         return fn(*args, **kwargs)
 
     return decorated
+
 
 def only_gssapi(fn):
     import pycurl
@@ -247,11 +271,12 @@ def only_gssapi(fn):
     @functools.wraps(fn)
     def decorated(*args, **kwargs):
         if not pycurl.version_info()[4] & pycurl.VERSION_GSSAPI:
-            raise unittest.SkipTest('libcurl does not support GSS-API')
+            raise unittest.SkipTest("libcurl does not support GSS-API")
 
         return fn(*args, **kwargs)
 
     return decorated
+
 
 def only_tls_srp(fn):
     import pycurl
@@ -259,18 +284,19 @@ def only_tls_srp(fn):
     @functools.wraps(fn)
     def decorated(*args, **kwargs):
         if not pycurl.version_info()[4] & pycurl.VERSION_TLSAUTH_SRP:
-            raise unittest.SkipTest('libcurl does not support TLS-SRP')
+            raise unittest.SkipTest("libcurl does not support TLS-SRP")
 
         return fn(*args, **kwargs)
 
     return decorated
 
+
 def guard_unknown_libcurl_option(fn):
-    '''Converts curl error 48, CURLE_UNKNOWN_OPTION, into a SkipTest
+    """Converts curl error 48, CURLE_UNKNOWN_OPTION, into a SkipTest
     exception. This is meant to be used with tests exercising libcurl
     features that depend on external libraries, such as libssh2/gssapi,
     where libcurl does not provide a way of detecting whether the
-    required libraries were compiled against.'''
+    required libraries were compiled against."""
 
     import pycurl
 
@@ -281,12 +307,17 @@ def guard_unknown_libcurl_option(fn):
         except pycurl.error:
             exc = sys.exc_info()[1]
             # E_UNKNOWN_OPTION is available as of libcurl 7.21.5
-            if hasattr(pycurl, 'E_UNKNOWN_OPTION') and exc.args[0] == pycurl.E_UNKNOWN_OPTION:
-                raise unittest.SkipTest('CURLE_UNKNOWN_OPTION, skipping test')
+            if (
+                hasattr(pycurl, "E_UNKNOWN_OPTION")
+                and exc.args[0] == pycurl.E_UNKNOWN_OPTION
+            ):
+                raise unittest.SkipTest("CURLE_UNKNOWN_OPTION, skipping test")
 
     return decorated
 
+
 create_connection = socket.create_connection
+
 
 def wait_for_network_service(netloc, check_interval, num_attempts):
     ok = False
@@ -294,13 +325,13 @@ def wait_for_network_service(netloc, check_interval, num_attempts):
         try:
             conn = create_connection(netloc, check_interval)
         except socket.error:
-            #e = sys.exc_info()[1]
             _time.sleep(check_interval)
         else:
             conn.close()
             ok = True
             break
     return ok
+
 
 def DefaultCurl():
     import pycurl
@@ -309,21 +340,47 @@ def DefaultCurl():
     curl.setopt(curl.FORBID_REUSE, True)
     return curl
 
+
 def DefaultCurlLocalhost(port):
-    '''This is a default curl with localhost -> 127.0.0.1 name mapping
+    """This is a default curl with localhost -> 127.0.0.1 name mapping
     on windows systems, because they don't have it in the hosts file.
-    '''
+    """
 
     curl = DefaultCurl()
 
-    if sys.platform == 'win32':
-        curl.setopt(curl.RESOLVE, ['localhost:%d:127.0.0.1' % port])
+    if sys.platform == "win32":
+        curl.setopt(curl.RESOLVE, ["localhost:%d:127.0.0.1" % port])
 
     return curl
+
 
 def with_real_write_file(fn):
     @functools.wraps(fn)
     def wrapper(*args):
         with tempfile.NamedTemporaryFile() as f:
             return fn(*(list(args) + [f.file]))
+
     return wrapper
+
+
+def gc_collect_hard(rounds=3):
+    for _ in range(rounds):
+        gc.collect()
+
+
+class LiveTracker:
+    def __init__(self):
+        self._items = []
+
+    def track(self, name, obj):
+        self._items.append((name, weakref.ref(obj), id(obj)))
+        return obj
+
+    def assert_all_gone(self):
+        gc_collect_hard()
+        live_ids = {id(o) for o in gc.get_objects()}
+        for name, wref, obj_id in self._items:
+            if wref() is None:
+                continue
+            tag = " (gc-tracked)" if obj_id in live_ids else ""
+            raise AssertionError(f"{name} still alive{tag} (id={obj_id})")


### PR DESCRIPTION
Replace the `len(gc.get_objects())` check in `check_callback`
with a weakref on the callback itself.

Closes #1006 