### PR TITLE
Add `CurlUrl` API

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -37,6 +37,7 @@ include src/pythoncompat.c
 include src/share.c
 include src/stringcompat.c
 include src/threadsupport.c
+include src/url.c
 include src/util.c
 include requirements*.txt
 include tests/*.py

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ RSYNC_USER = armco@web.sourceforge.net
 SOURCES = src/easy.c src/easycb.c src/easyinfo.c src/easyopt.c src/easyperform.c \
 	src/easyws.c src/mime.c src/module.c src/multi.c src/oscompat.c \
 	src/pythoncompat.c src/share.c src/stringcompat.c src/threadsupport.c \
-	src/util.c
+	src/url.c src/util.c
 
 GEN_SOURCES = src/docstrings.c src/docstrings.h
 
@@ -103,7 +103,21 @@ DOCSTRINGS_SOURCES = \
 	doc/docstrings/share_closed.rst \
 	doc/docstrings/share_setopt.rst \
 	doc/docstrings/share_share.rst \
-	doc/docstrings/share_unshare.rst
+	doc/docstrings/share_unshare.rst \
+	doc/docstrings/url.rst \
+	doc/docstrings/url_getpart.rst \
+	doc/docstrings/url_setpart.rst \
+	doc/docstrings/url_url.rst \
+	doc/docstrings/url_scheme.rst \
+	doc/docstrings/url_user.rst \
+	doc/docstrings/url_password.rst \
+	doc/docstrings/url_options.rst \
+	doc/docstrings/url_host.rst \
+	doc/docstrings/url_port.rst \
+	doc/docstrings/url_path.rst \
+	doc/docstrings/url_query.rst \
+	doc/docstrings/url_fragment.rst \
+	doc/docstrings/url_zoneid.rst
 
 all: build
 src-release: $(RELEASE_SOURCES)

--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,7 @@ libcurl, including:
 - WebSockets - first-class ``ws://``/``wss://`` support.
 - MIME / multipart forms - the ``pycurl.Mime`` and ``pycurl.MimePart``
   wrappers around libcurl's MIME API.
+- URL parsing - the ``pycurl.CurlUrl`` wrapper around libcurl's URL API.
 - Sockets used for network operations, permitting integration of PycURL
   into the application's I/O loop (e.g., using Tornado_).
 - Built-in ``asyncio`` support via ``pycurl.AsyncCurlMulti``, an asyncio

--- a/doc/curlurlobject.rst
+++ b/doc/curlurlobject.rst
@@ -1,0 +1,62 @@
+.. _curlurlobject:
+
+CurlUrl Object
+==============
+
+.. autoclass:: pycurl.CurlUrl
+
+    A ``CurlUrl`` wraps a libcurl ``CURLU`` handle and exposes libcurl's URL
+    API. It requires libcurl 7.62.0 or later.
+
+    Component getters return ``None`` when the part is absent, which is how an
+    absent part differs from an empty one. By default the properties read and
+    write the raw value with no percent-encoding or decoding. Use
+    :py:meth:`~pycurl.CurlUrl.getpart` and :py:meth:`~pycurl.CurlUrl.setpart`
+    with the ``U_*`` flags for encoding control.
+
+    CurlUrl objects have the following methods:
+
+    .. automethod:: pycurl.CurlUrl.getpart
+
+    .. automethod:: pycurl.CurlUrl.setpart
+
+    CurlUrl objects have the following attributes:
+
+    .. autoattribute:: pycurl.CurlUrl.url
+
+    .. autoattribute:: pycurl.CurlUrl.scheme
+
+    .. autoattribute:: pycurl.CurlUrl.user
+
+    .. autoattribute:: pycurl.CurlUrl.password
+
+    .. autoattribute:: pycurl.CurlUrl.options
+
+    .. autoattribute:: pycurl.CurlUrl.host
+
+    .. autoattribute:: pycurl.CurlUrl.port
+
+    .. autoattribute:: pycurl.CurlUrl.path
+
+    .. autoattribute:: pycurl.CurlUrl.query
+
+    .. autoattribute:: pycurl.CurlUrl.fragment
+
+    .. autoattribute:: pycurl.CurlUrl.zoneid
+
+A ``CurlUrl`` can drive a transfer when passed to a :ref:`Curl object
+<curlobject>` through the ``CURLU`` option, which requires libcurl 7.63.0 or
+later::
+
+    u = pycurl.CurlUrl("https://example.com/")
+    curl.setopt(pycurl.CURLU, u)
+
+libcurl reads the handle for each transfer, so a ``CurlUrl`` updated between
+transfers takes effect on the next one. The ``Curl`` object keeps the ``CurlUrl``
+alive while the option is set. Corresponds to `CURLOPT_CURLU`_ in libcurl.
+
+See `libcurl-url`_ for an overview of the libcurl URL API.
+
+.. _CURLOPT_CURLU: https://curl.se/libcurl/c/CURLOPT_CURLU.html
+
+.. _libcurl-url: https://curl.se/libcurl/c/libcurl-url.html

--- a/doc/docstrings/url.rst
+++ b/doc/docstrings/url.rst
@@ -1,0 +1,30 @@
+CurlUrl(url=None, flags=0) -> New CurlUrl object
+
+Create a :ref:`curlurlobject` wrapping a libcurl ``CURLU`` URL handle.
+
+Without arguments the handle is empty. If *url* is given it is parsed with
+``setpart(UPART_URL, url, flags)``, so *flags* may be any combination of the
+``U_*`` constants.
+
+The component properties (``scheme``, ``host``, ``port``, ``path``, ``query``,
+``fragment``, ``user``, ``password``, ``options`` and, on libcurl 7.65.0 or
+later, ``zoneid``) read and write the URL parts. A getter returns ``None`` when
+the part is absent. Assigning ``None`` or using ``del`` removes it. For control
+over encoding and other flags use :py:meth:`~pycurl.CurlUrl.getpart` and
+:py:meth:`~pycurl.CurlUrl.setpart`.
+
+A ``CurlUrl`` can be passed to a :ref:`Curl object <curlobject>` through the
+``CURLU`` option.
+
+Corresponds to `curl_url`_ in libcurl. Requires libcurl 7.62.0 or later.
+
+Example::
+
+    u = pycurl.CurlUrl("https://example.com/path?a=1")
+    u.host = "example.org"
+    curl.setopt(pycurl.CURLU, u)
+
+:param url: an optional URL string to parse into the new handle.
+:param int flags: ``U_*`` flags controlling how *url* is parsed.
+
+.. _curl_url: https://curl.se/libcurl/c/curl_url.html

--- a/doc/docstrings/url_fragment.rst
+++ b/doc/docstrings/url_fragment.rst
@@ -1,0 +1,2 @@
+The fragment, or ``None`` if the URL has no fragment. Corresponds to
+``CURLUPART_FRAGMENT``.

--- a/doc/docstrings/url_getpart.rst
+++ b/doc/docstrings/url_getpart.rst
@@ -1,0 +1,11 @@
+getpart(part, flags=0) -> str or None
+
+Return one URL component, or ``None`` when it is absent.
+
+*part* is one of the ``UPART_*`` constants. *flags* is a combination of the
+``U_*`` constants, for example ``U_URLDECODE``. Errors other than an absent
+part raise ``pycurl.error``.
+
+Corresponds to `curl_url_get`_ in libcurl.
+
+.. _curl_url_get: https://curl.se/libcurl/c/curl_url_get.html

--- a/doc/docstrings/url_host.rst
+++ b/doc/docstrings/url_host.rst
@@ -1,0 +1,2 @@
+The host name, or ``None`` if the URL has no host. An IPv6 address is returned
+in brackets, as it appears in the URL. Corresponds to ``CURLUPART_HOST``.

--- a/doc/docstrings/url_options.rst
+++ b/doc/docstrings/url_options.rst
@@ -1,0 +1,2 @@
+The options from the URL userinfo, or ``None`` if not set. Corresponds to
+``CURLUPART_OPTIONS``.

--- a/doc/docstrings/url_password.rst
+++ b/doc/docstrings/url_password.rst
@@ -1,0 +1,2 @@
+The password from the URL userinfo, or ``None`` if not set. Corresponds to
+``CURLUPART_PASSWORD``.

--- a/doc/docstrings/url_path.rst
+++ b/doc/docstrings/url_path.rst
@@ -1,0 +1,1 @@
+The URL path, or ``None`` if not set. Corresponds to ``CURLUPART_PATH``.

--- a/doc/docstrings/url_port.rst
+++ b/doc/docstrings/url_port.rst
@@ -1,0 +1,2 @@
+The port as a string, or ``None`` if the URL has no port. Assigning an int is
+also accepted. Corresponds to ``CURLUPART_PORT``.

--- a/doc/docstrings/url_query.rst
+++ b/doc/docstrings/url_query.rst
@@ -1,0 +1,2 @@
+The query string, or ``None`` if the URL has no query. Corresponds to
+``CURLUPART_QUERY``.

--- a/doc/docstrings/url_scheme.rst
+++ b/doc/docstrings/url_scheme.rst
@@ -1,0 +1,2 @@
+The URL scheme, or ``None`` if the URL has no scheme. Corresponds to
+``CURLUPART_SCHEME``.

--- a/doc/docstrings/url_setpart.rst
+++ b/doc/docstrings/url_setpart.rst
@@ -1,0 +1,12 @@
+setpart(part, value, flags=0) -> None
+
+Set one URL component.
+
+*part* is one of the ``UPART_*`` constants. *value* is a string or bytes, or
+``None`` to remove the part. *flags* is a combination of the ``U_*`` constants,
+for example ``U_URLENCODE`` or ``U_APPENDQUERY``. On failure ``pycurl.error``
+is raised.
+
+Corresponds to `curl_url_set`_ in libcurl.
+
+.. _curl_url_set: https://curl.se/libcurl/c/curl_url_set.html

--- a/doc/docstrings/url_url.rst
+++ b/doc/docstrings/url_url.rst
@@ -1,0 +1,2 @@
+The full URL as a string, or ``None`` if it is incomplete. Corresponds to
+``CURLUPART_URL``.

--- a/doc/docstrings/url_user.rst
+++ b/doc/docstrings/url_user.rst
@@ -1,0 +1,2 @@
+The user name from the URL userinfo, or ``None`` if not set. Corresponds to
+``CURLUPART_USER``.

--- a/doc/docstrings/url_zoneid.rst
+++ b/doc/docstrings/url_zoneid.rst
@@ -1,0 +1,2 @@
+The IPv6 zone id, or ``None`` if not set. Corresponds to ``CURLUPART_ZONEID``.
+Requires libcurl 7.65.0 or later.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -140,6 +140,7 @@ Documentation Contents
    curlmultiobject
    asynccurlmultiobject
    curlshareobject
+   curlurlobject
    mime
    callbacks
    curl

--- a/doc/pycurl.rst
+++ b/doc/pycurl.rst
@@ -45,4 +45,7 @@ pycurl Module Functionality
 .. autoclass:: pycurl.CurlMimePart
     :noindex:
 
+.. autoclass:: pycurl.CurlUrl
+    :noindex:
+
 .. _curl_version: https://curl.haxx.se/libcurl/c/curl_version.html

--- a/doc/thread-safety.rst
+++ b/doc/thread-safety.rst
@@ -47,6 +47,10 @@ For Python programs using PycURL, this means:
   are unsafe unless they happen inside that handle's active
   ``WRITEFUNCTION`` callback.
 
+* Individual ``CurlUrl`` reads and writes are thread-safe, on free-threaded
+  builds as well. Mutating a ``CurlUrl`` set through the ``CURLU`` option
+  during a transfer is unsafe.
+
 PycURL handles the necessary SSL locks for OpenSSL/LibreSSL/BoringSSL,
 GnuTLS, NSS, mbedTLS and wolfSSL.
 

--- a/setup.py
+++ b/setup.py
@@ -633,6 +633,7 @@ def get_extension(argv, split_extension_source=False):
             os.path.join("src", "share.c"),
             os.path.join("src", "stringcompat.c"),
             os.path.join("src", "threadsupport.c"),
+            os.path.join("src", "url.c"),
             os.path.join("src", "util.c"),
         ]
         depends = [

--- a/src/easy.c
+++ b/src/easy.c
@@ -505,6 +505,9 @@ do_curl_duphandle(CurlObject *self, PyObject *Py_UNUSED(ignored))
         curlmime_duphandle_incref_data_cb_owners(self->mimepost_obj);
     }
 #endif
+#ifdef HAVE_CURLOPT_CURLU
+    dup->curl_url = Py_XNewRef(self->curl_url);
+#endif
 
     /* Success - return cloned object */
     return dup;
