### PR TITLE
Refuse integers for blob options instead of crashing

### DIFF
--- a/src/easyopt.c
+++ b/src/easyopt.c
@@ -530,7 +530,11 @@ PYCURL_IGNORE_DEPRECATED_END
 
 
 #define IS_LONG_OPTION(o)   (o < CURLOPTTYPE_OBJECTPOINT)
-#define IS_OFF_T_OPTION(o)  (o >= CURLOPTTYPE_OFF_T)
+#ifdef CURLOPTTYPE_BLOB
+#define IS_OFF_T_OPTION(o)  ((o) >= CURLOPTTYPE_OFF_T && (o) < CURLOPTTYPE_BLOB)
+#else
+#define IS_OFF_T_OPTION(o)  ((o) >= CURLOPTTYPE_OFF_T)
+#endif
 
 
 static PyObject *

--- a/tests/setopt_test.py
+++ b/tests/setopt_test.py
@@ -34,6 +34,31 @@ def test_float_value_for_integer_option(curl):
         curl.setopt(pycurl.VERBOSE, 1.0)
 
 
+BLOB_OPTIONS = [
+    name
+    for name in (
+        # libcurl 7.71.0
+        "SSLCERT_BLOB",
+        "SSLKEY_BLOB",
+        "PROXY_SSLCERT_BLOB",
+        "PROXY_SSLKEY_BLOB",
+        "ISSUERCERT_BLOB",
+        "PROXY_ISSUERCERT_BLOB",
+        # libcurl 7.77.0
+        "CAINFO_BLOB",
+        "PROXY_CAINFO_BLOB",
+    )
+    if hasattr(pycurl, name)
+]
+
+
+@pytest.mark.parametrize("value", [12345, True], ids=["int", "bool"])
+@pytest.mark.parametrize("name", BLOB_OPTIONS)
+def test_integer_value_for_blob_option(curl, name, value):
+    with pytest.raises(TypeError, match="^integers are not supported for this option$"):
+        curl.setopt(getattr(pycurl, name), value)
+
+
 def test_httpheader_list(curl):
     curl.setopt(pycurl.HTTPHEADER, ["Accept:"])
 


### PR DESCRIPTION
- `setopt(pycurl.*_BLOB, <int>)` segfaulted the interpreter.
- They now raise the same `TypeError` any other non-integer option already gives.
