### PR TITLE
Support zero-copy write/header callbacks

### DIFF
--- a/doc/callbacks.rst
+++ b/doc/callbacks.rst
@@ -98,6 +98,19 @@ WRITEFUNCTION
     alternate way of indicating that the callback has consumed all of the
     string passed to it and, hence, succeeded.
 
+    Passing ``use_memoryview=True`` to ``Curl.setopt`` causes the callback to
+    receive a read-only ``memoryview`` over libcurl's temporary buffer
+    instead of a ``bytes`` copy. The memoryview is released as soon as the
+    callback returns, so any reference kept past that point raises
+    ``ValueError`` on access.
+
+    Example::
+
+        def write_cb(chunk: memoryview) -> int:
+            return len(chunk)
+
+        curl.setopt(pycurl.WRITEFUNCTION, write_cb, use_memoryview=True)
+
     `write_test.py test`_ shows how to use ``WRITEFUNCTION``.
 
 
@@ -147,6 +160,19 @@ HEADERFUNCTION
     an error and libcurl will abort the request. Returning ``None`` is an
     alternate way of indicating that the callback has consumed all of the
     string passed to it and, hence, succeeded.
+
+    Passing ``use_memoryview=True`` to ``Curl.setopt`` causes the callback to
+    receive a read-only ``memoryview`` over libcurl's temporary buffer
+    instead of a ``bytes`` copy. The memoryview is released as soon as the
+    callback returns, so any reference kept past that point raises
+    ``ValueError`` on access.
+
+    Example::
+
+        def header_cb(chunk: memoryview) -> int:
+            return len(chunk)
+
+        curl.setopt(pycurl.HEADERFUNCTION, header_cb, use_memoryview=True)
 
     `header_test.py test`_ shows how to use ``WRITEFUNCTION``.
 

--- a/doc/docstrings/curl_setopt.rst
+++ b/doc/docstrings/curl_setopt.rst
@@ -1,4 +1,4 @@
-setopt(option, value) -> None
+setopt(option, value, *, use_memoryview=False) -> None
 
 Set curl session option. Corresponds to `curl_easy_setopt`_ in libcurl.
 
@@ -73,6 +73,10 @@ values of different types:
     import io
     b = io.BytesIO()
     c.setopt(pycurl.WRITEFUNCTION, b.write)
+
+  The keyword-only ``use_memoryview`` argument is accepted for
+  ``WRITEFUNCTION`` and ``HEADERFUNCTION`` (see :ref:`callbacks`); passing it
+  with any other option raises ``TypeError``.
 
 - ``SHARE`` option accepts a :ref:`curlshareobject`.
 

--- a/src/easy.c
+++ b/src/easy.c
@@ -367,10 +367,12 @@ do_curl_duphandle(CurlObject *self, PyObject *Py_UNUSED(ignored))
         dup->w_cb = Py_NewRef(self->w_cb);
         curl_easy_setopt(dup->handle, CURLOPT_WRITEDATA, dup);
     }
+    dup->w_cb_memoryview = self->w_cb_memoryview;
     if (self->h_cb != NULL) {
         dup->h_cb = Py_NewRef(self->h_cb);
         curl_easy_setopt(dup->handle, CURLOPT_WRITEHEADER, dup);
     }
