### PR TITLE
Chain Python callback exceptions as `pycurl.error.__cause__`

### DIFF
--- a/doc/callbacks.rst
+++ b/doc/callbacks.rst
@@ -31,55 +31,33 @@ The signature of each callback used in PycURL is documented below.
 Error Reporting
 ---------------
 
-PycURL callbacks are invoked as follows:
+Callbacks are invoked by libcurl. On failure they should not raise an
+exception but return the failure value documented for each callback below.
 
-Python application -> ``perform()`` -> libcurl (C code) -> Python callback
-
-Because callbacks are invoked by libcurl, they should not raise exceptions
-on failure but instead return appropriate values indicating failure.
-The documentation for individual callbacks below specifies expected success and
-failure return values.
-
-Unhandled exceptions propagated out of Python callbacks will be intercepted
-by PycURL or the Python runtime. This will fail the callback with a
-generic failure status, in turn failing the ``perform()`` operation.
-A failing ``perform()`` will raise ``pycurl.error``, but the error code
-used depends on the specific callback.
-
-``KeyboardInterrupt`` and other ``BaseException`` subclasses (for example, ``SystemExit``)
-are handled specially: if they are raised inside a callback, they are preserved and re-raised
-to the caller instead of being converted into a ``pycurl.error``.
-
-Rich context information like exception objects can be stored in various ways,
-for example the following example stores OPENSOCKET callback exception on the
-Curl object::
-
-    import pycurl, random, socket
-
-    class ConnectionRejected(Exception):
-        pass
-
-    def opensocket(curl, purpose, curl_address):
-        # always fail
-        curl.exception = ConnectionRejected('Rejecting connection attempt in opensocket callback')
-        return pycurl.SOCKET_BAD
-
-        # the callback must create a socket if it does not fail,
-        # see examples/opensocketexception.py
-
-    c = pycurl.Curl()
-    c.setopt(c.URL, 'https://pycurl.github.io')
-    c.exception = None
-    c.setopt(c.OPENSOCKETFUNCTION,
-        lambda purpose, address: opensocket(c, purpose, address))
+A regular ``Exception`` raised inside an easy-handle callback is attached as the
+``__cause__`` of the ``pycurl.error`` that ``perform()`` raises. The
+``pycurl.error`` type, error code and message are unchanged, and the original
+exception remains available through ``__cause__`` with its traceback and
+attributes intact::
 
     try:
         c.perform()
     except pycurl.error as e:
-        if e.args[0] == pycurl.E_COULDNT_CONNECT and c.exception:
-            print(c.exception)
-        else:
-            print(e)
+        if isinstance(e.__cause__, MyError):
+            handle(e.__cause__)
+
+If several callbacks raise during the same ``perform()``, the captured
+exceptions are wrapped in an ``ExceptionGroup`` (Python 3.11 or later) that
+becomes the ``__cause__``. On Python 3.10 the first captured exception is used
+instead.
+
+``KeyboardInterrupt``, ``SystemExit`` and other ``BaseException`` subclasses are
+not converted to ``pycurl.error`` and propagate unchanged.
+
+A callback whose return value libcurl ignores (for example ``DEBUGFUNCTION``)
+cannot fail the transfer by itself. An exception raised in such a callback is
+printed to stderr, and becomes part of the ``__cause__`` only when the same
+``perform()`` fails for another reason.
 
 
 WRITEFUNCTION

--- a/src/easy.c
+++ b/src/easy.c
@@ -551,6 +551,7 @@ util_curl_xdecref(CurlObject *self, int flags, CURL *handle)
 
     if (flags & PYCURL_MEMGROUP_CALLBACK) {
         /* Decrement refcount for python callbacks. */
+        Py_CLEAR(self->callback_exception);
         Py_CLEAR(self->w_cb);
         Py_CLEAR(self->h_cb);
         Py_CLEAR(self->r_cb);
@@ -788,6 +789,8 @@ do_curl_traverse(CurlObject *self, visitproc visit, void *arg)
     VISIT(self->dict);
     VISIT(self->multi_weakref);
     VISIT((PyObject *) self->share);
+
+    VISIT(self->callback_exception);
 
     VISIT(self->w_cb);
     VISIT(self->h_cb);

--- a/src/easycb.c
+++ b/src/easycb.c
@@ -116,7 +116,7 @@ silent_error:
     Py_XDECREF(result);
     PYCURL_END_CALLBACK(ret);
 verbose_error:
-    print_callback_error_if_regular_exception();
+    pycurl_capture_callback_exception(&self->callback_exception);
     goto silent_error;
 }
 