@@ -605,6 +608,15 @@ util_curl_xdecref(CurlObject *self, int flags, CURL *handle)
         }
         /* Decrement refcounts for mimepost object. */
         Py_CLEAR(self->mimepost_obj);
+    }
+#endif
+
+#ifdef HAVE_CURLOPT_CURLU
+    if (flags & PYCURL_MEMGROUP_CURLU) {
+        if (self->curl_url != NULL && handle != NULL) {
+            (void)curl_easy_setopt(handle, CURLOPT_CURLU, NULL);
+        }
+        Py_CLEAR(self->curl_url);
     }
 #endif
 
@@ -804,6 +816,9 @@ do_curl_traverse(CurlObject *self, visitproc visit, void *arg)
 
 #ifdef HAVE_CURL_MIME
     VISIT(self->mimepost_obj);
+#endif
+#ifdef HAVE_CURLOPT_CURLU
+    VISIT(self->curl_url);
 #endif
 
     VISIT(self->ca_certs_obj);

--- a/src/easyopt.c
+++ b/src/easyopt.c
@@ -183,6 +183,9 @@ PYCURL_IGNORE_DEPRECATED_END
         Py_CLEAR(self->mimepost_obj);
         break;
 #endif
+#ifdef HAVE_CURLOPT_CURLU
+    CLEAR_OBJECT(CURLOPT_CURLU, self->curl_url);
+#endif
 
     /* "If you do not use a write callback, you must make pointer a 'FILE*'
      * as libcurl passes this to fwrite(3) when writing data" (default: stdout)
@@ -1203,6 +1206,35 @@ do_curl_setopt_mimepost(CurlObject *self, PyObject *obj)
 #endif
 
 
+#ifdef HAVE_CURLOPT_CURLU
+static PyObject *
+do_curl_setopt_curlurl(CurlObject *self, PyObject *obj)
+{
+    CurlUrlObject *url;
+    int res;
+
+    if (!PyObject_TypeCheck(obj, p_CurlUrl_Type)) {
+        PyErr_SetString(PyExc_TypeError, "setopt(option=CURLU) expects a CurlUrl object");
+        return NULL;
+    }
+
+    url = (CurlUrlObject *)obj;
+    if (url->url_handle == NULL) {
+        PyErr_SetString(PyExc_ValueError, "setopt(option=CURLU) received a CurlUrl without a handle");
+        return NULL;
+    }
+
+    res = curl_easy_setopt(self->handle, CURLOPT_CURLU, url->url_handle);
+    if (res != CURLE_OK) {
+        CURLERROR_RETVAL();
+    }
+
+    Py_XSETREF(self->curl_url, Py_NewRef(obj));
+    Py_RETURN_NONE;
+}
+#endif
+
+
 PYCURL_INTERNAL PyObject *
 do_curl_setopt_filelike(CurlObject *self, int option, PyObject *obj)
 {
@@ -1331,6 +1363,12 @@ do_curl_setopt(CurlObject *self, PyObject *args, PyObject *kwargs)
 #ifdef HAVE_CURL_MIME
     if (option == CURLOPT_MIMEPOST) {
         return do_curl_setopt_mimepost(self, obj);
+    }
+#endif
+
+#ifdef HAVE_CURLOPT_CURLU
+    if (option == CURLOPT_CURLU) {
+        return do_curl_setopt_curlurl(self, obj);
     }
 #endif
 

--- a/src/module.c
+++ b/src/module.c
@@ -30,6 +30,9 @@ PYCURL_INTERNAL PyTypeObject *p_CurlShare_Type = NULL;
 PYCURL_INTERNAL PyTypeObject *p_CurlMime_Type = NULL;
 PYCURL_INTERNAL PyTypeObject *p_CurlMimePart_Type = NULL;
 #endif
+#ifdef HAVE_CURL_URL
+PYCURL_INTERNAL PyTypeObject *p_CurlUrl_Type = NULL;
+#endif
 #ifdef HAVE_CURL_7_19_6_OPTS
 PYCURL_INTERNAL PyObject *khkey_type = NULL;
 #endif
@@ -437,6 +440,9 @@ PyMODINIT_FUNC PyInit__pycurl(void)
     assert(Curl_Type.tp_weaklistoffset > 0);
     assert(CurlMulti_Type.tp_weaklistoffset > 0);
     assert(CurlShare_Type.tp_weaklistoffset > 0);
+#ifdef HAVE_CURL_URL
+    assert(CurlUrl_Type.tp_weaklistoffset > 0);
+#endif
 
     /* Check the version, as this has caused nasty problems in
      * some cases. */
