### PR TITLE
Fix ws auto-pong test race on free-threaded Python 3.14t

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
           - curl-version: "vcpkg"
             python-version: "3.12"
             cibw-build: "cp312-manylinux_x86_64"
+          - curl-version: "vcpkg"
+            python-version: "3.14t"
+            cibw-build: "cp314t-manylinux_x86_64"
     permissions:
       packages: write
 

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -29,53 +29,42 @@ def connected(wscurl, ws_app):
 
 def _wait_readable(c, timeout):
     fd = c.getinfo(pycurl.ACTIVESOCKET)
-    r, _, _ = select.select([fd], [], [], timeout)
-    return bool(r)
+    select.select([fd], [], [], timeout)
 
 
 def _flush_pending_sends(c):
     # libcurl >= 8.21.0 queues the auto-PONG reply instead of sending it, and a
     # recv-only loop never flushes it. ws_send() flushes buffered frames first,
-    # so an empty PONG pushes the queued reply out. Returns False on EAGAIN.
+    # so an empty PONG pushes the queued reply out.
     try:
         c.ws_send(b"", pycurl.WS_PONG)
-        return True
     except BlockingIOError:
-        return False
+        pass
+
+
+def _recv_loop(c, recv, timeout, pump_sends=False):
+    # Try recv() first (libcurl may hold buffered data). Fall back to select()
+    # on BlockingIOError / CURLE_AGAIN. With pump_sends, flush the send side
+    # before each wait so the lazily-queued auto-PONG reaches the server.
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            return recv()
+        except BlockingIOError:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("timed out waiting for ws data")
+            if pump_sends:
+                _flush_pending_sends(c)
+            _wait_readable(c, remaining)
 
 
 def _recv(c, bufsize, timeout=5.0, pump_sends=False):
-    # Try ws_recv() first (libcurl may hold buffered data); fall back to
-    # select() on BlockingIOError / CURLE_AGAIN. With pump_sends, also flush the
-    # send side once it has drained so a queued auto-PONG reaches the server.
-    deadline = time.monotonic() + timeout
-    fd = c.getinfo(pycurl.ACTIVESOCKET)
-    flushed = False
-    while True:
-        try:
-            return c.ws_recv(bufsize)
-        except BlockingIOError:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                raise AssertionError("timed out waiting for ws data")
-            if pump_sends and not flushed:
-                r, w, _ = select.select([fd], [fd], [], remaining)
-                if w and not r:
-                    flushed = _flush_pending_sends(c)
-            else:
-                _wait_readable(c, remaining)
+    return _recv_loop(c, lambda: c.ws_recv(bufsize), timeout, pump_sends)
 
 
 def _recv_into(c, buffer, nbytes=0, timeout=5.0):
-    deadline = time.monotonic() + timeout
-    while True:
-        try:
-            return c.ws_recv_into(buffer, nbytes)
-        except BlockingIOError:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                raise AssertionError("timed out waiting for ws data")
-            _wait_readable(c, remaining)
+    return _recv_loop(c, lambda: c.ws_recv_into(buffer, nbytes), timeout)
 
 
 def _recv_until(c, predicate, timeout=5.0, pump_sends=False):
@@ -86,7 +75,7 @@ def _recv_until(c, predicate, timeout=5.0, pump_sends=False):
     while True:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
-            raise AssertionError("timed out waiting for ws data")
+            raise TimeoutError("timed out waiting for ws data")
         data, meta = _recv(c, 4096, remaining, pump_sends=pump_sends)
         frames.append((data, meta))
         if predicate(data, meta):

--- a/tests/wsappmanager.py
+++ b/tests/wsappmanager.py
@@ -85,7 +85,7 @@ class WsServer:
         async def ping_and_report_pong(ws):
             pong_waiter = await ws.ping(b"probe")
             try:
-                await asyncio.wait_for(pong_waiter, timeout=0.5)
+                await asyncio.wait_for(pong_waiter, timeout=2.0)
                 await ws.send("pong-ok")
             except asyncio.TimeoutError:
                 await ws.send("pong-missing")


### PR DESCRIPTION
Fixes #1027 

The pump flushed libcurl's queued PONG only once, right after the first
`ws_recv`, but on free-threaded builds that runs before the server's ping
arrives, so the flush goes out empty and the real PONG never does.

Fix: flush before each wait instead of once, so the PONG goes out whenever
the ping lands.