### PR TITLE
Refuse `pause()` from a thread other than the performing one

### DIFF
--- a/doc/docstrings/curl_pause.rst
+++ b/doc/docstrings/curl_pause.rst
@@ -8,6 +8,11 @@ Corresponds to `curl_easy_pause`_ in libcurl. The argument should be
 derived from the ``PAUSE_RECV``, ``PAUSE_SEND``, ``PAUSE_ALL`` and
 ``PAUSE_CONT`` constants.
 
+``pause()`` may be called from inside one of this handle's callbacks
+or from the thread running the transfer. Calls from other threads while
+``perform()`` is running are rejected with ``pycurl.error``, as libcurl
+does not support them.
+
 Raises pycurl.error exception upon failure.
 
 .. _curl_easy_pause: https://curl.haxx.se/libcurl/c/curl_easy_pause.html

--- a/doc/thread-safety.rst
+++ b/doc/thread-safety.rst
@@ -21,7 +21,11 @@ For Python programs using PycURL, this means:
 
 * Accessing a PycURL object that is involved in an active transfer from
   Python code *outside of a libcurl callback for the PycURL object in question*
-  is unsafe.
+  is unsafe. Where PycURL can detect this, it raises ``pycurl.error``
+  instead of proceeding: most methods refuse while ``perform()`` is
+  running, and ``pause()`` / ``unpause()`` refuse when called from a
+  thread other than the performing one, which `curl_easy_pause`_ does
+  not support. Misuse PycURL cannot detect remains undefined behavior.
 
 * ``CurlShare`` is thread-safe: methods may be called concurrently
   from multiple threads, and different ``Curl`` handles attached to
@@ -44,8 +48,8 @@ For Python programs using PycURL, this means:
   follows the same one-handle-one-thread rule: do not call ``ws_send``
   from one thread while ``ws_recv`` runs on another. Serialise access
   with a lock. Calls from another thread while ``perform()`` is running
-  are unsafe unless they happen inside that handle's active
-  ``WRITEFUNCTION`` callback.
+  are rejected with ``pycurl.error`` unless they happen inside that
+  handle's active ``WRITEFUNCTION`` callback.
 
 * Individual ``CurlUrl`` reads and writes are thread-safe, on free-threaded
   builds as well. Mutating a ``CurlUrl`` set through the ``CURLU`` option
@@ -61,5 +65,6 @@ work properly in multi-threaded programs. When using PycURL objects from
 multiple Python threads ``NOSIGNAL`` option `must be given`_.
 
 .. _libcurl thread safety documentation: https://curl.haxx.se/libcurl/c/threadsafe.html
+.. _curl_easy_pause: https://curl.se/libcurl/c/curl_easy_pause.html
 .. _CURLSHOPT_SHARE: https://curl.se/libcurl/c/CURLSHOPT_SHARE.html
 .. _must be given: https://github.com/curl/curl/issues/1003