@@ -528,6 +534,9 @@ PYCURL_IGNORE_DEPRECATED_END
     p_CurlMime_Type = &CurlMime_Type;
     p_CurlMimePart_Type = &CurlMimePart_Type;
 #endif
+#ifdef HAVE_CURL_URL
+    p_CurlUrl_Type = &CurlUrl_Type;
+#endif
     Py_SET_TYPE(&Curl_Type, &PyType_Type);
     Py_SET_TYPE(&CurlSlist_Type, &PyType_Type);
     Py_SET_TYPE(&CurlHttppost_Type, &PyType_Type);
@@ -536,6 +545,9 @@ PYCURL_IGNORE_DEPRECATED_END
 #ifdef HAVE_CURL_MIME
     Py_SET_TYPE(&CurlMime_Type, &PyType_Type);
     Py_SET_TYPE(&CurlMimePart_Type, &PyType_Type);
+#endif
+#ifdef HAVE_CURL_URL
+    Py_SET_TYPE(&CurlUrl_Type, &PyType_Type);
 #endif
 
     /* Create the module and add the functions */
@@ -559,6 +571,11 @@ PYCURL_IGNORE_DEPRECATED_END
         goto error;
 
     if (PyType_Ready(&CurlMimePart_Type) < 0)
+        goto error;
+#endif
+
+#ifdef HAVE_CURL_URL
+    if (PyType_Ready(&CurlUrl_Type) < 0)
         goto error;
 #endif
 
@@ -623,6 +640,9 @@ PYCURL_IGNORE_DEPRECATED_END
 #ifdef HAVE_CURL_MIME
     insobj2_modinit(d, NULL, "CurlMime", (PyObject *) p_CurlMime_Type);
     insobj2_modinit(d, NULL, "CurlMimePart", (PyObject *) p_CurlMimePart_Type);