@@ -299,7 +299,7 @@ done:
     Py_XDECREF(fileno_result);
     PYCURL_END_CALLBACK(ret);
 verbose_error:
-    print_callback_error_if_regular_exception();
+    pycurl_capture_callback_exception(&self->callback_exception);
     goto silent_error;
 }
 
@@ -331,6 +331,7 @@ sockopt_cb(void *clientp, curl_socket_t curlfd, curlsocktype purpose)
     ret_obj = PyObject_Call(self->sockopt_cb, arglist, NULL);
     Py_DECREF(arglist);
     if (callback_return_value_to_int(ret_obj, "sockopt", &ret) != 0) {
+        pycurl_stash_callback_exception(&self->callback_exception);
         goto silent_error;
     }
     goto done;
@@ -341,7 +342,7 @@ done:
     Py_XDECREF(ret_obj);
     PYCURL_END_CALLBACK(ret);
 verbose_error:
-    print_callback_error_if_regular_exception();
+    pycurl_capture_callback_exception(&self->callback_exception);
     goto silent_error;
 }
 
@@ -373,8 +374,10 @@ closesocket_callback(void *clientp, curl_socket_t curlfd)
 
     ret_obj = PyObject_Call(self->closesocket_cb, arglist, NULL);
     Py_DECREF(arglist);
+    /* libcurl ignores this callback's return, so a raise cannot abort the
+       transfer; print it (like DEBUGFUNCTION) rather than lose it on success. */
     if (callback_return_value_to_int(ret_obj, "closesocket", &ret) != 0) {
-        goto silent_error;
+        goto verbose_error;
     }
     goto done;
 
@@ -384,7 +387,7 @@ done:
     Py_XDECREF(ret_obj);
     PYCURL_END_CALLBACK(ret);
 verbose_error:
-    print_callback_error_if_regular_exception();
+    pycurl_capture_callback_exception(&self->callback_exception);
     goto silent_error;
 }
 #endif
@@ -450,6 +453,7 @@ ssh_key_cb(CURL *easy, const struct curl_khkey *knownkey,
     ret_obj = PyObject_Call(self->ssh_key_cb, arglist, NULL);
     Py_DECREF(arglist);
     if (callback_return_value_to_int(ret_obj, "ssh key", &ret) != 0) {
+        pycurl_stash_callback_exception(&self->callback_exception);
         goto silent_error;
     }
     goto done;
@@ -462,7 +466,7 @@ done:
     Py_XDECREF(ret_obj);
     PYCURL_END_CALLBACK(ret);
 verbose_error:
-    print_callback_error_if_regular_exception();
+    pycurl_capture_callback_exception(&self->callback_exception);
     goto silent_error;
 }
 #endif
@@ -534,7 +538,7 @@ silent_error:
     Py_XDECREF(result);
     PYCURL_END_CALLBACK(ret);
 verbose_error:
-    print_callback_error_if_regular_exception();
+    pycurl_capture_callback_exception(&self->callback_exception);
     goto silent_error;
 }
 
@@ -646,7 +650,7 @@ silent_error:
     Py_XDECREF(result);
     PYCURL_END_CALLBACK(ret);
 verbose_error:
-    print_callback_error_if_regular_exception();
+    pycurl_capture_callback_exception(&self->callback_exception);
     goto silent_error;
 }
 
@@ -697,7 +701,7 @@ silent_error:
     Py_XDECREF(result);
     PYCURL_END_CALLBACK(ret);
 verbose_error:
-    print_callback_error_if_regular_exception();
+    pycurl_capture_callback_exception(&self->callback_exception);
     goto silent_error;
 }
 
@@ -752,7 +756,7 @@ silent_error:
     Py_XDECREF(result);
     PYCURL_END_CALLBACK(ret);
 verbose_error:
-    print_callback_error_if_regular_exception();
+    pycurl_capture_callback_exception(&self->callback_exception);
     goto silent_error;
 }
 #endif
@@ -798,7 +802,7 @@ silent_error:
     Py_XDECREF(result);
     PYCURL_END_CALLBACK(ret);
 verbose_error:
-    print_callback_error_if_regular_exception();
+    pycurl_capture_callback_exception(&self->callback_exception);
     goto silent_error;
 }
 
@@ -848,7 +852,7 @@ silent_error:
     Py_XDECREF(result);
     PYCURL_END_CALLBACK((curlioerr) ret);
 verbose_error:
-    print_callback_error_if_regular_exception();
+    pycurl_capture_callback_exception(&self->callback_exception);
     goto silent_error;
 }
 
@@ -942,8 +946,9 @@ ssl_ctx_callback(CURL *curl, void *ssl_ctx, void *ptr)
                          PyBytes_AS_STRING(self->ca_certs_obj),
                          PyBytes_GET_SIZE(self->ca_certs_obj));
 
-    if (r != 0)
-        print_callback_error_if_regular_exception();
+    if (r != 0) {
+        pycurl_capture_callback_exception(&self->callback_exception);
+    }
 
     PYCURL_END_CALLBACK(r == 0 ? CURLE_OK : CURLE_FAILED_INIT);
 }
@@ -972,6 +977,7 @@ prereq_callback(void *clientp, char *conn_primary_ip, char *conn_local_ip,
     ret_obj = PyObject_Call(self->prereq_cb, arglist, NULL);
     Py_DECREF(arglist);
     if (callback_return_value_to_int(ret_obj, "prereq", &ret) != 0) {
+        pycurl_stash_callback_exception(&self->callback_exception);
         goto silent_error;
     }
     goto done;
@@ -982,7 +988,7 @@ done:
     Py_XDECREF(ret_obj);
     PYCURL_END_CALLBACK(ret);
 verbose_error:
-    print_callback_error_if_regular_exception();
+    pycurl_capture_callback_exception(&self->callback_exception);
     goto silent_error;
 }
 #endif
@@ -1010,6 +1016,7 @@ fnmatch_callback(void *clientp, const char *pattern, const char *string)
     ret_obj = PyObject_Call(self->fnmatch_cb, arglist, NULL);
     Py_DECREF(arglist);
     if (callback_return_value_to_int(ret_obj, "fnmatch", &ret) != 0) {
+        pycurl_stash_callback_exception(&self->callback_exception);
         goto silent_error;
     }
     goto done;
@@ -1020,7 +1027,7 @@ done:
     Py_XDECREF(ret_obj);
     PYCURL_END_CALLBACK(ret);
 verbose_error:
-    print_callback_error_if_regular_exception();
+    pycurl_capture_callback_exception(&self->callback_exception);
     goto silent_error;
 }
 #endif
@@ -1059,7 +1066,7 @@ done:
     Py_XDECREF(ret_obj);
     PYCURL_END_CALLBACK(ret);
 verbose_error:
-    print_callback_error_if_regular_exception();
+    pycurl_capture_callback_exception(&self->callback_exception);
     goto silent_error;
 }
 #endif
@@ -1115,7 +1122,7 @@ done:
     PYCURL_END_CALLBACK(ret);
 verbose_error:
     *list = NULL;
-    print_callback_error_if_regular_exception();
+    pycurl_capture_callback_exception(&self->callback_exception);
     goto silent_error;
 }
 #endif
@@ -1294,7 +1301,7 @@ done:
 verbose_error:
     Py_XDECREF(expire_obj);
     Py_XDECREF(arglist);
-    print_callback_error_if_regular_exception();
+    pycurl_capture_callback_exception(&self->callback_exception);
     goto silent_error;
 }
 
@@ -1379,7 +1386,7 @@ done:
     Py_XDECREF(ret_obj);
     PYCURL_END_CALLBACK(ret);
 verbose_error:
-    print_callback_error_if_regular_exception();
+    pycurl_capture_callback_exception(&self->callback_exception);
     goto silent_error;
 }
 #endif

--- a/src/easyperform.c
+++ b/src/easyperform.c
@@ -12,17 +12,24 @@ do_curl_perform(CurlObject *self, PyObject *Py_UNUSED(ignored))
         return NULL;
     }
 
+    pycurl_easy_clear_callback_state(self);
+
     PYCURL_BEGIN_ALLOW_THREADS
     res = curl_easy_perform(self->handle);
     PYCURL_END_ALLOW_THREADS
 
     if (check_pending_python_exception_or_signal() != 0) {
+        pycurl_easy_clear_callback_state(self);
         return NULL;
     }
 
     if (res != CURLE_OK) {
-        CURLERROR_RETVAL();
+        create_and_set_error_object(self, (int) res);
+        pycurl_easy_attach_callback_cause(self);
+        return NULL;
     }