+    dup->h_cb_memoryview = self->h_cb_memoryview;
     if (self->r_cb != NULL) {
         dup->r_cb = Py_NewRef(self->r_cb);
         curl_easy_setopt(dup->handle, CURLOPT_READDATA, dup);
@@ -959,7 +961,7 @@ PYCURL_INTERNAL PyMethodDef curlobject_methods[] = {
     {"recv_into", (PyCFunction)do_curl_recv_into, METH_VARARGS | METH_KEYWORDS, curl_recv_into_doc},
     {"reset", (PyCFunction)do_curl_reset, METH_NOARGS, curl_reset_doc},
     {"send", (PyCFunction)do_curl_send, METH_VARARGS, curl_send_doc},
-    {"setopt", (PyCFunction)do_curl_setopt, METH_VARARGS, curl_setopt_doc},
+    {"setopt", (PyCFunction)do_curl_setopt, METH_VARARGS | METH_KEYWORDS, curl_setopt_doc},
     {"setopt_string", (PyCFunction)do_curl_setopt_string, METH_VARARGS, curl_setopt_string_doc},
     {"share", (PyCFunction)do_curl_share, METH_NOARGS, curl_share_doc},
     {"unpause", (PyCFunction)do_curl_unpause, METH_NOARGS, curl_unpause_doc},

--- a/src/easycb.c
+++ b/src/easycb.c
@@ -34,11 +34,13 @@ static size_t
 util_write_callback(int flags, char *ptr, size_t size, size_t nmemb, void *stream)
 {
     CurlObject *self;
+    PyObject *arg;
     PyObject *arglist;
     PyObject *result = NULL;
     size_t ret = 0;     /* assume error */
     PyObject *cb;
     Py_ssize_t total_size;
+    int as_memoryview;
     int track_ws_write_callback;
     int prev_ws_write_callback = 0;
     PYCURL_DECLARE_THREAD_STATE;
@@ -61,7 +63,17 @@ util_write_callback(int flags, char *ptr, size_t size, size_t nmemb, void *strea
     }
 
     /* run callback */
-    arglist = Py_BuildValue("(y#)", ptr, total_size);
+    as_memoryview = flags ? self->h_cb_memoryview : self->w_cb_memoryview;
+    if (as_memoryview) {
+        arg = PyMemoryView_FromMemory(ptr, total_size, PyBUF_READ);
+    } else {
+        arg = PyBytes_FromStringAndSize(ptr, total_size);
+    }
+    if (arg == NULL) {
+        goto verbose_error;
+    }
+    arglist = PyTuple_Pack(1, arg);
+    Py_DECREF(arg);
     if (arglist == NULL)
         goto verbose_error;
     track_ws_write_callback = (flags == 0);
@@ -72,6 +84,15 @@ util_write_callback(int flags, char *ptr, size_t size, size_t nmemb, void *strea
     result = PyObject_Call(cb, arglist, NULL);
     if (track_ws_write_callback) {
         self->ws_write_cb_running = prev_ws_write_callback;
+    }
+    if (as_memoryview) {
+        PyObject *mv = PyTuple_GET_ITEM(arglist, 0);
+        PyObject *exc_type, *exc_val, *exc_tb;
+
+        /* invalidate stashed references; preserve any callback exception */
+        PyErr_Fetch(&exc_type, &exc_val, &exc_tb);
+        Py_XDECREF(PyObject_CallMethod(mv, "release", NULL));
+        PyErr_Restore(exc_type, exc_val, exc_tb);
     }
     Py_DECREF(arglist);
     if (result == NULL)

--- a/src/easyopt.c
+++ b/src/easyopt.c
@@ -907,7 +907,7 @@ do_curl_setopt_list(CurlObject *self, int option, int which, PyObject *obj)
 
 
 static PyObject *
-do_curl_setopt_callable(CurlObject *self, int option, PyObject *obj)
+do_curl_setopt_callable(CurlObject *self, int option, PyObject *obj, int use_memoryview_flag)
 {
     /* We use function types here to make sure that our callback
      * definitions exactly match the <curl/curl.h> interface.
@@ -949,6 +949,7 @@ do_curl_setopt_callable(CurlObject *self, int option, PyObject *obj)
         Py_CLEAR(self->writedata_fp);
         Py_CLEAR(self->w_cb);
         self->w_cb = obj;
+        self->w_cb_memoryview = (use_memoryview_flag == 1) ? 1 : 0;
         curl_easy_setopt(self->handle, CURLOPT_WRITEFUNCTION, w_cb);
         curl_easy_setopt(self->handle, CURLOPT_WRITEDATA, self);
         break;
@@ -957,6 +958,7 @@ do_curl_setopt_callable(CurlObject *self, int option, PyObject *obj)
         Py_CLEAR(self->writeheader_fp);
         Py_CLEAR(self->h_cb);
         self->h_cb = obj;
+        self->h_cb_memoryview = (use_memoryview_flag == 1) ? 1 : 0;
         curl_easy_setopt(self->handle, CURLOPT_HEADERFUNCTION, h_cb);
         curl_easy_setopt(self->handle, CURLOPT_WRITEHEADER, self);
         break;
@@ -1239,7 +1241,7 @@ do_curl_setopt_filelike(CurlObject *self, int option, PyObject *obj)
         if (arglist == NULL) {
             return NULL;
         }
-        rv = do_curl_setopt(self, arglist);
+        rv = do_curl_setopt(self, arglist, NULL);
         Py_DECREF(arglist);
         return rv;
     } else {
@@ -1254,13 +1256,16 @@ do_curl_setopt_filelike(CurlObject *self, int option, PyObject *obj)
 
 
 PYCURL_INTERNAL PyObject *
-do_curl_setopt(CurlObject *self, PyObject *args)
+do_curl_setopt(CurlObject *self, PyObject *args, PyObject *kwargs)
 {
     int option;
     PyObject *obj;
     int which;
+    int use_memoryview_flag = -1;  /* sentinel: kwarg not supplied */
+    static char *kwlist[] = {"option", "value", "use_memoryview", NULL};
 
-    if (!PyArg_ParseTuple(args, "iO:setopt", &option, &obj))
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "iO|$p:setopt",
+                                     kwlist, &option, &obj, &use_memoryview_flag))
         return NULL;
     if (check_curl_state(self, PYCURL_REQUIRE_HANDLE | PYCURL_REQUIRE_NOT_RUNNING, "setopt") != 0)
         return NULL;
@@ -1277,6 +1282,14 @@ do_curl_setopt(CurlObject *self, PyObject *args)
 #endif
     if (option % 10000 >= OPTIONS_SIZE)
         goto error;
+
+    if (use_memoryview_flag != -1 &&
+        option != CURLOPT_WRITEFUNCTION &&
+        option != CURLOPT_HEADERFUNCTION) {
+        PyErr_SetString(PyExc_TypeError,
+            "use_memoryview is only supported for WRITEFUNCTION and HEADERFUNCTION");
+        return NULL;
+    }
 
     /* Handle the case of None as the call of unsetopt() */
     if (obj == Py_None) {
@@ -1308,7 +1321,7 @@ do_curl_setopt(CurlObject *self, PyObject *args)
     /* Handle the case of function objects for callbacks */
     if (PyFunction_Check(obj) || PyCFunction_Check(obj) ||
         PyCallable_Check(obj) || PyMethod_Check(obj)) {
-        return do_curl_setopt_callable(self, option, obj);
+        return do_curl_setopt_callable(self, option, obj, use_memoryview_flag);
     }
     /* handle the SHARE case */
     if (option == CURLOPT_SHARE) {

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -488,7 +488,9 @@ typedef struct CurlObject {
 #endif
     /* callbacks */
     PyObject *w_cb;
+    int       w_cb_memoryview;
     PyObject *h_cb;
+    int       h_cb_memoryview;
     PyObject *r_cb;
     PyObject *pro_cb;
 #if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 32, 0)
@@ -659,7 +661,7 @@ do_url_strerror(PyObject *dummy, PyObject *args);
 #endif
 
 PYCURL_INTERNAL PyObject *
-do_curl_setopt(CurlObject *self, PyObject *args);
+do_curl_setopt(CurlObject *self, PyObject *args, PyObject *kwargs);
 PYCURL_INTERNAL PyObject *
 do_curl_setopt_string(CurlObject *self, PyObject *args);
 PYCURL_INTERNAL PyObject *

--- a/tests/test_write_cb_memoryview.py
+++ b/tests/test_write_cb_memoryview.py
@@ -1,0 +1,149 @@
+import sys
+
+import pycurl
+import pytest
+
+
+@pytest.fixture(
+    params=[pycurl.WRITEFUNCTION, pycurl.HEADERFUNCTION],
+    ids=["write", "header"],
+)
+def cb_option(request):
+    return request.param
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [{}, {"use_memoryview": False}],
+    ids=["default", "use_memoryview_false"],
+)
+def test_passes_bytes(curl, app, cb_option, kwargs):
+    curl.setopt(pycurl.URL, f"{app}/success")
+    seen = []
+
+    def cb(chunk):
+        seen.append(type(chunk))
+        return len(chunk)
+
+    curl.setopt(cb_option, cb, **kwargs)
+    curl.perform()
+    assert seen
+    assert all(t is bytes for t in seen)
+
+
+def test_memoryview_true_passes_readonly_memoryview(curl, app, cb_option):
+    curl.setopt(pycurl.URL, f"{app}/success")
+    seen = []
+
+    def cb(chunk):
+        seen.append((type(chunk), chunk.readonly))
+        return len(chunk)
+
+    curl.setopt(cb_option, cb, use_memoryview=True)
+    curl.perform()
+    assert seen
+    for typ, readonly in seen:
+        assert typ is memoryview
+        assert readonly is True
+
+
+def test_memoryview_true_return_none(curl, app, cb_option):
+    curl.setopt(pycurl.URL, f"{app}/success")
+    chunks = []
+    curl.setopt(
+        cb_option, lambda chunk: chunks.append(bytes(chunk)), use_memoryview=True
+    )
+    curl.perform()
+    assert b"".join(chunks)  # got data
+
+
+def test_memoryview_true_return_length(curl, app, cb_option):
+    curl.setopt(pycurl.URL, f"{app}/success")
+    curl.setopt(cb_option, lambda chunk: len(chunk), use_memoryview=True)
+    curl.perform()  # would raise if length mismatched
+
+
+def test_memoryview_true_wrong_length_aborts(curl, app, cb_option):
+    curl.setopt(pycurl.URL, f"{app}/success")
+    curl.setopt(
+        cb_option, lambda chunk: 1 if len(chunk) > 1 else 0, use_memoryview=True
+    )
+    with pytest.raises(pycurl.error) as exc_info:
+        curl.perform()
+    assert exc_info.value.args[0] == pycurl.E_WRITE_ERROR
+
+
+def test_memoryview_true_callback_exception_preserved(curl, app, cb_option):
+    curl.setopt(pycurl.URL, f"{app}/success")
+
+    def cb(_):
+        raise RuntimeError("boom")
+
+    curl.setopt(cb_option, cb, use_memoryview=True)
+    with pytest.raises(pycurl.error) as exc_info:
+        curl.perform()
+    assert exc_info.value.args[0] == pycurl.E_WRITE_ERROR
+    assert sys.last_type is RuntimeError
+    assert str(sys.last_value) == "boom"
+
+
+def test_memoryview_released_after_callback(curl, app, cb_option):
+    curl.setopt(pycurl.URL, f"{app}/success")
+    stashed = []
+
+    def cb(chunk):
+        stashed.append(chunk)
+        return len(chunk)
+
+    curl.setopt(cb_option, cb, use_memoryview=True)
+    curl.perform()
+    assert stashed
+    with pytest.raises(ValueError, match="released memoryview"):
+        bytes(stashed[0])
+
+
+def test_setopt_without_memoryview_resets_to_bytes(curl, app, cb_option):
+    curl.setopt(pycurl.URL, f"{app}/success")
+    seen = []
+
+    def cb(chunk):
+        seen.append(type(chunk))
+        return len(chunk)
+
+    curl.setopt(cb_option, cb, use_memoryview=True)
+    curl.setopt(cb_option, cb)  # no memoryview kwarg -> reset to default
+    curl.perform()
+    assert seen
+    assert all(t is bytes for t in seen)
+
+
+def test_duphandle_preserves_memoryview_flag(curl, app, cb_option):
+    curl.setopt(pycurl.URL, f"{app}/success")
+    seen = []
+
+    def cb(chunk):
+        seen.append(type(chunk))
+        return len(chunk)
+
+    curl.setopt(cb_option, cb, use_memoryview=True)
+    dup = curl.duphandle()
+    try:
+        dup.perform()
+    finally:
+        dup.close()
+    assert seen
+    assert all(t is memoryview for t in seen)
+
+
+@pytest.mark.parametrize("flag", [False, True])
+def test_memoryview_rejected_on_unrelated_option(curl, app, flag):
+    with pytest.raises(
+        TypeError,
+        match="use_memoryview is only supported for WRITEFUNCTION and HEADERFUNCTION",
+    ):
+        curl.setopt(pycurl.URL, f"{app}/success", use_memoryview=flag)
+
+
+def test_memoryview_must_be_keyword_only(curl):
+    with pytest.raises(TypeError):
+        curl.setopt(pycurl.WRITEFUNCTION, lambda chunk: len(chunk), True)


### PR DESCRIPTION
This is a proposal of API evolution for `WRITEFUNCTION` and `HEADERFUNCTION`.

Passing `use_memoryview=False` to `Curl.setopt` lets the callback receive a
read-only `memoryview` over libcurl's buffer instead of `bytes`. The default is unchanged.

`use_memoryview` is kwarg-only and only accepted for these two options. The
view is released when the callback returns.