### PR TITLE
Fix callback exceptions being replaced by `SystemError`

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -457,6 +457,11 @@ multi_notify_callback(CURLM *multi,
             "multi_notify_callback failed to acquire thread");
         return;
     }
+    /* a pending exception would turn this callback's PyObject_Call into a
+       SystemError, replacing the original */
+    if (PyErr_Occurred()) {
+        goto done;
+    }
 
     /* The callback may fire during curl_multi_cleanup after Py_CLEAR(n_cb). */
     if (self->n_cb == NULL) {

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -339,6 +339,12 @@ PYCURL_INTERNAL void pycurl_ssl_cleanup(void);
     if (!pycurl_python_enter(tstate)) { \
         warn_failed_to_acquire_thread(#callback_name " failed to acquire thread"); \
         return (retval); \
+    } \
+    /* a pending exception would turn this callback's PyObject_Call into a \
+       SystemError, replacing the original */ \
+    if (PyErr_Occurred()) { \
+        PYCURL_PYTHON_LEAVE(); \
+        return (retval); \
     }
 
 /* Convert socket values without truncation on Win64 where curl_socket_t is SOCKET. */

--- a/tests/test_callback_signals.py
+++ b/tests/test_callback_signals.py
@@ -128,6 +128,31 @@ def test_xferinfo_callback_keyboard_interrupt(curl, app):
     assert called["called"]
 
 
+def test_debug_callback_keyboard_interrupt(callback_curl):
+    # DEBUGFUNCTION reports success, so the transfer outlives the interrupt.
+    calls = {"debug": 0, "write": 0}
+
+    def debug_function(_typ, _data):
+        calls["debug"] += 1
+        if calls["debug"] == 1:
+            raise KeyboardInterrupt()
+
+    def write_function(chunk):
+        calls["write"] += 1
+        return len(chunk)
+
+    callback_curl.setopt(pycurl.VERBOSE, 1)
+    callback_curl.setopt(pycurl.DEBUGFUNCTION, debug_function)
+    callback_curl.setopt(pycurl.WRITEFUNCTION, write_function)
+
+    with pytest.raises(KeyboardInterrupt):
+        callback_curl.perform()
+
+    # later callbacks are skipped rather than invoked with the interrupt pending
+    assert calls["debug"] == 1
+    assert calls["write"] == 0
+
+
 def test_header_callback_non_interrupt_exception(callback_curl):
     def header_function(_):
         raise ValueError("boom")

--- a/tests/test_multi_notify.py
+++ b/tests/test_multi_notify.py
@@ -114,6 +114,24 @@ def test_info_read_from_inside_callback(notify_setup):
     assert easy in flat_ok
 
 
+def test_callback_keyboard_interrupt_not_replaced(notify_setup, capfd):
+    easy, multi, observed, timer_state = notify_setup
+
+    def on_notify(notification, curl):
+        observed.append((notification, curl))
+        if len(observed) == 1:
+            raise KeyboardInterrupt()
+
+    multi.setopt(pycurl.M_NOTIFYFUNCTION, on_notify)
+    multi.notify_enable(pycurl.M_NOTIFY_INFO_READ, pycurl.M_NOTIFY_EASY_DONE)
+    multi.add_handle(easy)
+
+    with pytest.raises(KeyboardInterrupt):
+        _drive(multi, timer_state, observed)
+
+    assert "SystemError" not in capfd.readouterr().err
+
+
 def test_callback_exception_printed_to_stderr(notify_setup, capfd):
     easy, multi, observed, timer_state = notify_setup
 


### PR DESCRIPTION
- A `KeyboardInterrupt` raised in a callback is left pending so `perform()` can re-raise it, but
  callbacks reporting success let the transfer continue. The next callback then ran with it pending
  and failed with `SystemError`, which is printed and cleared, losing the original exception.
- Callback entry now returns early when an exception is pending, with regression tests.