+    /* Drop captures from ignored-return callbacks such as DEBUGFUNCTION. */
+    pycurl_easy_clear_callback_state(self);
     Py_RETURN_NONE;
 }
 
@@ -316,11 +323,18 @@ do_curl_pause_internal(CurlObject *self, int bitmask, const char *op_name)
         return NULL;
     }
 
+    /* pause() may run nested inside a callback. Chain onto its own error
+       without clearing the enclosing perform's captures. */
     if (res != CURLE_OK) {
-        CURLERROR_MSG("pause/unpause failed");
-    } else {
-        Py_RETURN_NONE;
+        PyObject *v = Py_BuildValue("(is)", (int) res, "pause/unpause failed");
+        if (v != NULL) {
+            PyErr_SetObject(ErrorObject, v);
+            Py_DECREF(v);
+        }
+        pycurl_easy_attach_callback_cause(self);
+        return NULL;
     }
+    Py_RETURN_NONE;
 }
 
 

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -398,6 +398,24 @@ struct CurlObject;
 PYCURL_INTERNAL void
 create_and_set_error_object(struct CurlObject *self, int code);
 
+/* Capture the pending exception onto the *storage list. The _capture_ variant
+   also prints it. A BaseException is left set to keep propagating. */
+PYCURL_INTERNAL void
+pycurl_capture_callback_exception(PyObject **storage);
+PYCURL_INTERNAL void
+pycurl_stash_callback_exception(PyObject **storage);
+
+/* Attach the captures in *storage as __cause__ of the pending error (an
+   ExceptionGroup on 3.11+ when several). Always clears *storage. */
+PYCURL_INTERNAL void
+pycurl_attach_callback_cause(PyObject **storage);
+
+/* Easy-handle wrappers operating on self->callback_exception. */
+PYCURL_INTERNAL void
+pycurl_easy_clear_callback_state(struct CurlObject *self);
+PYCURL_INTERNAL void
+pycurl_easy_attach_callback_cause(struct CurlObject *self);
+
 
 /* Raise exception based on return value `res' and `self->error' */
 #define CURLERROR_RETVAL() do {\
@@ -556,6 +574,8 @@ typedef struct CurlObject {
     PyObject *ca_certs_obj;
     /* true while executing WRITEFUNCTION for this handle */
     int ws_write_cb_running;
+    /* captured callback exceptions, chained as __cause__ by perform() */
+    PyObject *callback_exception;
     /* misc */
     char error[CURL_ERROR_SIZE+1];
 } CurlObject;

--- a/src/util.c
+++ b/src/util.c
@@ -34,6 +34,125 @@ print_callback_error_if_regular_exception(void)
     }
 }
 
