### PR TITLE
Fix `CurlShare` leak when `close()` detaches attached handles

### DIFF
--- a/src/share.c
+++ b/src/share.c
@@ -343,6 +343,7 @@ share_cleanup_and_count_live_easies(CurlShareObject *self)
                     if (self->detach_on_close && !performing) {
                         curl_easy_setopt(easy->handle, CURLOPT_SHARE, NULL);
                         easy->share = NULL;
+                        Py_DECREF(self);
 
                         PyList_Append(to_remove, wr);
                     } else {

--- a/tests/test_memory_mgmt_close_matrix.py
+++ b/tests/test_memory_mgmt_close_matrix.py
@@ -11,8 +11,8 @@ from .util import LiveTracker, gc_collect_hard
 logger = logging.getLogger(__name__)
 
 
-def default_share() -> pycurl.CurlShare:
-    s = pycurl.CurlShare(detach_on_close=False)
+def default_share(*, detach_on_close: bool = False) -> pycurl.CurlShare:
+    s = pycurl.CurlShare(detach_on_close=detach_on_close)
     s.setopt(pycurl.SH_SHARE, pycurl.LOCK_DATA_COOKIE)
     s.setopt(pycurl.SH_SHARE, pycurl.LOCK_DATA_DNS)
     s.setopt(pycurl.SH_SHARE, pycurl.LOCK_DATA_SSL_SESSION)
@@ -276,6 +276,25 @@ def test_share_close_matrix(app, make_share_easies, order):
     del sios
     del easies
     del s
+    gc_collect_hard()
+
+    tr.assert_all_gone()
+
+
+def test_share_close_detaching_releases_easies(make_share_easies):
+    tr = LiveTracker()
+    s = default_share(detach_on_close=True)
+    tr.track("share", s)
+
+    easies, _ = make_share_easies(s, n=3, set_write=False)
+    for i, e in enumerate(easies):
+        tr.track(f"easy[{i}]", e)
+
+    s.close()
+    assert s.closed
+    assert all(e.share() is None for e in easies)
+
+    del e, easies, s
     gc_collect_hard()
 
     tr.assert_all_gone()


### PR DESCRIPTION
- `setopt(SHARE, s)` takes a strong reference, but `close()` cleared `easy->share` without releasing
  it, leaking the share once per attached handle.
- Add a regression test covering `detach_on_close=True`.
