### PR TITLE
Fix abort on non-text string arguments

### DIFF
--- a/src/stringcompat.c
+++ b/src/stringcompat.c
@@ -12,9 +12,14 @@ PyText_AsStringAndSize(PyObject *obj, char **buffer, Py_ssize_t *length, PyObjec
         return PyBytes_AsStringAndSize(obj, buffer, length);
     } else {
         int rv;
-        assert(PyUnicode_Check(obj));
         *encoded_obj = PyUnicode_AsEncodedString(obj, "ascii", "strict");
         if (*encoded_obj == NULL) {
+            if (PyErr_ExceptionMatches(PyExc_TypeError)) {
+                PyErr_Clear();
+                PyErr_Format(PyExc_TypeError,
+                    "expected bytes or an ASCII string, got %.200s",
+                    Py_TYPE(obj)->tp_name);
+            }
             return -1;
         }
         rv = PyBytes_AsStringAndSize(*encoded_obj, buffer, length);

--- a/tests/setopt_test.py
+++ b/tests/setopt_test.py
@@ -146,6 +146,20 @@ def test_httpheader_replace_cycle(app, curl):
     assert io.getvalue() == b"d"
 
 
+def test_httppost_non_text_field_name(curl):
+    with (
+        pytest.warns(DeprecationWarning, match="HTTPPOST is deprecated; use MIMEPOST"),
+        pytest.raises(
+            TypeError,
+            match=(
+                r"^list or tuple must contain a byte string or Unicode string "
+                r"with ASCII code points only as first element$"
+            ),
+        ),
+    ):
+        curl.setopt(pycurl.HTTPPOST, [(1, b"value")])
+
+
 def test_httpheader_replace_refcount(curl):
     first = ["x-test: first"]
     before = sys.getrefcount(first)

--- a/tests/test_mime.py
+++ b/tests/test_mime.py
@@ -377,6 +377,16 @@ def test_mime_addpart_and_part_methods(fixture_data_path):
         mime.close()
 
 
+@pytest.mark.parametrize("method", ["name", "filename", "type", "encoder", "filedata"])
+def test_mimepart_text_methods_reject_non_text(method):
+    with pycurl.Curl() as curl, pycurl.CurlMime(curl) as mime:
+        part = mime.addpart()
+        with pytest.raises(
+            TypeError, match=r"^expected bytes or an ASCII string, got int$"
+        ):
+            getattr(part, method)(123)
+
+
 def test_mimepart_data_accepts_common_value_types(data_value):
     with pycurl.Curl() as curl:
         mime = pycurl.CurlMime(curl)


### PR DESCRIPTION
- Replace live `assert()` in `PyText_AsStringAndSize()` with `TypeError: expected bytes or an ASCII string, got ...`. Add regression tests.
