### PR TITLE
Pin socket callback tests to IPv4 to handle dual-stack localhost resolution

### DIFF
--- a/tests/close_socket_cb_test.py
+++ b/tests/close_socket_cb_test.py
@@ -96,6 +96,7 @@ def test_closesocketfunction_on_close(app):
 
     curl = util.DefaultCurl()
     curl.setopt(curl.URL, f"{app}/success")
+    curl.setopt(pycurl.IPRESOLVE, pycurl.IPRESOLVE_V4)
     curl.setopt(pycurl.FORBID_REUSE, False)
     curl.setopt(pycurl.CONNECT_ONLY, True)
     curl.setopt(pycurl.CLOSESOCKETFUNCTION, closesocketfunction)
@@ -120,6 +121,7 @@ def test_closesocketfunction_on_dealloc(app):
 
     curl = util.DefaultCurl()
     curl.setopt(curl.URL, f"{app}/success")
+    curl.setopt(pycurl.IPRESOLVE, pycurl.IPRESOLVE_V4)
     curl.setopt(pycurl.FORBID_REUSE, False)
     curl.setopt(pycurl.CONNECT_ONLY, True)
     curl.setopt(pycurl.CLOSESOCKETFUNCTION, closesocketfunction)

--- a/tests/open_socket_cb_test.py
+++ b/tests/open_socket_cb_test.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import socket
 from io import BytesIO
+from urllib.parse import urlparse
 
 import pycurl
 import pytest
@@ -45,7 +46,8 @@ def test_socket_open_ipv6(curl, app):
         return s
 
     curl.setopt(pycurl.OPENSOCKETFUNCTION, on_open)
-    curl.setopt(curl.URL, f"{app.replace('127.0.0.1', '[::1]')}/success")
+    port = urlparse(app).port
+    curl.setopt(curl.URL, f"http://[::1]:{port}/success")
     sio = BytesIO()
     curl.setopt(pycurl.WRITEFUNCTION, sio.write)
     with pytest.raises(pycurl.error):

--- a/tests/test_callback_signals.py
+++ b/tests/test_callback_signals.py
@@ -61,6 +61,7 @@ def test_opensocket_callback_keyboard_interrupt(callback_curl):
         called["called"] = True
         raise KeyboardInterrupt()
 
+    callback_curl.setopt(pycurl.IPRESOLVE, pycurl.IPRESOLVE_V4)
     callback_curl.setopt(pycurl.OPENSOCKETFUNCTION, opensocket_function)
 
     with pytest.raises(KeyboardInterrupt):


### PR DESCRIPTION
Closes #822 

# Context

When `localhost` resolves to both IPV4 and IPV6 addresses, libcurl's Happy Eyeballs
tries `::1` first. The Flask test server only binds `127.0.0.1`, so
libcurl opens a short-lived IPv6 socket, gets `Connection refused`,
closes it, then falls back to IPv4. That extra open + close fires
`OPENSOCKETFUNCTION` and `CLOSESOCKETFUNCTION` one extra time, which
breaks tests that assume exactly one connection attempt:
`test_closesocketfunction_on_close`, `test_closesocketfunction_on_dealloc`,
and `test_opensocket_callback_keyboard_interrupt` (the cascaded
failures mask the `KeyboardInterrupt` as `CURLE_COULDNT_CONNECT`).

`test_socket_open_ipv6` also breaks because it builds its IPv6 URL
with `app.replace('127.0.0.1', '[::1]')`, which is a silent no-op
when the `app` URL host is `localhost`.
