### PR TITLE
Accept buffer objects for blob options

### DIFF
--- a/doc/docstrings/curl_setopt.rst
+++ b/doc/docstrings/curl_setopt.rst
@@ -44,6 +44,13 @@ values of different types:
     c.setopt(pycurl.URL, "http://www.python.org/")
     c.setopt(pycurl.URL, b"http://www.python.org/")
 
+- Blob options, that is the ``*_BLOB`` options, accept the same values as
+  string options, plus any object supporting the buffer protocol such as
+  ``bytearray``, ``memoryview`` or ``array.array``. The value is copied, so
+  it does not have to be kept alive. Example::
+
+    c.setopt(pycurl.SSLCERT_BLOB, memoryview(certificate))
+
 - ``HTTP200ALIASES``, ``HTTPHEADER``, ``POSTQUOTE``, ``PREQUOTE``,
   ``PROXYHEADER`` and
   ``QUOTE`` accept a list or tuple of strings. The same rules apply to these

--- a/src/easyopt.c
+++ b/src/easyopt.c
@@ -293,15 +293,50 @@ error:
 }
 
 
+#ifdef CURLOPTTYPE_BLOB
+/* CURL_BLOB_COPY makes libcurl copy the data, so the buffer only has to stay
+   valid across curl_easy_setopt(). */
+static PyObject *
+do_curl_setopt_blob(CurlObject *self, int option, PyObject *obj)
+{
+    struct curl_blob curlblob;
+    PyObject *encoded_obj = NULL;
+    Py_buffer view;
+    int view_active = 0;
+    char *str;
+    Py_ssize_t len;
+    int res;
+
+    if (PyText_OrBuffer_AsStringAndSize(obj, &str, &len, &encoded_obj,
+            &view, &view_active, "blob option value") != 0) {
+        return NULL;
+    }
+
+    curlblob.data = str;
+    curlblob.len = len;
+    curlblob.flags = CURL_BLOB_COPY;
+
+    res = curl_easy_setopt(self->handle, (CURLoption)option, &curlblob);
+
+    if (view_active) {
+        PyBuffer_Release(&view);
+    }
+    Py_XDECREF(encoded_obj);
+
+    if (res != CURLE_OK) {
+        CURLERROR_RETVAL();
+    }
+    Py_RETURN_NONE;
+}
+#endif
+
+
 static PyObject *
 do_curl_setopt_string_impl(CurlObject *self, int option, PyObject *obj)
 {
     char *str = NULL;
     Py_ssize_t len = -1;
     PyObject *encoded_obj;
-#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 71, 0)
-    struct curl_blob curlblob;
-#endif
     int res;
 
     /* Check that the option specified a string as well as the input */
@@ -465,33 +500,6 @@ PYCURL_IGNORE_DEPRECATED_END
             CURLERROR_RETVAL();
         }
         break;
-#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 71, 0)
-    case CURLOPT_SSLCERT_BLOB:
-    case CURLOPT_SSLKEY_BLOB:
-    case CURLOPT_PROXY_SSLCERT_BLOB:
-    case CURLOPT_PROXY_SSLKEY_BLOB:
-    case CURLOPT_ISSUERCERT_BLOB:
-    case CURLOPT_PROXY_ISSUERCERT_BLOB:
-#if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 77, 0)
-    case CURLOPT_CAINFO_BLOB:
-    case CURLOPT_PROXY_CAINFO_BLOB:
-#endif
-        if (PyText_AsStringAndSize(obj, &str, &len, &encoded_obj) != 0)
-            return NULL;
-
-        curlblob.data = str;
-        curlblob.len = len;
-        curlblob.flags = CURL_BLOB_COPY;
-
-        res = curl_easy_setopt(self->handle, (CURLoption)option, &curlblob);
-        if (res != CURLE_OK) {
-            Py_XDECREF(encoded_obj);
-            CURLERROR_RETVAL();
-        }
-        Py_XDECREF(encoded_obj);
-        Py_RETURN_NONE;
-        break;
-#endif
     default:
         PyErr_SetString(PyExc_TypeError, "strings are not supported for this option");
         return NULL;
@@ -532,6 +540,7 @@ PYCURL_IGNORE_DEPRECATED_END
 #define IS_LONG_OPTION(o)   (o < CURLOPTTYPE_OBJECTPOINT)
 #ifdef CURLOPTTYPE_BLOB
 #define IS_OFF_T_OPTION(o)  ((o) >= CURLOPTTYPE_OFF_T && (o) < CURLOPTTYPE_BLOB)
