### PR TITLE
Fix bare except: use specific exception types in examples

### DIFF
--- a/examples/retriever-multi.py
+++ b/examples/retriever-multi.py
@@ -31,7 +31,7 @@ try:
             urls = fp.readlines()
     if len(sys.argv) >= 3:
         num_conn = int(sys.argv[2])
-except:
+except (ValueError, IndexError):
     print("Usage: %s <file with URLs to fetch> [<# of concurrent connections>]" % sys.argv[0])
     raise SystemExit
 

--- a/examples/retriever.py
+++ b/examples/retriever.py
@@ -31,7 +31,7 @@ try:
             urls = fp.readlines()
     if len(sys.argv) >= 3:
         num_conn = int(sys.argv[2])
-except:
+except (ValueError, IndexError):
     print("Usage: %s <file with URLs to fetch> [<# of concurrent connections>]" % sys.argv[0])
     raise SystemExit
 
@@ -76,7 +76,7 @@ class WorkerThread(threading.Thread):
                 curl.setopt(pycurl.WRITEDATA, fp)
                 try:
                     curl.perform()
-                except:
+                except Exception:
                     import traceback
                     traceback.print_exc(file=sys.stderr)
                     sys.stderr.flush()

--- a/examples/sfquery.py
+++ b/examples/sfquery.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
     try:
         auth = netrc.netrc().authenticators("sourceforge.net")
         name, account, password = auth
-    except:
+    except Exception:
         if len(sys.argv) < 4:
             print("Usage: %s <project id> <username> <password>" % sys.argv[0])
             raise SystemExit


### PR DESCRIPTION
Replace bare `except:` clauses with specific exception types in examples:

- `examples/retriever.py`: `except (ValueError, IndexError):` for `int(sys.argv[2])`, `except Exception:` for `curl.perform()`
- `examples/sfquery.py`: `except Exception:` for credential unpacking
- `examples/retriever-multi.py`: `except (ValueError, IndexError):` for `int(sys.argv[2])`

Bare `except:` catches `BaseException` including `SystemExit` and `KeyboardInterrupt`.