--- a/src/easy.c
+++ b/src/easy.c
@@ -183,13 +183,24 @@ assert_curl_state(const CurlObject *self)
 PYCURL_INTERNAL int
 check_curl_state(const CurlObject *self, int flags, const char *name)
 {
+    PyThreadState *callback_state;
+
     assert_curl_state(self);
     if ((flags & PYCURL_REQUIRE_HANDLE) && self->handle == NULL) {
         PyErr_Format(ErrorObject, "cannot invoke %s() - no curl handle", name);
         return -1;
     }
-    if ((flags & PYCURL_REQUIRE_NOT_RUNNING) && pycurl_get_thread_state(self) != NULL) {
+    callback_state = pycurl_get_thread_state(self);
+    if ((flags & PYCURL_REQUIRE_NOT_RUNNING) && callback_state != NULL) {
         PyErr_Format(ErrorObject, "cannot invoke %s() - perform() is currently running", name);
+        return -1;
+    }
+    if ((flags & PYCURL_REQUIRE_SAME_THREAD)
+        && callback_state != NULL
+        && PyThreadState_Get() != callback_state) {
+        PyErr_Format(ErrorObject,
+            "cannot invoke %s() - perform() is currently running "
+            "on another thread", name);
         return -1;
     }
     return 0;

--- a/src/easyperform.c
+++ b/src/easyperform.c
@@ -283,7 +283,10 @@ do_curl_pause_internal(CurlObject *self, int bitmask, const char *op_name)
     CURLcode res;
     PyThreadState *saved_state;
 
-    if (check_curl_state(self, PYCURL_REQUIRE_HANDLE, op_name) != 0) {
+    /* "While it may feel tempting, take care and notice that you cannot
+       call this function from another thread."
+       https://curl.se/libcurl/c/curl_easy_pause.html */
+    if (check_curl_state(self, PYCURL_REQUIRE_HANDLE | PYCURL_REQUIRE_SAME_THREAD, op_name) != 0) {
         return NULL;
     }
 

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -741,6 +741,7 @@ do_curl_ws_close(CurlObject *self, PyObject *args, PyObject *kwds);
 /* Bit flags for check_curl_state / check_multi_state. */
 #define PYCURL_REQUIRE_HANDLE       (1 << 0)
 #define PYCURL_REQUIRE_NOT_RUNNING  (1 << 1)
+#define PYCURL_REQUIRE_SAME_THREAD  (1 << 2)
 
 PYCURL_INTERNAL int
 check_curl_state(const CurlObject *self, int flags, const char *name);

--- a/tests/pause_test.py
+++ b/tests/pause_test.py
@@ -1,6 +1,5 @@
-#! /usr/bin/env python
-# vi:ts=4:et
 import json
+import threading
 import time
 from io import BytesIO
 
@@ -353,3 +352,44 @@ def test_multi_excludes_low_speed_limit_and_resets_timer(app, curl):
 def test_easy_excludes_low_speed_limit_and_resets_timer(app, curl):
     """Paused transfers ignore low-speed checks until unpaused (easy)."""
     _assert_low_speed_timeout(app, curl, _run_with_unpause_easy)
+
+
+@pytest.mark.parametrize("op", ["pause", "unpause"])
+def test_pause_from_another_thread_is_refused(app, curl, op):
+    curl.setopt(pycurl.URL, f"{app}/success")
+    in_callback = threading.Event()
+    release = threading.Event()
+    perform_error = []
+
+    def writefunc(data):
+        in_callback.set()
+        release.wait(10)
+        return len(data)
+
+    curl.setopt(pycurl.WRITEFUNCTION, writefunc)
+
+    def perform():
+        try:
+            curl.perform()
+        except pycurl.error as exc:
+            perform_error.append(exc)
+
+    thread = threading.Thread(target=perform, daemon=True)
+    thread.start()
+    try:
+        assert in_callback.wait(10)
+        with pytest.raises(
+            pycurl.error,
+            match=rf"^cannot invoke {op}\(\) - perform\(\) is currently "
+            r"running on another thread$",
+        ):
+            if op == "pause":
+                curl.pause(pycurl.PAUSE_ALL)
+            else:
+                curl.unpause()
+    finally:
+        release.set()
+        thread.join(10)
+
+    assert not thread.is_alive()
+    assert perform_error == []


### PR DESCRIPTION
- Calling `pause()` or `unpause()` from a thread other than the one inside `perform()`
  overwrote that thread's saved thread state and killed the interpreter with
  `Fatal Python error: pycurl_python_leave: attached thread state differs from slot`.
  libcurl forbids this call anyway, `curl_easy_pause(3)`: "you cannot call this
  function from another thread".
- Both methods now raise `pycurl.error` instead, via a new `PYCURL_REQUIRE_SAME_THREAD`
  flag on `check_curl_state`, matching `ws_send()`/`ws_close()`. Pausing from inside a
  callback keeps working. Documented in the `pause()` docstring and `doc/thread-safety.rst`.