+#define IS_BLOB_OPTION(o)   ((o) >= CURLOPTTYPE_BLOB)
 #else
 #define IS_OFF_T_OPTION(o)  ((o) >= CURLOPTTYPE_OFF_T)
 #endif
@@ -1331,6 +1340,13 @@ do_curl_setopt(CurlObject *self, PyObject *args, PyObject *kwargs)
     if (obj == Py_None) {
         return util_curl_unsetopt(self, option);
     }
+
+#ifdef CURLOPTTYPE_BLOB
+    /* Blob options accept text and buffer objects alike */
+    if (IS_BLOB_OPTION(option)) {
+        return do_curl_setopt_blob(self, option, obj);
+    }
+#endif
 
     /* Handle the case of string arguments */
     if (PyText_Check(obj)) {

--- a/src/mime.c
+++ b/src/mime.c
@@ -783,34 +783,6 @@ static PyObject *do_curlmimepart_headers(CurlMimePartObject *self, PyObject *arg
 static PyObject *do_curlmimepart_subparts(CurlMimePartObject *self, PyObject *arg);
 
 static int
-curlmimepart_data_as_string_or_buffer(PyObject *arg,
-    char **data,
-    Py_ssize_t *data_len,
-    PyObject **encoded_obj,
-    Py_buffer *view,
-    int *view_active)
-{
-    if (PyObject_CheckBuffer(arg)) {
-        if (PyObject_GetBuffer(arg, view, PyBUF_SIMPLE) != 0) {
-            return -1;
-        }
-
-        *view_active = 1;
-        *data = (char *)view->buf;
-        *data_len = view->len;
-        return 0;
-    }
-
-    if (PyBytes_Check(arg) || PyUnicode_Check(arg)) {
-        return PyText_AsStringAndSize(arg, data, data_len, encoded_obj);
-    }
-
-    PyErr_SetString(PyExc_TypeError,
-        "data() argument must be a byte string, ASCII-only Unicode string, or a buffer object");
-    return -1;
-}
-
-static int
 curlmime_validate_text_arg(PyObject *obj, const char *name)
 {
     char *value;
@@ -847,8 +819,8 @@ curlmime_validate_data_arg(PyObject *obj)
         return 0;
     }
 
-    if (curlmimepart_data_as_string_or_buffer(obj, &data, &data_len,
-            &encoded_obj, &view, &view_active) != 0)
+    if (PyText_OrBuffer_AsStringAndSize(obj, &data, &data_len,
+            &encoded_obj, &view, &view_active, "data() argument") != 0)
     {
         return -1;
     }
@@ -1453,8 +1425,8 @@ do_curlmimepart_data(CurlMimePartObject *self, PyObject *arg)
         return NULL;
     }
 
-    if (curlmimepart_data_as_string_or_buffer(arg, &data, &data_len,
-            &encoded_obj, &view, &view_active) != 0)
+    if (PyText_OrBuffer_AsStringAndSize(arg, &data, &data_len,
+            &encoded_obj, &view, &view_active, "data() argument") != 0)
     {
         return NULL;
     }

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -380,6 +380,9 @@ PyListOrTuple_GetItem(PyObject *v, Py_ssize_t i, int which);
 
 PYCURL_INTERNAL int
 PyText_AsStringAndSize(PyObject *obj, char **buffer, Py_ssize_t *length, PyObject **encoded_obj);
+PYCURL_INTERNAL int
+PyText_OrBuffer_AsStringAndSize(PyObject *obj, char **buffer, Py_ssize_t *length,
+    PyObject **encoded_obj, Py_buffer *view, int *view_active, const char *what);
 PYCURL_INTERNAL char *
 PyText_AsString_NoNUL(PyObject *obj, PyObject **encoded_obj);
 PYCURL_INTERNAL int

--- a/src/stringcompat.c
+++ b/src/stringcompat.c
@@ -59,6 +59,33 @@ PyText_Check(PyObject *o)
     return PyUnicode_Check(o) || PyBytes_Check(o);
 }
 
