### PR TITLE
Add HTTP/3 support in libcurl wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ before-all = [
     "git clone https://github.com/microsoft/vcpkg.git $VCPKG_ROOT",
     "$VCPKG_ROOT/bootstrap-vcpkg.sh",
     "{project}/scripts/setup-vcpkg-nuget.sh",
-    "PATH=$(echo \"$PATH\" | tr ':' '\n' | grep -v '^/usr/local/bin$' | paste -sd:) vcpkg install curl[brotli,core,gssapi,http2,non-http,openssl,psl,ssh,websockets] --triplet=$VCPKG_TRIPLET",
+    "PATH=$(echo \"$PATH\" | tr ':' '\n' | grep -v '^/usr/local/bin$' | paste -sd:) vcpkg install curl[brotli,core,gssapi,http2,http3,non-http,openssl,psl,ssh,websockets] --triplet=$VCPKG_TRIPLET",
 ]
 before-test = [
     "pip install flake8 -r requirements-dev.txt",
@@ -105,7 +105,7 @@ before-all = [
     "if ! which mono >/dev/null 2>&1; then brew install mono; fi",
     "if ! which vcpkg >/dev/null 2>&1; then brew install vcpkg && git clone https://github.com/microsoft/vcpkg.git $HOME/vcpkg; fi",
     "brew install autoconf autoconf-archive automake libtool",
-    "vcpkg install curl[brotli,core,http2,non-http,openssl,psl,ssh,websockets] --triplet=$VCPKG_TRIPLET",
+    "vcpkg install curl[brotli,core,http2,http3,non-http,openssl,psl,ssh,websockets] --triplet=$VCPKG_TRIPLET",
 ]
 before-test = [
     "pip install flake8 -r requirements-dev.txt",


### PR DESCRIPTION
This only applies to MacOS and Linux, which use OpenSSL. Windows, which uses Schannel, does not have an easy way to enable HTTP/3 support AFAICT. I still think this is worth supporting on Mac and Linux.