+#endif
+#ifdef HAVE_CURL_URL
+    insobj2_modinit(d, NULL, "CurlUrl", (PyObject *) p_CurlUrl_Type);
 #endif
 
     /**
@@ -1265,6 +1285,77 @@ PYCURL_IGNORE_DEPRECATED_END
 #if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 62, 0)
     insint_c(d, "DOH_URL", CURLOPT_DOH_URL);
 #endif
+#ifdef HAVE_CURLOPT_CURLU
+    /* pass a CurlUrl to an easy handle instead of a URL string */
+    insint_c(d, "CURLU", CURLOPT_CURLU);
+#endif
+
+    /* curl URL API: parts for CurlUrl.getpart()/setpart() (7.62.0+) */
+#ifdef HAVE_CURL_URL
+    insint(d, "UPART_URL", CURLUPART_URL);
+    insint(d, "UPART_SCHEME", CURLUPART_SCHEME);
+    insint(d, "UPART_USER", CURLUPART_USER);
+    insint(d, "UPART_PASSWORD", CURLUPART_PASSWORD);
+    insint(d, "UPART_OPTIONS", CURLUPART_OPTIONS);
+    insint(d, "UPART_HOST", CURLUPART_HOST);
+    insint(d, "UPART_PORT", CURLUPART_PORT);
+    insint(d, "UPART_PATH", CURLUPART_PATH);
+    insint(d, "UPART_QUERY", CURLUPART_QUERY);
+    insint(d, "UPART_FRAGMENT", CURLUPART_FRAGMENT);
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 65, 0)
+    insint(d, "UPART_ZONEID", CURLUPART_ZONEID);
+#endif
+    /* curl URL API flags. These are #define macros, so each is guarded on its
+     * own definition rather than on a libcurl version number. */
+#ifdef CURLU_DEFAULT_PORT
+    insint(d, "U_DEFAULT_PORT", CURLU_DEFAULT_PORT);
+#endif
+#ifdef CURLU_NO_DEFAULT_PORT
+    insint(d, "U_NO_DEFAULT_PORT", CURLU_NO_DEFAULT_PORT);
+#endif
+#ifdef CURLU_DEFAULT_SCHEME
+    insint(d, "U_DEFAULT_SCHEME", CURLU_DEFAULT_SCHEME);
+#endif
+#ifdef CURLU_NON_SUPPORT_SCHEME
+    insint(d, "U_NON_SUPPORT_SCHEME", CURLU_NON_SUPPORT_SCHEME);
+#endif
+#ifdef CURLU_PATH_AS_IS
+    insint(d, "U_PATH_AS_IS", CURLU_PATH_AS_IS);
+#endif
+#ifdef CURLU_DISALLOW_USER
+    insint(d, "U_DISALLOW_USER", CURLU_DISALLOW_USER);
+#endif
+#ifdef CURLU_URLDECODE
+    insint(d, "U_URLDECODE", CURLU_URLDECODE);
+#endif
+#ifdef CURLU_URLENCODE
+    insint(d, "U_URLENCODE", CURLU_URLENCODE);
+#endif
+#ifdef CURLU_APPENDQUERY
+    insint(d, "U_APPENDQUERY", CURLU_APPENDQUERY);
+#endif
+#ifdef CURLU_GUESS_SCHEME
+    insint(d, "U_GUESS_SCHEME", CURLU_GUESS_SCHEME);
+#endif
+#ifdef CURLU_NO_AUTHORITY
+    insint(d, "U_NO_AUTHORITY", CURLU_NO_AUTHORITY);
+#endif
+#ifdef CURLU_ALLOW_SPACE
+    insint(d, "U_ALLOW_SPACE", CURLU_ALLOW_SPACE);
+#endif
+#ifdef CURLU_PUNYCODE
+    insint(d, "U_PUNYCODE", CURLU_PUNYCODE);
+#endif
+#ifdef CURLU_PUNY2IDN
+    insint(d, "U_PUNY2IDN", CURLU_PUNY2IDN);
+#endif
+#ifdef CURLU_GET_EMPTY
+    insint(d, "U_GET_EMPTY", CURLU_GET_EMPTY);
+#endif
+#ifdef CURLU_NO_GUESS_SCHEME
+    insint(d, "U_NO_GUESS_SCHEME", CURLU_NO_GUESS_SCHEME);
+#endif
+#endif /* URL API, 7.62.0+ */
 #if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 64, 0)
     insint_c(d, "HTTP09_ALLOWED", CURLOPT_HTTP09_ALLOWED);
 #endif

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -190,6 +190,16 @@ pycurl_inet_ntop (int family, void *addr, char *string, size_t string_size);
 #define HAVE_CURL_MIME
 #endif
 
+/* URL API (curl_url and friends), the CurlUrl object */
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 62, 0)
+#define HAVE_CURL_URL
+#endif
+
+/* CURLOPT_CURLU, binding a CurlUrl to an easy handle */
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 63, 0)
+#define HAVE_CURLOPT_CURLU
+#endif
+
 #if LIBCURL_VERSION_NUM >= 0x074300 /* check for 7.67.0 or greater */
 #define HAVE_CURL_7_67_0_MULTI_STREAMS
 #endif
@@ -431,12 +441,14 @@ create_and_set_error_object(struct CurlObject *self, int code);
 #define PYCURL_MEMGROUP_SLIST           256
 /* CurlMime object pinned via CURLOPT_MIMEPOST */
 #define PYCURL_MEMGROUP_MIMEPOST        512