+/* Accepts text or any buffer object. On success the caller must release
+   *view when *view_active is set, and decref *encoded_obj. */
+PYCURL_INTERNAL int
+PyText_OrBuffer_AsStringAndSize(PyObject *obj, char **buffer, Py_ssize_t *length,
+    PyObject **encoded_obj, Py_buffer *view, int *view_active, const char *what)
+{
+    if (PyObject_CheckBuffer(obj)) {
+        if (PyObject_GetBuffer(obj, view, PyBUF_SIMPLE) != 0) {
+            return -1;
+        }
+
+        *view_active = 1;
+        *buffer = (char *)view->buf;
+        *length = view->len;
+        return 0;
+    }
+
+    if (PyText_Check(obj)) {
+        return PyText_AsStringAndSize(obj, buffer, length, encoded_obj);
+    }
+
+    PyErr_Format(PyExc_TypeError,
+        "%s must be a byte string, ASCII-only Unicode string, or a buffer object",
+        what);
+    return -1;
+}
+
 PYCURL_INTERNAL PyObject *
 PyText_FromString_Ignore(const char *string)
 {

--- a/tests/option_constants_test.py
+++ b/tests/option_constants_test.py
@@ -1,3 +1,5 @@
+import array
+
 import pycurl
 import pytest
 
@@ -251,6 +253,16 @@ def test_capath(curl):
     curl.setopt(curl.CAPATH, "/bogus-capath")
 
 
+def _exercise_blob_option(curl, option):
+    curl.setopt(option, "bogus-blob-as-str")
+    curl.setopt(option, b"bogus-blob-as-bytes")
+    curl.setopt(option, bytearray(b"bogus-blob-as-bytearray"))
+    curl.setopt(option, memoryview(b"bogus-blob-as-memoryview"))
+    curl.setopt(option, array.array("B", b"bogus-blob-as-array"))
+    curl.setopt(option, None)
+    curl.unsetopt(option)
+
+
 @util.only_ssl_backends_with_min_libcurl(
     {
         "openssl": (7, 77, 0),
@@ -262,37 +274,25 @@ def test_capath(curl):
     }
 )
 def test_cainfo_blob(curl):
-    curl.setopt(curl.CAINFO_BLOB, "bogus-cainfo-blob-as-str")
-    curl.setopt(curl.CAINFO_BLOB, None)
-    curl.setopt(curl.CAINFO_BLOB, b"bogus-cainfo-blob-as-bytes")
-    curl.unsetopt(curl.CAINFO_BLOB)
+    _exercise_blob_option(curl, curl.CAINFO_BLOB)
 
 
 @util.min_libcurl(7, 71, 0)
 @util.only_ssl_backends("openssl", "schannel", "mbedtls", "wolfssl")
 def test_sslcert_blob(curl):
-    curl.setopt(curl.SSLCERT_BLOB, "bogus-sslcert-blob-as-str")
-    curl.setopt(curl.SSLCERT_BLOB, None)
-    curl.setopt(curl.SSLCERT_BLOB, b"bogus-sslcert-blob-as-bytes")
-    curl.unsetopt(curl.SSLCERT_BLOB)
+    _exercise_blob_option(curl, curl.SSLCERT_BLOB)
 
 
 @util.min_libcurl(7, 71, 0)
 @util.only_ssl_backends("openssl", "wolfssl")
 def test_sslkey_blob(curl):
-    curl.setopt(curl.SSLKEY_BLOB, "bogus-sslkey-blob-as-str")
-    curl.setopt(curl.SSLKEY_BLOB, None)
-    curl.setopt(curl.SSLKEY_BLOB, b"bogus-sslkey-blob-as-bytes")
-    curl.unsetopt(curl.SSLKEY_BLOB)
+    _exercise_blob_option(curl, curl.SSLKEY_BLOB)
 
 
 @util.min_libcurl(7, 71, 0)
 @util.only_ssl_backends("openssl")
 def test_issuercert_blob(curl):
-    curl.setopt(curl.ISSUERCERT_BLOB, "bogus-issuercert-blob-as-str")
-    curl.setopt(curl.ISSUERCERT_BLOB, None)
-    curl.setopt(curl.ISSUERCERT_BLOB, b"bogus-issuercert-blob-as-bytes")
-    curl.unsetopt(curl.ISSUERCERT_BLOB)
+    _exercise_blob_option(curl, curl.ISSUERCERT_BLOB)
 
 
 # CURLOPT_PROXY_CAPATH was introduced in libcurl-7.52.0
@@ -311,10 +311,7 @@ def test_proxy_cainfo(curl):
 @util.min_libcurl(7, 77, 0)
 @util.only_ssl_backends("openssl", "rustls", "schannel")
 def test_proxy_cainfo_blob(curl):
-    curl.setopt(curl.PROXY_CAINFO_BLOB, "bogus-cainfo-blob-as-str")
-    curl.setopt(curl.PROXY_CAINFO_BLOB, None)
-    curl.setopt(curl.PROXY_CAINFO_BLOB, b"bogus-cainfo-blob-as-bytes")
-    curl.unsetopt(curl.PROXY_CAINFO_BLOB)
+    _exercise_blob_option(curl, curl.PROXY_CAINFO_BLOB)
 
 
 @util.min_libcurl(7, 52, 0)
@@ -332,10 +329,7 @@ def test_proxy_sslcert(curl):
 @util.min_libcurl(7, 71, 0)
 @util.only_ssl_backends("openssl", "schannel")
 def test_proxy_sslcert_blob(curl):
-    curl.setopt(curl.PROXY_SSLCERT_BLOB, "bogus-sslcert-blob-as-str")
-    curl.setopt(curl.PROXY_SSLCERT_BLOB, None)
-    curl.setopt(curl.PROXY_SSLCERT_BLOB, b"bogus-sslcert-blob-as-bytes")
-    curl.unsetopt(curl.PROXY_SSLCERT_BLOB)
+    _exercise_blob_option(curl, curl.PROXY_SSLCERT_BLOB)
 
 
 @util.min_libcurl(7, 52, 0)
@@ -353,10 +347,7 @@ def test_proxy_sslkey(curl):
 @util.min_libcurl(7, 71, 0)
 @util.only_ssl_backends("openssl")
 def test_proxy_sslkey_blob(curl):
-    curl.setopt(curl.PROXY_SSLKEY_BLOB, "bogus-sslkey-blob-as-str")
-    curl.setopt(curl.PROXY_SSLKEY_BLOB, None)
-    curl.setopt(curl.PROXY_SSLKEY_BLOB, b"bogus-sslkey-blob-as-bytes")
-    curl.unsetopt(curl.PROXY_SSLKEY_BLOB)
+    _exercise_blob_option(curl, curl.PROXY_SSLKEY_BLOB)
 
 
 @util.min_libcurl(7, 52, 0)
@@ -368,10 +359,7 @@ def test_proxy_sslkeytype(curl):
 @util.min_libcurl(7, 71, 0)
 @util.only_ssl_backends("openssl")
 def test_proxy_issuercert_blob(curl):
-    curl.setopt(curl.PROXY_ISSUERCERT_BLOB, "bogus-issuercert-blob-as-str")
-    curl.setopt(curl.PROXY_ISSUERCERT_BLOB, None)
-    curl.setopt(curl.PROXY_ISSUERCERT_BLOB, b"bogus-issuercert-blob-as-bytes")
-    curl.unsetopt(curl.PROXY_ISSUERCERT_BLOB)
+    _exercise_blob_option(curl, curl.PROXY_ISSUERCERT_BLOB)
 
 
 @util.min_libcurl(7, 52, 0)

--- a/tests/setopt_test.py
+++ b/tests/setopt_test.py
@@ -52,11 +52,24 @@ BLOB_OPTIONS = [
 ]
 
 
-@pytest.mark.parametrize("value", [12345, True], ids=["int", "bool"])
+@pytest.mark.parametrize("value", [12345, True, 1.5], ids=["int", "bool", "float"])
 @pytest.mark.parametrize("name", BLOB_OPTIONS)
-def test_integer_value_for_blob_option(curl, name, value):
-    with pytest.raises(TypeError, match="^integers are not supported for this option$"):
+def test_unsupported_value_for_blob_option(curl, name, value):
+    with pytest.raises(
+        TypeError,
+        match=(
+            "^blob option value must be a byte string, ASCII-only Unicode "
+            "string, or a buffer object$"
+        ),
+    ):
         curl.setopt(getattr(pycurl, name), value)
+
+
+@pytest.mark.skipif(not BLOB_OPTIONS, reason="libcurl without blob options")
+def test_noncontiguous_buffer_for_blob_option(curl):
+    option = getattr(pycurl, BLOB_OPTIONS[0])
+    with pytest.raises(BufferError):
+        curl.setopt(option, memoryview(bytearray(b"abcdefgh"))[::2])
 
 
 def test_httpheader_list(curl):


### PR DESCRIPTION
- `*_BLOB` options now also accept `bytearray`, `memoryview` and
  `array.array`. libcurl copies blob data, so the buffer is released as soon as `setopt` returns.
- Blob options are handled in one place now instead of being split between the string
  dispatch and the option table and `setopt_string()` no longer takes blob options.