+/* Stash the pending exception on the *storage list; also print it when
+   print_traceback is set. A BaseException is left set to keep propagating. */
+static void
+capture_callback_exception(PyObject **storage, int print_traceback)
+{
+    PyObject *type = NULL, *value = NULL, *tb = NULL, *list;
+
+    if (!PyErr_Occurred() || !PyErr_ExceptionMatches(PyExc_Exception)) {
+        return;
+    }
+    PyErr_Fetch(&type, &value, &tb);
+    PyErr_NormalizeException(&type, &value, &tb);
+    if (value == NULL) {
+        Py_XDECREF(type);
+        Py_XDECREF(tb);
+        return;
+    }
+    if (tb != NULL) {
+        PyException_SetTraceback(value, tb);
+    }
+
+    list = *storage;
+    if (list == NULL) {
+        list = PyList_New(0);
+        if (list != NULL) {
+            *storage = list;
+        }
+    }
+    if (list != NULL) {
+        (void) PyList_Append(list, value);
+    }
+
+    if (print_traceback) {
+        PyErr_Restore(type, value, tb);
+        PyErr_Print();
+    } else {
+        Py_DECREF(value);
+        Py_XDECREF(type);
+        Py_XDECREF(tb);
+    }
+}
+
+PYCURL_INTERNAL void
+pycurl_capture_callback_exception(PyObject **storage)
+{
+    capture_callback_exception(storage, 1);
+}
+
+PYCURL_INTERNAL void
+pycurl_stash_callback_exception(PyObject **storage)
+{
+    capture_callback_exception(storage, 0);
+}
+
+PYCURL_INTERNAL void
+pycurl_attach_callback_cause(PyObject **storage)
+{
+    PyObject *list = *storage;
+    PyObject *cause = NULL;
+    PyObject *type = NULL, *value = NULL, *tb = NULL;
+    Py_ssize_t n;
+
+    *storage = NULL;
+    if (list == NULL) {
+        return;
+    }
+    n = PyList_GET_SIZE(list);
+    if (n == 0) {
+        Py_DECREF(list);
+        return;
+    }
+    /* No pending error: the libcurl call succeeded despite the callback
+       raising (e.g. DEBUGFUNCTION). Drop the captures. */
+    if (!PyErr_Occurred()) {
+        Py_DECREF(list);
+        return;
+    }
+
+    PyErr_Fetch(&type, &value, &tb);
+    PyErr_NormalizeException(&type, &value, &tb);
+    if (value == NULL) {
+        PyErr_Restore(type, value, tb);
+        Py_DECREF(list);
+        return;
+    }
+
+#if PY_VERSION_HEX >= 0x030B0000
+    /* Several captures wrap in an ExceptionGroup (all leaves are Exception). */
+    if (n > 1) {
+        cause = PyObject_CallFunction(PyExc_BaseExceptionGroup, "sO",
+                                      "PycURL callback exceptions", list);
+    } else
+#endif
+    {
+        cause = Py_NewRef(PyList_GET_ITEM(list, 0));
+    }
+    Py_DECREF(list);
+    if (cause == NULL) {
+        PyErr_Clear();
+        PyErr_Restore(type, value, tb);
+        return;
+    }
+
+    PyException_SetCause(value, cause); /* steals cause */
+    PyErr_Restore(type, value, tb);     /* steals type/value/tb */
+}
+
+PYCURL_INTERNAL void
+pycurl_easy_clear_callback_state(CurlObject *self)
+{
+    Py_CLEAR(self->callback_exception);
+}
+
+PYCURL_INTERNAL void
+pycurl_easy_attach_callback_cause(CurlObject *self)
+{
+    pycurl_attach_callback_cause(&self->callback_exception);
+}
+
 PYCURL_INTERNAL PyObject *
 PyLong_FromCurlSocket(curl_socket_t sockfd)
 {

--- a/tests/test_callback_cause.py
+++ b/tests/test_callback_cause.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import builtins
+import os.path
+import sys
+import urllib.request
+
+import pycurl
+import pytest
+
+from . import util
+
+
+# Empty tuple on 3.10 so isinstance(x, _BaseExceptionGroup) is harmlessly False.
+_BaseExceptionGroup = getattr(builtins, "BaseExceptionGroup", ())
+
+_FILE_URL = "file:" + urllib.request.pathname2url(os.path.abspath(__file__))
+
+
+def _raise_runtime(*_a, **_kw):
+    raise RuntimeError("boom")
+
+
+def _discard(_data):
+    return None
+
+
+def _walk_leaves(exc):
+    if isinstance(exc, _BaseExceptionGroup):
+        for sub in exc.exceptions:
+            yield from _walk_leaves(sub)
+    else:
+        yield exc
+
+
+def _assert_cause_includes(err, exc_type, message=None):
+    # __cause__ is the exception itself, or an ExceptionGroup of them on 3.11+.
+    cause = err.__cause__
+    assert cause is not None, f"expected a __cause__, got None on {err!r}"
+    leaves = [e for e in _walk_leaves(cause) if isinstance(e, exc_type)]
+    assert leaves, f"no {exc_type.__name__} in {cause!r}"
+    if message is not None:
+        assert any(str(e) == message for e in leaves)
+    # the original traceback survives on the raised exception(s)
+    assert all(e.__traceback__ is not None for e in leaves)
+
+
+@pytest.fixture
+def file_curl():
+    c = util.DefaultCurl()
+    c.setopt(pycurl.URL, _FILE_URL)
+    yield c
+    c.close()
+
+
+def _cfg_write(curl, app):
+    curl.setopt(pycurl.URL, _FILE_URL)
+    curl.setopt(pycurl.WRITEFUNCTION, _raise_runtime)
+
+
+def _cfg_header(curl, app):
+    curl.setopt(pycurl.URL, f"{app}/success")
+    curl.setopt(pycurl.WRITEFUNCTION, _discard)
+    curl.setopt(pycurl.HEADERFUNCTION, _raise_runtime)
+
+
+def _cfg_read(curl, app):
+    curl.setopt(pycurl.URL, f"{app}/postfields")
+    curl.setopt(pycurl.POST, 1)
+    curl.setopt(pycurl.POSTFIELDSIZE, 16)
+    curl.setopt(pycurl.WRITEFUNCTION, _discard)
+    curl.setopt(pycurl.READFUNCTION, _raise_runtime)
+
+
+def _cfg_progress(curl, app):
+    curl.setopt(pycurl.URL, _FILE_URL)
+    curl.setopt(pycurl.WRITEFUNCTION, _discard)
+    curl.setopt(pycurl.NOPROGRESS, 0)
+    with pytest.warns(DeprecationWarning, match="PROGRESSFUNCTION is deprecated"):
+        curl.setopt(pycurl.PROGRESSFUNCTION, _raise_runtime)
+
+
+def _cfg_xferinfo(curl, app):
+    curl.setopt(pycurl.URL, _FILE_URL)
+    curl.setopt(pycurl.WRITEFUNCTION, _discard)
+    curl.setopt(pycurl.NOPROGRESS, 0)
+    curl.setopt(pycurl.XFERINFOFUNCTION, _raise_runtime)
+
+
+def _cfg_opensocket(curl, app):
+    curl.setopt(pycurl.URL, f"{app}/success")
+    curl.setopt(pycurl.WRITEFUNCTION, _discard)
+    curl.setopt(pycurl.OPENSOCKETFUNCTION, _raise_runtime)
+
+
+def _cfg_sockopt(curl, app):
+    curl.setopt(pycurl.URL, f"{app}/success")
+    curl.setopt(pycurl.WRITEFUNCTION, _discard)
+    curl.setopt(pycurl.SOCKOPTFUNCTION, _raise_runtime)
+
+
+@pytest.mark.parametrize(
+    "configure",
+    [
+        _cfg_write,
+        _cfg_header,
+        _cfg_read,
+        _cfg_progress,
+        _cfg_xferinfo,
+        _cfg_opensocket,
+        _cfg_sockopt,
+    ],
+    ids=["write", "header", "read", "progress", "xferinfo", "opensocket", "sockopt"],
+)
+def test_callback_exception_becomes_cause(configure, curl, app):
+    configure(curl, app)
+    with pytest.raises(pycurl.error) as excinfo:
+        curl.perform()
+    _assert_cause_includes(excinfo.value, RuntimeError, "boom")
+
+
+def test_cause_preserves_message_and_attributes(file_curl):
+    class Boom(Exception):
+        pass
+
+    def write_cb(_data):
+        err = Boom("kaboom")
+        err.detail = 42
+        raise err
+
+    file_curl.setopt(pycurl.WRITEFUNCTION, write_cb)
+    with pytest.raises(pycurl.error) as excinfo:
+        file_curl.perform()
+    cause = excinfo.value.__cause__
+    assert isinstance(cause, Boom)
+    assert str(cause) == "kaboom"
+    assert cause.detail == 42
+
+
+def test_callback_exception_with_existing_cause_is_preserved(file_curl):
+    def write_cb(_data):
+        try:
+            raise ValueError("inner")
+        except ValueError as inner:
+            raise RuntimeError("outer") from inner
+
+    file_curl.setopt(pycurl.WRITEFUNCTION, write_cb)
+    with pytest.raises(pycurl.error) as excinfo:
+        file_curl.perform()
+    _assert_cause_includes(excinfo.value, RuntimeError, "outer")
+    (outer,) = _walk_leaves(excinfo.value.__cause__)
+    assert isinstance(outer.__cause__, ValueError)
+    assert str(outer.__cause__) == "inner"
+
+
+def test_callback_exception_still_printed_to_stderr(file_curl, capfd):
+    file_curl.setopt(pycurl.WRITEFUNCTION, _raise_runtime)
+    with pytest.raises(pycurl.error):
+        file_curl.perform()
+    captured = capfd.readouterr()
+    assert "Traceback" in captured.err
+    assert "RuntimeError: boom" in captured.err
+
+
+@pytest.mark.parametrize(
+    "exc, exc_type",
+    [
+        (KeyboardInterrupt(), KeyboardInterrupt),
+        (SystemExit(7), SystemExit),
+        (GeneratorExit(), GeneratorExit),
+    ],
+    ids=["KeyboardInterrupt", "SystemExit", "GeneratorExit"],
+)
+def test_base_exception_propagates_unchanged(file_curl, exc, exc_type):
+    def write_cb(_data):
+        raise exc
+
+    file_curl.setopt(pycurl.WRITEFUNCTION, write_cb)
+    with pytest.raises(exc_type) as excinfo:
+        file_curl.perform()
+    assert excinfo.type is exc_type
+    assert excinfo.value.__cause__ is None
+
+
+def test_system_exit_preserves_code(file_curl):
+    def write_cb(_data):
+        raise SystemExit(7)
+
+    file_curl.setopt(pycurl.WRITEFUNCTION, write_cb)
+    with pytest.raises(SystemExit) as excinfo:
+        file_curl.perform()
+    assert excinfo.value.code == 7
+
+
+def test_no_stale_cause_after_failed_then_successful_perform(file_curl):
+    file_curl.setopt(pycurl.WRITEFUNCTION, _raise_runtime)
+    with pytest.raises(pycurl.error) as excinfo:
+        file_curl.perform()
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+
+    file_curl.setopt(pycurl.WRITEFUNCTION, _discard)
+    file_curl.perform()
+
+    file_curl.setopt(pycurl.WRITEFUNCTION, lambda _data: -1)
+    with pytest.raises(pycurl.error) as excinfo:
+        file_curl.perform()
+    assert excinfo.value.__cause__ is None
+
+
+def test_pycurl_error_without_callback_exception_has_no_cause(curl, free_port):
+    curl.setopt(pycurl.URL, f"http://127.0.0.1:{free_port}/")
+    curl.setopt(pycurl.CONNECTTIMEOUT, 1)
+    with pytest.raises(pycurl.error) as excinfo:
+        curl.perform()
+    assert excinfo.value.__cause__ is None
+
+
+def test_debug_cb_capture_does_not_leak_to_setopt(file_curl):
+    def debug_cb(_type, _buf):
+        raise RuntimeError("stale debug")
+
+    file_curl.setopt(pycurl.VERBOSE, 1)
+    file_curl.setopt(pycurl.DEBUGFUNCTION, debug_cb)
+    file_curl.setopt(pycurl.WRITEFUNCTION, _discard)
+    file_curl.perform()
+
+    file_curl.setopt(pycurl.DEBUGFUNCTION, None)
+    with pytest.raises(pycurl.error) as excinfo:
+        file_curl.setopt(pycurl.PROXYTYPE, 999999)
+    assert excinfo.value.__cause__ is None
+
+
+def test_first_callback_to_raise_wins(app, curl):
+    # HEADERFUNCTION runs (and aborts) before WRITEFUNCTION.
+    seen = []
+
+    def header_cb(_data):
+        seen.append("header")
+        raise ValueError("header err")
+
+    def write_cb(_data):
+        seen.append("write")
+        raise RuntimeError("write err")
+
+    curl.setopt(pycurl.URL, f"{app}/success")
+    curl.setopt(pycurl.HEADERFUNCTION, header_cb)
+    curl.setopt(pycurl.WRITEFUNCTION, write_cb)
+    with pytest.raises(pycurl.error) as excinfo:
+        curl.perform()
+    assert seen[0] == "header"
+    _assert_cause_includes(excinfo.value, ValueError, "header err")
+
+
+def test_debug_cb_exception_alone_does_not_abort(file_curl):
+    file_curl.setopt(pycurl.VERBOSE, 1)
+    file_curl.setopt(pycurl.DEBUGFUNCTION, _raise_runtime)
+    file_curl.setopt(pycurl.WRITEFUNCTION, _discard)
+    file_curl.perform()
+
+
+def test_closesocket_cb_exception_is_printed_not_lost(app, curl, capfd):
+    # libcurl ignores CLOSESOCKETFUNCTION's return, so a raise cannot abort the
+    # (successful) transfer; it must be printed, not silently dropped.
+    def close_socket(_curlfd):
+        raise RuntimeError("close boom")
+
+    curl.setopt(pycurl.URL, f"{app}/success")
+    curl.setopt(pycurl.WRITEFUNCTION, _discard)
+    curl.setopt(pycurl.CLOSESOCKETFUNCTION, close_socket)
+    curl.perform()
+    assert "RuntimeError: close boom" in capfd.readouterr().err
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11), reason="ExceptionGroup added in Python 3.11"
+)
+def test_multiple_captures_wrap_in_exception_group(file_curl):
+    file_curl.setopt(pycurl.VERBOSE, 1)
+
+    def debug_cb(_type, _buf):
+        raise RuntimeError("debug boom")
+
+    file_curl.setopt(pycurl.DEBUGFUNCTION, debug_cb)
+    file_curl.setopt(pycurl.WRITEFUNCTION, lambda _b: -1)
+    with pytest.raises(pycurl.error) as excinfo:
+        file_curl.perform()
+    cause = excinfo.value.__cause__
+    assert isinstance(cause, _BaseExceptionGroup)
+    leaves = list(_walk_leaves(cause))
+    assert len(leaves) >= 2
+    assert all(isinstance(e, RuntimeError) for e in leaves)
+
+
+def test_debug_cb_exception_surfaces_when_other_callback_fails(file_curl):
+    file_curl.setopt(pycurl.VERBOSE, 1)
+
+    def debug_cb(_type, _buf):
+        raise RuntimeError("debug boom")
+
+    file_curl.setopt(pycurl.DEBUGFUNCTION, debug_cb)
+    file_curl.setopt(pycurl.WRITEFUNCTION, lambda _b: -1)
+    with pytest.raises(pycurl.error) as excinfo:
+        file_curl.perform()
+    _assert_cause_includes(excinfo.value, RuntimeError, "debug boom")