+/* CurlUrl object pinned via CURLOPT_CURLU */
+#define PYCURL_MEMGROUP_CURLU           1024
 
 #define PYCURL_MEMGROUP_EASY \
     (PYCURL_MEMGROUP_CALLBACK | PYCURL_MEMGROUP_FILE | \
     PYCURL_MEMGROUP_HTTPPOST | PYCURL_MEMGROUP_POSTFIELDS | \
     PYCURL_MEMGROUP_CACERTS | PYCURL_MEMGROUP_SLIST | \
-    PYCURL_MEMGROUP_MIMEPOST)
+    PYCURL_MEMGROUP_MIMEPOST | PYCURL_MEMGROUP_CURLU)
 
 #define PYCURL_MEMGROUP_ALL \
     (PYCURL_MEMGROUP_ATTRDICT | PYCURL_MEMGROUP_EASY | \
@@ -467,6 +479,10 @@ typedef struct CurlObject {
     struct CurlHttppostObject *httppost;
 #ifdef HAVE_CURL_MIME
     PyObject *mimepost_obj;
+#endif
+#ifdef HAVE_CURLOPT_CURLU
+    /* strong ref to the CurlUrl set via CURLOPT_CURLU (or NULL) */
+    PyObject *curl_url;
 #endif
     struct CurlSlistObject *httpheader;
 #if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 37, 0)
@@ -596,6 +612,17 @@ typedef struct CurlMimePartObject {
 
 PYCURL_INTERNAL void
 curlmime_duphandle_incref_data_cb_owners(PyObject *mime_obj);
+#endif
+
+#ifdef HAVE_CURL_URL
+typedef struct CurlUrlObject {
+    PyObject_HEAD
+    PyObject *weakreflist;
+    CURLU *url_handle;
+#ifdef Py_GIL_DISABLED
+    pycurl_mutex_t api_lock;    /* serialises curl_url_* access on this handle */
+#endif
+} CurlUrlObject;
 #endif
 
 PYCURL_INTERNAL PyThreadState *
@@ -813,6 +840,9 @@ extern PyTypeObject CurlShare_Type;
 extern PyTypeObject CurlMime_Type;
 extern PyTypeObject CurlMimePart_Type;
 #endif
+#ifdef HAVE_CURL_URL
+extern PyTypeObject CurlUrl_Type;
+#endif
 
 extern PyObject *ErrorObject;
 extern PyTypeObject *p_Curl_Type;
@@ -823,6 +853,9 @@ extern PyTypeObject *p_CurlShare_Type;
 #ifdef HAVE_CURL_MIME
 extern PyTypeObject *p_CurlMime_Type;
 extern PyTypeObject *p_CurlMimePart_Type;
+#endif
+#ifdef HAVE_CURL_URL
+extern PyTypeObject *p_CurlUrl_Type;
 #endif
 extern PyObject *khkey_type;
 extern PyObject *curl_sockaddr_type;

--- a/src/url.c
+++ b/src/url.c
@@ -1,0 +1,488 @@
+#include "pycurl.h"
+#include "docstrings.h"
+
+#ifdef HAVE_CURL_URL
+
+/* The api_lock only exists on free-threaded builds; the GIL serialises
+ * curl_url_* on every other build, so the macros compile away there. */
+#ifdef Py_GIL_DISABLED
+#  define PYCURL_URL_LOCK(u)   PYCURL_MUTEX_LOCK(&(u)->api_lock)
+#  define PYCURL_URL_UNLOCK(u) PYCURL_MUTEX_UNLOCK(&(u)->api_lock)
+#else
+#  define PYCURL_URL_LOCK(u)   ((void)0)
+#  define PYCURL_URL_UNLOCK(u) ((void)0)
+#endif
+
+/*************************************************************************
+// static utility functions
+**************************************************************************/
+
+/* Raise pycurl.error from a CURLUcode. curl_url_strerror is 7.80.0+, so
+ * older builds fall back to a fixed message. */
+static int
+check_url_result(CURLUcode res)
+{
+    const char *msg;
+    PyObject *v;
+
+    if (res == CURLUE_OK) {
+        return 0;
+    }
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 80, 0)
+    msg = curl_url_strerror(res);
+#else
+    msg = "libcurl URL API error";
+#endif
+    v = Py_BuildValue("(is)", (int)res, msg);
+    if (v != NULL) {
+        PyErr_SetObject(ErrorObject, v);
+        Py_DECREF(v);
+    }
+    return -1;
+}
+
+
+/* Free the underlying handle. Nulls the pointer first so re-entry is safe. */
+static void
+util_url_close(CurlUrlObject *self)
+{
+    if (self->url_handle != NULL) {
+        CURLU *handle = self->url_handle;
+        self->url_handle = NULL;
+        curl_url_cleanup(handle);
+    }
+}
+
+
+/* Read one part. Returns a str, None when the part is absent, or NULL with an
+ * exception set on a real error. Shared by getpart() and the property getters. */
+static PyObject *
+util_url_getpart(CurlUrlObject *self, CURLUPart part, unsigned int flags)
+{
+    char *out = NULL;
+    CURLUcode res;
+    PyObject *ret;
+
+    if (self->url_handle == NULL) {
+        PyErr_SetString(ErrorObject, "cannot use a CurlUrl without a handle");
+        return NULL;
+    }
+
+    PYCURL_URL_LOCK(self);
+    res = curl_url_get(self->url_handle, part, &out, flags);
+    PYCURL_URL_UNLOCK(self);
+
+    if (res == CURLUE_OK) {
+        ret = PyText_FromString_Ignore(out);
+        curl_free(out);
+        return ret;
+    }
+
+    /* An absent part is not an error, it maps to None. */
+    switch (res) {
+    case CURLUE_NO_SCHEME:
+    case CURLUE_NO_USER:
+    case CURLUE_NO_PASSWORD:
+    case CURLUE_NO_OPTIONS:
+    case CURLUE_NO_HOST:
+    case CURLUE_NO_PORT:
+    case CURLUE_NO_QUERY:
+    case CURLUE_NO_FRAGMENT:
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 65, 0)
+    case CURLUE_NO_ZONEID:
+#endif
+        Py_RETURN_NONE;
+    default:
+        check_url_result(res);
+        return NULL;
+    }
+}
+
+
+/* Set one part. value may be a str, bytes, None or NULL (the last two remove
+ * the part). Shared by setpart() and the property setters and deleters. */
+static PyObject *
+util_url_setpart(CurlUrlObject *self, CURLUPart part, PyObject *value,
+                 unsigned int flags)
+{
+    CURLUcode res;
+    char *cstr = NULL;
+    PyObject *encoded = NULL;
+
+    if (self->url_handle == NULL) {
+        PyErr_SetString(ErrorObject, "cannot use a CurlUrl without a handle");
+        return NULL;
+    }
+
+    if (value != NULL && value != Py_None) {
+        if (!PyText_Check(value)) {
+            PyErr_SetString(PyExc_TypeError,
+                "a URL part must be a string, bytes, or None");
+            return NULL;
+        }
+        cstr = PyText_AsString_NoNUL(value, &encoded);
+        if (cstr == NULL) {
+            return NULL;
+        }
+    }
+
+    PYCURL_URL_LOCK(self);
+    res = curl_url_set(self->url_handle, part, cstr, flags);
+    PYCURL_URL_UNLOCK(self);
+
+    Py_XDECREF(encoded);
+
+    if (res != CURLUE_OK) {
+        check_url_result(res);
+        return NULL;
+    }
+    Py_RETURN_NONE;
+}
+
+
+/* Clone the underlying handle into a fresh object. Backs __copy__/__deepcopy__. */
+static PyObject *
+util_url_dup(CurlUrlObject *self)
+{
+    CurlUrlObject *dup;
+    CURLU *newhandle;
+    int *ptr;
+
+    if (self->url_handle == NULL) {
+        PyErr_SetString(ErrorObject, "cannot copy a CurlUrl without a handle");
+        return NULL;
+    }
+
+    dup = (CurlUrlObject *)Py_TYPE(self)->tp_alloc(Py_TYPE(self), 0);
+    if (dup == NULL) {
+        return NULL;
+    }
+
+    /* tp_alloc is expected to return zeroed memory */
+    for (ptr = (int *) &dup->weakreflist;
+        ptr < (int *) (((char *) dup) + sizeof(CurlUrlObject));
+        ++ptr)
+            assert(*ptr == 0);
+
+    PYCURL_URL_LOCK(self);
+    newhandle = curl_url_dup(self->url_handle);
+    PYCURL_URL_UNLOCK(self);
+
+    if (newhandle == NULL) {
+        Py_DECREF(dup);
+        return PyErr_NoMemory();
+    }
+    dup->url_handle = newhandle;
+    return (PyObject *)dup;
+}
+
+
+/*************************************************************************
+// constructor / destructor
+**************************************************************************/
+
+PYCURL_INTERNAL PyObject *
+do_url_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
+{
+    CurlUrlObject *self;
+    PyObject *url = NULL;
+    unsigned int flags = 0;
+    int *ptr;
+    static char *kwlist[] = {"url", "flags", NULL};
+
+    if (subtype == p_CurlUrl_Type &&
+        !PyArg_ParseTupleAndKeywords(args, kwds, "|OI:CurlUrl", kwlist,
+                                     &url, &flags)) {
+        return NULL;
+    }
+
+    self = (CurlUrlObject *) subtype->tp_alloc(subtype, 0);
+    if (self == NULL) {
+        return NULL;
+    }
+
+    /* tp_alloc is expected to return zeroed memory. On free-threaded builds this
+     * leaves api_lock (a PyMutex) in its valid unlocked state. */
+    for (ptr = (int *) &self->weakreflist;
+        ptr < (int *) (((char *) self) + sizeof(CurlUrlObject));
+        ++ptr)
+            assert(*ptr == 0);
+
+    self->url_handle = curl_url();
+    if (self->url_handle == NULL) {
+        Py_DECREF(self);
+        return PyErr_NoMemory();
+    }
+
+    if (url != NULL && url != Py_None) {
+        PyObject *ret = util_url_setpart(self, CURLUPART_URL, url, flags);
+        if (ret == NULL) {
+            Py_DECREF(self);
+            return NULL;
+        }
+        Py_DECREF(ret);
+    }
+
+    return (PyObject *)self;
+}
+
+
+static int
+do_url_traverse(CurlUrlObject *Py_UNUSED(self), visitproc Py_UNUSED(visit),
+                void *Py_UNUSED(arg))
+{
+    /* CurlUrl holds no strong Python references, so there is nothing to visit.
+     * GC support is kept only so Py_TPFLAGS_BASETYPE subclasses collect cleanly. */
+    return 0;
+}
+
+
+static void
+do_url_dealloc(CurlUrlObject *self)
+{
+    PyObject_GC_UnTrack(self);
+    Py_TRASHCAN_BEGIN(self, do_url_dealloc);
+
+    util_url_close(self);
+
+    if (self->weakreflist != NULL) {
+        PyObject_ClearWeakRefs((PyObject *) self);
+    }
+
+    CurlUrl_Type.tp_free(self);
+    Py_TRASHCAN_END
+}
+
+
+/*************************************************************************
+// methods
+**************************************************************************/
+
+static PyObject *
+do_url_getpart(CurlUrlObject *self, PyObject *args)
+{
+    int part;
+    unsigned int flags = 0;
+
+    if (!PyArg_ParseTuple(args, "i|I:getpart", &part, &flags)) {
+        return NULL;
+    }
+    return util_url_getpart(self, (CURLUPart)part, flags);
+}
+
+
+static PyObject *
+do_url_setpart(CurlUrlObject *self, PyObject *args)
+{
+    int part;
+    PyObject *value;
+    unsigned int flags = 0;
+
+    if (!PyArg_ParseTuple(args, "iO|I:setpart", &part, &value, &flags)) {
+        return NULL;
+    }
+    return util_url_setpart(self, (CURLUPart)part, value, flags);
+}
+
+
+static PyObject *
+do_url_copy(CurlUrlObject *self, PyObject *Py_UNUSED(ignored))
+{
+    return util_url_dup(self);
+}
+
+
+static PyObject *
+do_url_deepcopy(CurlUrlObject *self, PyObject *Py_UNUSED(memo))
+{
+    return util_url_dup(self);
+}
+
+
+static PyObject *
+do_url_getstate(CurlUrlObject *Py_UNUSED(self), PyObject *Py_UNUSED(ignored))
+{
+    PyErr_SetString(PyExc_TypeError, "CurlUrl objects do not support serialization");
+    return NULL;
+}
+
+
+static PyObject *
+do_url_setstate(CurlUrlObject *Py_UNUSED(self), PyObject *Py_UNUSED(args))
+{
+    PyErr_SetString(PyExc_TypeError, "CurlUrl objects do not support deserialization");
+    return NULL;
+}
+
+
+/*************************************************************************
+// str / repr
+**************************************************************************/
+
+static PyObject *
+do_url_str(CurlUrlObject *self)
+{
+    PyObject *url = util_url_getpart(self, CURLUPART_URL, 0);
+
+    if (url == NULL) {
+        return NULL;
+    }
+    if (url == Py_None) {
+        Py_DECREF(url);
+        PyErr_SetString(ErrorObject, "cannot serialise an incomplete URL");
+        return NULL;
+    }
+    return url;
+}
+
+
+static PyObject *
+do_url_repr(CurlUrlObject *self)
+{
+    PyObject *url = util_url_getpart(self, CURLUPART_URL, 0);
+    PyObject *repr;
+
+    if (url == NULL) {
+        PyErr_Clear();
+    }
+    if (url != NULL && url != Py_None) {
+        repr = PyUnicode_FromFormat("<pycurl.CurlUrl \"%U\" at %p>", url, self);
+    } else {
+        repr = PyUnicode_FromFormat("<pycurl.CurlUrl (incomplete) at %p>", self);
+    }
+    Py_XDECREF(url);
+    return repr;
+}
+
+
+/*************************************************************************
+// properties
+**************************************************************************/
+
+static PyObject *
+do_url_get_part_prop(CurlUrlObject *self, void *closure)
+{
+    return util_url_getpart(self, (CURLUPart)(size_t)closure, 0);
+}
+
+
+static int
+do_url_set_part_prop(CurlUrlObject *self, PyObject *value, void *closure)
+{
+    PyObject *ret = util_url_setpart(self, (CURLUPart)(size_t)closure, value, 0);
+
+    if (ret == NULL) {
+        return -1;
+    }
+    Py_DECREF(ret);
+    return 0;
+}
+
+
+/* Like do_url_set_part_prop, but also accepts an int for convenience. */
+static int
+do_url_set_port(CurlUrlObject *self, PyObject *value, void *closure)
+{
+    PyObject *strval = NULL;
+    int rv;
+
+    if (value != NULL && PyLong_Check(value)) {
+        strval = PyObject_Str(value);
+        if (strval == NULL) {
+            return -1;
+        }
+        value = strval;
+    }
+    rv = do_url_set_part_prop(self, value, closure);
+    Py_XDECREF(strval);
+    return rv;
+}
+
+
+/*************************************************************************
+// type definitions
+**************************************************************************/
+
+PYCURL_INTERNAL PyMethodDef curlurlobject_methods[] = {
+    {"getpart", (PyCFunction)do_url_getpart, METH_VARARGS, url_getpart_doc},
+    {"setpart", (PyCFunction)do_url_setpart, METH_VARARGS, url_setpart_doc},
+    {"__copy__", (PyCFunction)do_url_copy, METH_NOARGS, NULL},
+    {"__deepcopy__", (PyCFunction)do_url_deepcopy, METH_O, NULL},
+    {"__getstate__", (PyCFunction)do_url_getstate, METH_NOARGS, NULL},
+    {"__setstate__", (PyCFunction)do_url_setstate, METH_VARARGS, NULL},
+    {NULL, NULL, 0, NULL}
+};
+
+
+PYCURL_INTERNAL PyGetSetDef curlurlobject_getsets[] = {
+    {"url", (getter)do_url_get_part_prop, (setter)do_url_set_part_prop,
+        url_url_doc, (void *)(size_t)CURLUPART_URL},
+    {"scheme", (getter)do_url_get_part_prop, (setter)do_url_set_part_prop,
+        url_scheme_doc, (void *)(size_t)CURLUPART_SCHEME},
+    {"user", (getter)do_url_get_part_prop, (setter)do_url_set_part_prop,
+        url_user_doc, (void *)(size_t)CURLUPART_USER},
+    {"password", (getter)do_url_get_part_prop, (setter)do_url_set_part_prop,
+        url_password_doc, (void *)(size_t)CURLUPART_PASSWORD},
+    {"options", (getter)do_url_get_part_prop, (setter)do_url_set_part_prop,
+        url_options_doc, (void *)(size_t)CURLUPART_OPTIONS},
+    {"host", (getter)do_url_get_part_prop, (setter)do_url_set_part_prop,
+        url_host_doc, (void *)(size_t)CURLUPART_HOST},
+    {"port", (getter)do_url_get_part_prop, (setter)do_url_set_port,
+        url_port_doc, (void *)(size_t)CURLUPART_PORT},
+    {"path", (getter)do_url_get_part_prop, (setter)do_url_set_part_prop,
+        url_path_doc, (void *)(size_t)CURLUPART_PATH},
+    {"query", (getter)do_url_get_part_prop, (setter)do_url_set_part_prop,
+        url_query_doc, (void *)(size_t)CURLUPART_QUERY},
+    {"fragment", (getter)do_url_get_part_prop, (setter)do_url_set_part_prop,
+        url_fragment_doc, (void *)(size_t)CURLUPART_FRAGMENT},
+#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 65, 0)
+    {"zoneid", (getter)do_url_get_part_prop, (setter)do_url_set_part_prop,
+        url_zoneid_doc, (void *)(size_t)CURLUPART_ZONEID},
+#endif
+    {NULL, NULL, NULL, NULL, NULL}
+};
+
+
+PYCURL_INTERNAL PyTypeObject CurlUrl_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "pycurl.CurlUrl",           /* tp_name */
+    sizeof(CurlUrlObject),      /* tp_basicsize */
+    0,                          /* tp_itemsize */
+    (destructor)do_url_dealloc, /* tp_dealloc */
+    0,                          /* tp_print */
+    0,                          /* tp_getattr */
+    0,                          /* tp_setattr */
+    0,                          /* tp_reserved */
+    (reprfunc)do_url_repr,      /* tp_repr */
+    0,                          /* tp_as_number */
+    0,                          /* tp_as_sequence */
+    0,                          /* tp_as_mapping */
+    0,                          /* tp_hash  */
+    0,                          /* tp_call */
+    (reprfunc)do_url_str,       /* tp_str */
+    0,                          /* tp_getattro */
+    0,                          /* tp_setattro */
+    0,                          /* tp_as_buffer */
+    PYCURL_TYPE_FLAGS,          /* tp_flags */
+    url_doc,                    /* tp_doc */
+    (traverseproc)do_url_traverse, /* tp_traverse */
+    0,                          /* tp_clear */
+    0,                          /* tp_richcompare */
+    offsetof(CurlUrlObject, weakreflist), /* tp_weaklistoffset */
+    0,                          /* tp_iter */
+    0,                          /* tp_iternext */
+    curlurlobject_methods,      /* tp_methods */
+    0,                          /* tp_members */
+    curlurlobject_getsets,      /* tp_getset */
+    0,                          /* tp_base */
+    0,                          /* tp_dict */
+    0,                          /* tp_descr_get */
+    0,                          /* tp_descr_set */
+    0,                          /* tp_dictoffset */
+    0,                          /* tp_init */
+    PyType_GenericAlloc,        /* tp_alloc */
+    (newfunc)do_url_new,        /* tp_new */
+    PyObject_GC_Del,            /* tp_free */
+};
+
+#endif /* HAVE_CURL_URL */

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1,0 +1,301 @@
+import copy
+import gc
+import io
+import pickle
+import weakref
+
+import pytest
+
+import pycurl
+
+from . import util
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(pycurl, "CurlUrl"), reason="libcurl without URL API (< 7.62.0)"
+)
+
+FULL_URL = "https://user:pw@example.com:8080/a/b?x=1#frag"
+
+
+def test_construct_empty():
+    u = pycurl.CurlUrl()
+    assert u.scheme is None
+    assert u.host is None
+    with pytest.raises(pycurl.error):
+        str(u)
+
+
+def test_construct_from_url():
+    u = pycurl.CurlUrl(FULL_URL)
+    assert u.scheme == "https"
+    assert u.user == "user"
+    assert u.password == "pw"
+    assert u.host == "example.com"
+    assert u.port == "8080"
+    assert u.path == "/a/b"
+    assert u.query == "x=1"
+    assert u.fragment == "frag"
+    assert u.url == FULL_URL
+
+
+def test_absent_part_is_none():
+    u = pycurl.CurlUrl("https://example.com/")
+    assert u.fragment is None
+    assert u.query is None
+    assert u.user is None
+    assert u.options is None
+
+
+def test_construct_invalid_raises():
+    with pytest.raises(pycurl.error) as excinfo:
+        pycurl.CurlUrl("this is not a url")
+    assert isinstance(excinfo.value.args[0], int)
+
+
+def test_construct_with_flags():
+    u = pycurl.CurlUrl(
+        "example.com/path", flags=pycurl.U_DEFAULT_SCHEME | pycurl.U_GUESS_SCHEME
+    )
+    assert u.host == "example.com"
+    assert u.scheme is not None
+
+
+def test_construct_from_bytes():
+    u = pycurl.CurlUrl(b"https://example.com/")
+    assert u.host == "example.com"
+
+
+def test_set_components():
+    u = pycurl.CurlUrl("https://example.com/")
+    u.scheme = "http"
+    u.host = "example.org"
+    u.path = "/x"
+    u.query = "a=1"
+    u.fragment = "top"
+    assert u.url == "http://example.org/x?a=1#top"
+
+
+def test_set_none_removes():
+    u = pycurl.CurlUrl(FULL_URL)
+    u.fragment = None
+    assert u.fragment is None
+    assert "#" not in str(u)
+
+
+def test_del_removes():
+    u = pycurl.CurlUrl(FULL_URL)
+    del u.query
+    assert u.query is None
+    assert "?" not in str(u)
+
+
+def test_port_accepts_int_and_str():
+    u = pycurl.CurlUrl("https://example.com/")
+    u.port = 9090
+    assert u.port == "9090"
+    u.port = "1234"
+    assert u.port == "1234"
+
+
+def test_str_roundtrip():
+    u = pycurl.CurlUrl(FULL_URL)
+    assert str(u) == FULL_URL
+
+
+def test_str_incomplete_raises():
+    u = pycurl.CurlUrl()
+    u.path = "/only-a-path"
+    with pytest.raises(pycurl.error):
+        str(u)
+
+
+def test_repr_never_raises():
+    complete = pycurl.CurlUrl("https://example.com/")
+    assert "example.com" in repr(complete)
+    incomplete = pycurl.CurlUrl()
+    assert "incomplete" in repr(incomplete)
+
+
+def test_getpart_setpart_roundtrip():
+    u = pycurl.CurlUrl(FULL_URL)
+    assert u.getpart(pycurl.UPART_HOST) == "example.com"
+    u.setpart(pycurl.UPART_HOST, "example.net")
+    assert u.host == "example.net"
+
+
+def test_getpart_absent_is_none():
+    u = pycurl.CurlUrl("https://example.com/")
+    assert u.getpart(pycurl.UPART_FRAGMENT) is None
+
+
+def test_setpart_urlencode_and_urldecode():
+    u = pycurl.CurlUrl("https://example.com/")
+    u.setpart(pycurl.UPART_QUERY, "a=b c", pycurl.U_URLENCODE)
+    raw = u.getpart(pycurl.UPART_QUERY)
+    assert raw != "a=b c"
+    assert " " not in raw
+    assert u.getpart(pycurl.UPART_QUERY, pycurl.U_URLDECODE) == "a=b c"
+
+
+def test_setpart_appendquery():
+    u = pycurl.CurlUrl("https://example.com/?a=1")
+    u.setpart(pycurl.UPART_QUERY, "b=2", pycurl.U_APPENDQUERY)
+    assert u.query == "a=1&b=2"
+
+
+def test_setpart_remove_with_none():
+    u = pycurl.CurlUrl(FULL_URL)
+    u.setpart(pycurl.UPART_FRAGMENT, None)
+    assert u.fragment is None
+
+
+def test_getpart_bad_part_raises():
+    u = pycurl.CurlUrl("https://example.com/")
+    with pytest.raises(pycurl.error):
+        u.getpart(9999)
+
+
+def test_setpart_bad_value_type():
+    u = pycurl.CurlUrl("https://example.com/")
+    with pytest.raises(TypeError):
+        u.setpart(pycurl.UPART_HOST, 123)
+
+
+def test_copy_is_independent():
+    u = pycurl.CurlUrl(FULL_URL)
+    v = copy.copy(u)
+    v.host = "changed.example"
+    assert u.host == "example.com"
+    assert v.host == "changed.example"
+
+
+def test_deepcopy_is_independent():
+    u = pycurl.CurlUrl(FULL_URL)
+    v = copy.deepcopy(u)
+    v.scheme = "http"
+    assert u.scheme == "https"
+    assert v.scheme == "http"
+
+
+def test_pickle_raises():
+    u = pycurl.CurlUrl(FULL_URL)
+    with pytest.raises((TypeError, pickle.PicklingError)):
+        pickle.dumps(u)
+
+
+def test_weakref_and_gc():
+    u = pycurl.CurlUrl(FULL_URL)
+    ref = weakref.ref(u)
+    assert ref() is u
+    del u
+    gc.collect()
+    assert ref() is None
+
+
+def test_no_reference_leak():
+    for _ in range(500):
+        u = pycurl.CurlUrl("https://example.com/p?q=1")
+        u.host = "example.org"
+    gc.collect()
+
+
+@util.min_libcurl(7, 65, 0)
+def test_zoneid():
+    u = pycurl.CurlUrl("https://[fe80::1%25eth0]/")
+    assert u.zoneid == "eth0"
+    u.zoneid = "eth1"
+    assert u.zoneid == "eth1"
+
+
+def test_version_gate_meta():
+    supported = pycurl.COMPILE_LIBCURL_VERSION_NUM >= 0x073E00
+    assert hasattr(pycurl, "CurlUrl") == supported
+    assert hasattr(pycurl, "UPART_URL") == supported
+
+
+@util.min_libcurl(7, 63, 0)
+def test_curlu_option_transfer(curl, app):
+    u = pycurl.CurlUrl(f"{app}/success")
+    buf = io.BytesIO()
+    curl.setopt(pycurl.CURLU, u)
+    curl.setopt(pycurl.WRITEDATA, buf)
+    curl.perform()
+    assert buf.getvalue() == b"success"
+    assert curl.getinfo(pycurl.EFFECTIVE_URL) == f"{app}/success"
+
+
+@util.min_libcurl(7, 63, 0)
+def test_curlu_option_keeps_url_alive(curl, app):
+    u = pycurl.CurlUrl(f"{app}/success")
+    ref = weakref.ref(u)
+    curl.setopt(pycurl.CURLU, u)
+    del u
+    gc.collect()
+    assert ref() is not None
+    buf = io.BytesIO()
+    curl.setopt(pycurl.WRITEDATA, buf)
+    curl.perform()
+    assert buf.getvalue() == b"success"
+
+
+@util.min_libcurl(7, 63, 0)
+def test_curlu_option_mutation_between_transfers(curl, app):
+    u = pycurl.CurlUrl(f"{app}/success")
+    curl.setopt(pycurl.CURLU, u)
+    buf = io.BytesIO()
+    curl.setopt(pycurl.WRITEDATA, buf)
+    curl.perform()
+    assert buf.getvalue() == b"success"
+    assert curl.getinfo(pycurl.HTTP_CODE) == 200
+
+    u.path = "/status/404"
+    buf2 = io.BytesIO()
+    curl.setopt(pycurl.WRITEDATA, buf2)
+    curl.perform()
+    assert buf2.getvalue() == b"not found"
+    assert curl.getinfo(pycurl.HTTP_CODE) == 404
+
+
+@util.min_libcurl(7, 63, 0)
+def test_curlu_option_unset(curl, app):
+    u = pycurl.CurlUrl(f"{app}/success")
+    curl.setopt(pycurl.CURLU, u)
+    curl.unsetopt(pycurl.CURLU)
+    buf = io.BytesIO()
+    curl.setopt(pycurl.URL, f"{app}/success")
+    curl.setopt(pycurl.WRITEDATA, buf)
+    curl.perform()
+    assert buf.getvalue() == b"success"
+
+
+@util.min_libcurl(7, 63, 0)
+def test_curlu_option_duphandle_shares_url():
+    u = pycurl.CurlUrl("https://example.com/")
+    ref = weakref.ref(u)
+    c = pycurl.Curl()
+    d = None
+    try:
+        c.setopt(pycurl.CURLU, u)
+        d = c.duphandle()
+        del u
+        gc.collect()
+        assert ref() is not None
+        c.close()
+        gc.collect()
+        assert ref() is not None
+    finally:
+        c.close()
+        if d is not None:
+            d.close()
+    gc.collect()
+    assert ref() is None
+
+
+@util.min_libcurl(7, 63, 0)
+def test_curlu_option_wrong_type():
+    c = util.DefaultCurl()
+    try:
+        with pytest.raises((TypeError, pycurl.error)):
+            c.setopt(pycurl.CURLU, "https://example.com/")
+    finally:
+        c.close()


### PR DESCRIPTION
Implement new `pycurl.CurlUrl` class, a wrapper for libcurl's URL API. It creates, parses and modifies URLs, and it can also drive a transfer:

- Properties for all the URL parts, plus `getpart()` and `setpart()` with the `U_*` flags for the complete libcurl behaviour.
- Support for `setopt(pycurl.CURLU, url)`, so a transfer can use a `CurlUrl`.
- New docs and tests.
