### PR TITLE
Use step-security's fork of msvc-dev-cmd

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: ilammy/msvc-dev-cmd@v1
+    - uses: step-security/msvc-dev-cmd@v1
       with:
         arch: ${{ matrix.arch }}
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           python-version: 3.14
 
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: step-security/msvc-dev-cmd@v1
         if: runner.os == 'Windows'
         with:
           arch: ${{ matrix.arch }}


### PR DESCRIPTION
The ilammy version seems unmaintained and does not support Node v24.