--- a/tests/test_callback_signals.py
+++ b/tests/test_callback_signals.py
@@ -1,6 +1,3 @@
-#! /usr/bin/env python
-# vi:ts=4:et
-
 import os
 import select
 import signal
@@ -98,7 +95,9 @@ def test_progress_callback_keyboard_interrupt(curl, app):
         called["called"] = True
         raise KeyboardInterrupt()
 
-    with pytest.warns(DeprecationWarning, match="PROGRESSFUNCTION is deprecated; use XFERINFOFUNCTION"):
+    with pytest.warns(
+        DeprecationWarning, match="PROGRESSFUNCTION is deprecated; use XFERINFOFUNCTION"
+    ):
         curl.setopt(pycurl.PROGRESSFUNCTION, progress_function)
 
     with pytest.raises(KeyboardInterrupt):
@@ -163,6 +162,8 @@ def test_header_callback_non_interrupt_exception(callback_curl):
         callback_curl.perform()
 
     assert excinfo.value.args[0] == pycurl.E_WRITE_ERROR
+    assert isinstance(excinfo.value.__cause__, ValueError)
+    assert str(excinfo.value.__cause__) == "boom"
 
 
 def test_header_callback_system_exit(callback_curl):

--- a/tests/write_cb_bogus_test.py
+++ b/tests/write_cb_bogus_test.py
@@ -22,3 +22,9 @@ def test_write_cb_bogus_return(curl, bogus_return):
     assert sys.last_type == pycurl.error
     assert hasattr(sys, "last_value")
     assert str(sys.last_value) == "write callback must return int or None"
+
+    cause = exc_info.value.__cause__
+    assert cause is not None
+    leaves = getattr(cause, "exceptions", None)
+    messages = [str(e) for e in leaves] if leaves else [str(cause)]
+    assert any("write callback must return int or None" in m for m in messages)


### PR DESCRIPTION
Draft to start the discussion. It chains the exception raised inside a callback
as `pycurl.error.__cause__`, instead of dropping it.

**Core changes:**
- A callback `Exception` becomes the `__cause__` of the `pycurl.error` raised by `perform()` or `pause()`.
- Several raises in one `perform()` become an `ExceptionGroup` (3.11 or later). On 3.10 the first exception wins.
- A `BaseException` propagates without changes
- New capture and attach helpers, and a GC tracked `callback_exception` on `CurlObject`, cleared on each perform and pause.
- Update docs and tests.

Next steps:
- Support multi: Socket, timer, notify, and report the easy captures during `multi.perform()`.
- Support mime callbacks and remove the temporary print helper.

Open questions:
- `ExceptionGroup` or a single first exception as the `__cause__`, or always `ExceptionGroup` also with a single error.
- Keep the print to stderr, or put it behind a toggle (for now, activated by default).
