### PR TITLE
Reject callback return values that do not fit in an int

### DIFF
--- a/src/easycb.c
+++ b/src/easycb.c
@@ -8,6 +8,35 @@
 #define PYCURL_BEGIN_CALLBACK(callback_name, retval) \
     PYCURL_BEGIN_CALLBACK_COMMON(PYCURL_GET_THREAD_STATE, retval, callback_name)
 
+/* Keeps reporting a non-integer return on stderr, as raising here would replace
+   the libcurl error the callers report for it. KeyboardInterrupt and SystemExit
+   raised while building the report are left pending, so that perform() still
+   reports them. */
+static void
+report_non_integer_return(const char *callback_name, PyObject *ret_obj)
+{
+    PyObject *repr = PyObject_Repr(ret_obj);
+    PyObject *encoded = NULL;
+
+    if (repr == NULL) {
+        if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_Exception)) {
+            PyErr_Clear();
+        }
+    }
+    else {
+        /* backslashreplace, so a non-ASCII repr still encodes */
+        encoded = PyUnicode_AsEncodedString(repr, "ascii", "backslashreplace");
+        if (encoded == NULL
+                && PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_Exception)) {
+            PyErr_Clear();
+        }
+        Py_DECREF(repr);
+    }
+    fprintf(stderr, "%s callback returned %s which is not an integer\n",
+        callback_name, encoded != NULL ? PyBytes_AS_STRING(encoded) : "a value");
+    Py_XDECREF(encoded);
+}
+
 PYCURL_INTERNAL int
 callback_return_value_to_int(PyObject *ret_obj, const char *callback_name, int *ret_out)
 {
@@ -15,17 +44,19 @@ callback_return_value_to_int(PyObject *ret_obj, const char *callback_name, int *
         return -1;
     }
     if (!PyLong_Check(ret_obj)) {
-        PyObject *ret_repr = PyObject_Repr(ret_obj);
-        if (ret_repr) {
-            PyObject *encoded_obj;
-            char *str = PyText_AsString_NoNUL(ret_repr, &encoded_obj);
-            fprintf(stderr, "%s callback returned %s which is not an integer\n", callback_name, str);
-            Py_XDECREF(encoded_obj);
-            Py_DECREF(ret_repr);
+        report_non_integer_return(callback_name, ret_obj);
+        return -1;
+    }
+    /* Truncating to int would turn an abort request into a continue */
+    if (pycurl_long_as_int(ret_obj, ret_out) != 0) {
+        if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
+            PyErr_Clear();
+            PyErr_Format(PyExc_OverflowError,
+                "%s callback returned %R which does not fit in an int",
+                callback_name, ret_obj);
         }
         return -1;
     }
-    *ret_out = (int) PyLong_AsLong(ret_obj);
     return 0;
 }
 
@@ -103,8 +134,12 @@ util_write_callback(int flags, char *ptr, size_t size, size_t nmemb, void *strea
         ret = total_size;           /* None means success */
     }
     else if (PyLong_Check(result)) {
-        /* if the cast to long fails, PyLong_AsLong() returns -1L */
-        ret = (size_t) PyLong_AsLong(result);
+        long value = PyLong_AsLong(result);
+
+        if (value == -1 && PyErr_Occurred()) {
+            goto verbose_error;
+        }
+        ret = (size_t) value;
     }
     else {
         PyErr_SetString(ErrorObject, "write callback must return int or None");
@@ -518,7 +553,11 @@ seek_callback(void *stream, curl_off_t offset, int origin)
         ret = 0;           /* None means success */
     }
     else if (PyLong_Check(result)) {
-        int ret_code = PyLong_AsLong(result);
+        int ret_code;
+
+        if (callback_return_value_to_int(result, "seek", &ret_code) != 0) {
+            goto verbose_error;
+        }
         if (ret_code < 0 || ret_code > 2) {
             PyErr_Format(ErrorObject, "invalid return value for seek callback %d not in (0, 1, 2)", ret_code);
             goto verbose_error;
@@ -631,6 +670,9 @@ read_callback(char *ptr, size_t size, size_t nmemb, void *stream)
     }
     else if (PyLong_Check(result)) {
         long r = PyLong_AsLong(result);
+        if (r == -1 && PyErr_Occurred()) {
+            goto verbose_error;
+        }
         if (r != CURL_READFUNC_ABORT && r != CURL_READFUNC_PAUSE)
             goto type_error;
         ret = r; /* either CURL_READFUNC_ABORT or CURL_READFUNC_PAUSE */
@@ -684,7 +726,9 @@ progress_callback(void *stream,
         ret = 0;        /* None means success */
     }
     else if (PyLong_Check(result)) {
-        ret = (int) PyLong_AsLong(result);
+        if (callback_return_value_to_int(result, "progress", &ret) != 0) {
+            goto verbose_error;
+        }
     }
     else {
         ret = PyObject_IsTrue(result);
@@ -739,7 +783,9 @@ xferinfo_callback(void *stream,
         ret = 0;        /* None means success */
     }
     else if (PyLong_Check(result)) {
-        ret = (int) PyLong_AsLong(result);
+        if (callback_return_value_to_int(result, "xferinfo", &ret) != 0) {
+            goto verbose_error;
+        }
     }
     else {
         ret = PyObject_IsTrue(result);
@@ -837,7 +883,9 @@ ioctl_callback(CURL *curlobj, int cmd, void *stream)
         ret = CURLIOE_OK;        /* None means success */
     }
     else if (PyLong_Check(result)) {
-        ret = (int) PyLong_AsLong(result);
+        if (callback_return_value_to_int(result, "ioctl", &ret) != 0) {
+            goto verbose_error;
+        }
         if (ret >= CURLIOE_LAST || ret < 0) {
             PyErr_SetString(ErrorObject, "ioctl callback returned invalid value");
             goto verbose_error;
@@ -914,7 +962,11 @@ add_ca_certs(SSL_CTX *context, void *data, Py_ssize_t len)
         ERR_clear_error();
         retval = 0;
     } else {
-        PyErr_SetString(ErrorObject, ERR_reason_error_string(err));
+        /* NULL for an error code OpenSSL cannot map */
+        const char *reason = ERR_reason_error_string(err);
+
+        PyErr_SetString(ErrorObject,
+            reason != NULL ? reason : "unknown OpenSSL error");
         ERR_clear_error();
         retval = -1;
     }

--- a/src/mime.c
+++ b/src/mime.c
@@ -324,6 +324,9 @@ curlmimepart_read_callback(char *ptr, size_t size, size_t nmemb, void *arg)
     }
     else if (PyLong_Check(result)) {
         long long_res = PyLong_AsLong(result);
+        if (long_res == -1 && PyErr_Occurred()) {
+            goto verbose_error;
+        }
         if (long_res != CURL_READFUNC_ABORT && long_res != CURL_READFUNC_PAUSE) {
             PyErr_SetString(ErrorObject, "mime read callback must return a buffer object, an ASCII-only Unicode string, READFUNC_ABORT, or READFUNC_PAUSE");
             goto verbose_error;
@@ -401,8 +404,9 @@ curlmimepart_seek_callback(void *arg, curl_off_t offset, int origin)
         ret = CURL_SEEKFUNC_OK;
     }
     else if (PyLong_Check(result)) {
-        int ret_code = (int)PyLong_AsLong(result);
-        if (PyErr_Occurred()) {
+        int ret_code;
+
+        if (callback_return_value_to_int(result, "mime seek", &ret_code) != 0) {
             goto verbose_error;
         }
         if (ret_code < CURL_SEEKFUNC_OK || ret_code > CURL_SEEKFUNC_CANTSEEK) {

--- a/src/multi.c
+++ b/src/multi.c
@@ -344,7 +344,7 @@ multi_socket_callback(CURL *easy,
     if (result == Py_None) {
         ret = 0;
     } else if (callback_return_value_to_int(result, "multi socket", &ret) != 0) {
-        goto silent_error;
+        goto verbose_error;
     }
 
 silent_error:
@@ -395,7 +395,7 @@ multi_timer_callback(CURLM *multi,
     if (result == Py_None) {
         ret = 0;
     } else if (callback_return_value_to_int(result, "multi timer", &ret) != 0) {
-        goto silent_error;
+        goto verbose_error;
     }
 
 silent_error:

--- a/src/pycurl.h
+++ b/src/pycurl.h
@@ -363,6 +363,9 @@ PyLong_FromCurlSocket(curl_socket_t sockfd);
 PYCURL_INTERNAL int
 PyLong_AsCurlSocket(PyObject *obj, curl_socket_t *sockfd);
 
+PYCURL_INTERNAL int
+pycurl_long_as_int(PyObject *obj, int *ret_out);
+
 #define PYLISTORTUPLE_LIST 1
 #define PYLISTORTUPLE_TUPLE 2
 #define PYLISTORTUPLE_OTHER 0

--- a/src/util.c
+++ b/src/util.c
@@ -110,6 +110,34 @@ PyLong_AsCurlSocket(PyObject *obj, curl_socket_t *sockfd)
 #endif
 }
 
+/* Returns -1 with the OverflowError PyLong_AsInt raises, so that callers see the
+   same contract before and after it became available in 3.13. */
+PYCURL_INTERNAL int
+pycurl_long_as_int(PyObject *obj, int *ret_out)
+{
+#if PY_VERSION_HEX >= 0x030D0000
+    int value = PyLong_AsInt(obj);
+
+    if (value == -1 && PyErr_Occurred()) {
+        return -1;
+    }
+#else
+    int overflow;
+    long value = PyLong_AsLongAndOverflow(obj, &overflow);
+
+    if (value == -1 && PyErr_Occurred()) {
+        return -1;
+    }
+    if (overflow || value > INT_MAX || value < INT_MIN) {
+        PyErr_SetString(PyExc_OverflowError,
+                        "Python int too large to convert to C int");
+        return -1;
+    }
+#endif
+    *ret_out = (int) value;
+    return 0;
+}
+
 static PyObject *
 create_error_object(CurlObject *self, int code)
 {

--- a/tests/app.py
+++ b/tests/app.py
@@ -32,6 +32,15 @@ def not_found():
 def postfields():
     return json.dumps(dict(flask.request.form))
 
+@app.route('/upload_redirect', methods=['PUT', 'POST'])
+def upload_redirect():
+    return flask.Response(status=307,
+        headers={'Location': flask.url_for('upload_target')})
+
+@app.route('/upload_target', methods=['PUT', 'POST'])
+def upload_target():
+    return str(len(flask.request.get_data()))
+
 @app.route('/raw_utf8', methods=['POST'])
 def raw_utf8():
     data = flask.request.data.decode('utf8')

--- a/tests/cadata_test.py
+++ b/tests/cadata_test.py
@@ -44,6 +44,19 @@ def test_set_ca_certs_bogus_type(curl):
     )
 
 
+@util.only_ssl_backends("openssl")
+def test_set_ca_certs_without_a_certificate_reports_an_error(ssl_curl, ssl_app):
+    ssl_curl.set_ca_certs("this blob holds no certificate")
+    ssl_curl.setopt(pycurl.SSL_VERIFYPEER, 1)
+    ssl_curl.setopt(pycurl.URL, f"{ssl_app}/success")
+
+    # the ssl ctx callback reports its failure as E_FAILED_INIT, so the parse
+    # error itself only reaches stderr
+    with pytest.raises(pycurl.error) as exc_info:
+        ssl_curl.perform()
+    assert exc_info.value.args[0] == pycurl.E_FAILED_INIT
+
+
 @pytest.mark.parametrize("free_original", [False, True], ids=["alive", "freed"])
 @util.only_ssl_backends("openssl")
 def test_duphandle_keeps_ca_certs_working(ssl_app, free_original):

--- a/tests/multi_callback_test.py
+++ b/tests/multi_callback_test.py
@@ -295,3 +295,75 @@ def test_easy_close(multi_ctx: MultiCtx):
 
     _run_until(multi_ctx, lambda: multi_ctx.socket_result is not None, timeout=10.0)
     assert multi_ctx.socket_result is not None
+
+
+def _overflowing_timer(timeout_ms):
+    return 2**32
+
+
+TIMER_OVERFLOW = "multi timer callback returned 4294967296 which does not fit in an int"
+SOCKET_OVERFLOW = (
+    "multi socket callback returned 4294967296 which does not fit in an int"
+)
+
+
+@pytest.fixture
+def callback_multi():
+    multi = pycurl.CurlMulti()
+    multi.setopt(pycurl.M_SOCKETFUNCTION, lambda *args: 0)
+    multi.setopt(pycurl.M_TIMERFUNCTION, lambda timeout_ms: 0)
+    yield multi
+    multi.close()
+
+
+@pytest.fixture
+def spare_easy():
+    easy = util.DefaultCurl()
+    easy.setopt(pycurl.URL, "http://127.0.0.1:1/")
+    yield easy
+    easy.close()
+
+
+def test_multi_timer_overflow_on_add_handle_is_reported(
+    callback_multi, spare_easy, capfd
+):
+    callback_multi.setopt(pycurl.M_TIMERFUNCTION, _overflowing_timer)
+
+    with pytest.raises(pycurl.error):
+        callback_multi.add_handle(spare_easy)
+    assert f"OverflowError: {TIMER_OVERFLOW}" in capfd.readouterr().err
+
+
+def test_multi_timer_overflow_on_remove_handle_is_reported(
+    callback_multi, spare_easy, capfd
+):
+    callback_multi.add_handle(spare_easy)
+    callback_multi.setopt(pycurl.M_TIMERFUNCTION, _overflowing_timer)
+
+    with pytest.raises(pycurl.error):
+        callback_multi.remove_handle(spare_easy)
+    assert f"OverflowError: {TIMER_OVERFLOW}" in capfd.readouterr().err
+
+
+def test_multi_timer_overflow_on_close_is_reported(callback_multi, spare_easy, capfd):
+    callback_multi.add_handle(spare_easy)
+    callback_multi.setopt(pycurl.M_TIMERFUNCTION, _overflowing_timer)
+
+    callback_multi.close()
+    assert f"OverflowError: {TIMER_OVERFLOW}" in capfd.readouterr().err
+
+
+def _overflowing_socket(*args):
+    return 2**32
+
+
+# An overflow must not leave an exception pending: libcurl keeps CURLM_OK here,
+# and a pending exception would stop the callbacks that close the socket.
+def test_multi_socket_overflow_on_remove_handle_is_reported(multi_ctx, capfd):
+    partial_transfer(multi_ctx)
+    multi_ctx.multi.setopt(pycurl.M_SOCKETFUNCTION, _overflowing_socket)
+
+    multi_ctx.multi.remove_handle(multi_ctx.easy)
+    multi_ctx.handle_added = False
+
+    assert f"OverflowError: {SOCKET_OVERFLOW}" in capfd.readouterr().err

--- a/tests/sockopt_cb_test.py
+++ b/tests/sockopt_cb_test.py
@@ -1,84 +1,104 @@
-#! /usr/bin/env python
-# vi:ts=4:et
+import pytest
 
-from . import localhost
-import unittest
 import pycurl
 
 from . import util
-from . import appmanager
 
-setup_module, teardown_module = appmanager.setup(('app', 8380))
 
-class SockoptCbTest(unittest.TestCase):
-    def setUp(self):
-        self.curl = util.DefaultCurl()
-        self.curl.setopt(self.curl.URL, 'http://%s:8380/success' % localhost)
+@pytest.fixture
+def sockopt_curl(curl, app):
+    curl.setopt(pycurl.URL, f"{app}/success")
+    return curl
 
-    def tearDown(self):
-        self.curl.close()
 
-    def test_sockoptfunction_ok(self):
-        called = {}
+def _record_and_return(called, value):
+    def sockoptfunction(curlfd, purpose):
+        called.append(True)
+        return value
 
-        def sockoptfunction(curlfd, purpose):
-            called['called'] = True
-            return 0
+    return sockoptfunction
 
-        self.curl.setopt(pycurl.SOCKOPTFUNCTION, sockoptfunction)
 
-        self.curl.perform()
-        assert called['called']
+def test_sockoptfunction_ok(sockopt_curl):
+    called = []
+    sockopt_curl.setopt(pycurl.SOCKOPTFUNCTION, _record_and_return(called, 0))
 
-    def test_sockoptfunction_fail(self):
-        called = {}
+    sockopt_curl.perform()
+    assert called
 
-        def sockoptfunction(curlfd, purpose):
-            called['called'] = True
-            return 1
 
-        self.curl.setopt(pycurl.SOCKOPTFUNCTION, sockoptfunction)
+def _assert_connection_refused(curl, return_value):
+    called = []
+    curl.setopt(pycurl.SOCKOPTFUNCTION, _record_and_return(called, return_value))
 
-        try:
-            self.curl.perform()
-            self.fail('should have raised')
-        except pycurl.error as e:
-            assert e.args[0] in [pycurl.E_ABORTED_BY_CALLBACK, pycurl.E_COULDNT_CONNECT], \
-                'Unexpected pycurl error code %s' % e.args[0]
-        assert called['called']
+    with pytest.raises(pycurl.error) as exc_info:
+        curl.perform()
+    assert exc_info.value.args[0] in (
+        pycurl.E_ABORTED_BY_CALLBACK,
+        pycurl.E_COULDNT_CONNECT,
+    )
+    assert called
 
-    def test_sockoptfunction_bogus_return(self):
-        called = {}
 
-        def sockoptfunction(curlfd, purpose):
-            called['called'] = True
-            return 'bogus'
+def test_sockoptfunction_fail(sockopt_curl):
+    _assert_connection_refused(sockopt_curl, 1)
 
-        self.curl.setopt(pycurl.SOCKOPTFUNCTION, sockoptfunction)
 
-        try:
-            self.curl.perform()
-            self.fail('should have raised')
-        except pycurl.error as e:
-            assert e.args[0] in [pycurl.E_ABORTED_BY_CALLBACK, pycurl.E_COULDNT_CONNECT], \
-                'Unexpected pycurl error code %s' % e.args[0]
-        assert called['called']
+class _UnreprableReturn:
+    def __repr__(self):
+        raise ValueError("no repr")
 
-    @util.min_libcurl(7, 28, 0)
-    def test_socktype_accept(self):
-        assert hasattr(pycurl, 'SOCKTYPE_ACCEPT')
-        assert hasattr(self.curl, 'SOCKTYPE_ACCEPT')
 
-    def test_socktype_ipcxn(self):
-        assert hasattr(pycurl, 'SOCKTYPE_IPCXN')
-        assert hasattr(self.curl, 'SOCKTYPE_IPCXN')
+@pytest.mark.parametrize(
+    "return_value, expected",
+    [
+        ("bogus", "returned 'bogus' which is not an integer"),
+        # the repr is encoded with backslashreplace, so non-ASCII still prints
+        ("caf\xe9", "returned 'caf\\xe9' which is not an integer"),
+        (object(), "returned <object object at"),
+        (_UnreprableReturn(), "returned a value which is not an integer"),
+    ],
+    ids=["ascii-str", "non-ascii-str", "object", "repr-raises"],
+)
+def test_sockoptfunction_bogus_return(sockopt_curl, return_value, expected, capfd):
+    _assert_connection_refused(sockopt_curl, return_value)
+    assert f"sockopt callback {expected}" in capfd.readouterr().err
 
-class SockoptCbUnsetTest(unittest.TestCase):
-    def setUp(self):
-        self.curl = util.DefaultCurl()
 
-    def test_sockoptfunction_none(self):
-        self.curl.setopt(pycurl.SOCKOPTFUNCTION, None)
+@pytest.mark.parametrize(
+    "return_value",
+    [2**31, 2**32, 2**70],
+    ids=["int32-overflow", "int-truncates-to-zero", "long-overflow"],
+)
+def test_sockoptfunction_oversized_return(sockopt_curl, return_value):
+    called = []
+    sockopt_curl.setopt(
+        pycurl.SOCKOPTFUNCTION, _record_and_return(called, return_value)
+    )
 
-    def test_sockoptfunction_unset(self):
-        self.curl.unsetopt(pycurl.SOCKOPTFUNCTION)
+    with pytest.raises(OverflowError) as exc_info:
+        sockopt_curl.perform()
+    assert (
+        str(exc_info.value)
+        == f"sockopt callback returned {return_value} which does not fit in an int"
+    )
+    assert called
+
+
+@util.min_libcurl(7, 28, 0)
+def test_socktype_accept(curl):
+    assert hasattr(pycurl, "SOCKTYPE_ACCEPT")
+    assert hasattr(curl, "SOCKTYPE_ACCEPT")
+
+
+def test_socktype_ipcxn(curl):
+    assert hasattr(pycurl, "SOCKTYPE_IPCXN")
+    assert hasattr(curl, "SOCKTYPE_IPCXN")
+
+
+def test_sockoptfunction_none(curl):
+    curl.setopt(pycurl.SOCKOPTFUNCTION, None)
+
+
+def test_sockoptfunction_unset(curl):
+    curl.unsetopt(pycurl.SOCKOPTFUNCTION)

--- a/tests/test_mime.py
+++ b/tests/test_mime.py
@@ -446,6 +446,24 @@ def test_mimepart_data_cb_streams_field_value(app):
         }
 
 
+def test_mimepart_data_cb_oversized_return_fails_the_transfer(app, capfd):
+    with pycurl.Curl() as curl:
+        mime = pycurl.CurlMime(curl)
+        part = mime.addpart()
+        part.name("field")
+        part.data_cb(10, lambda userdata, size: 2**70)
+        curl.setopt(pycurl.MIMEPOST, mime)
+        curl.setopt(pycurl.URL, f"{app}/postfields")
+        curl.setopt(pycurl.WRITEFUNCTION, io.BytesIO().write)
+
+        with pytest.raises(pycurl.error):
+            curl.perform()
+
+    err = capfd.readouterr().err
+    assert "OverflowError" in err
+    assert "must return a buffer object" not in err
+
+
 def test_mimepart_data_cb_requires_callable_read():
     with pycurl.Curl() as curl:
         mime = pycurl.CurlMime(curl)

--- a/tests/test_upload_rewind.py
+++ b/tests/test_upload_rewind.py
@@ -1,0 +1,73 @@
+import contextlib
+import warnings
+from io import BytesIO
+
+import pytest
+
+import pycurl
+
+UPLOAD_SIZE = 64
+
+# Older libcurl understands this value but only defines the constant in 7.19.5+
+SEEKFUNC_OK = 0
+
+REWIND_OPTIONS = [
+    pytest.param(pycurl.SEEKFUNCTION, "seek", id="seek"),
+    pytest.param(pycurl.IOCTLFUNCTION, "ioctl", id="ioctl"),
+]
+
+
+@pytest.fixture
+def upload_curl(curl, app):
+    curl.setopt(pycurl.URL, f"{app}/upload_redirect")
+    curl.setopt(pycurl.UPLOAD, 1)
+    curl.setopt(pycurl.FOLLOWLOCATION, 1)
+    curl.setopt(pycurl.INFILESIZE, UPLOAD_SIZE)
+    curl.setopt(pycurl.WRITEDATA, BytesIO())
+    return curl
+
+
+def _rewind_with(curl, option, return_value):
+    """Install a rewind callback returning return_value, and record its calls."""
+    source = BytesIO(b"X" * UPLOAD_SIZE)
+    calls = []
+
+    def callback(*args):
+        calls.append(args)
+        source.seek(0)
+        return return_value
+
+    curl.setopt(pycurl.READFUNCTION, source.read)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        curl.setopt(option, callback)
+    return calls
+
+
+@pytest.mark.parametrize("option, callback_name", REWIND_OPTIONS)
+def test_rewind_callback_ok(upload_curl, option, callback_name):
+    body = BytesIO()
+    upload_curl.setopt(pycurl.WRITEDATA, body)
+    calls = _rewind_with(upload_curl, option, SEEKFUNC_OK)
+
+    upload_curl.perform()
+    assert calls
+    assert body.getvalue() == str(UPLOAD_SIZE).encode()
+
+
+@pytest.mark.parametrize("option, callback_name", REWIND_OPTIONS)
+@pytest.mark.parametrize(
+    "return_value", [2**31, 2**32], ids=["int32-overflow", "truncates-to-zero"]
+)
+def test_rewind_callback_oversized_return_is_refused(
+    upload_curl, option, callback_name, return_value, capfd
+):
+    calls = _rewind_with(upload_curl, option, return_value)
+
+    with contextlib.suppress(pycurl.error):
+        upload_curl.perform()
+    assert calls
+    assert (
+        f"OverflowError: {callback_name} callback returned {return_value} "
+        "which does not fit in an int"
+    ) in capfd.readouterr().err

--- a/tests/xferinfo_cb_test.py
+++ b/tests/xferinfo_cb_test.py
@@ -1,74 +1,93 @@
-#! /usr/bin/env python
-# vi:ts=4:et
+import warnings
 
-from . import localhost
-import unittest
+import pytest
+
 import pycurl
 
 from . import util
-from . import appmanager
 
-setup_module, teardown_module = appmanager.setup(('app', 8380))
+pytestmark = pytest.mark.skipif(
+    util.pycurl_version_less_than(7, 32, 0), reason="libcurl < 7.32.0"
+)
 
-class XferinfoCbTest(unittest.TestCase):
-    def setUp(self):
-        self.curl = util.DefaultCurl()
-        self.curl.setopt(self.curl.URL, 'http://%s:8380/long_pause' % localhost)
 
-    def tearDown(self):
-        self.curl.close()
+@pytest.fixture
+def xferinfo_curl(curl, app):
+    curl.setopt(pycurl.URL, f"{app}/long_pause")
+    curl.setopt(pycurl.NOPROGRESS, False)
+    return curl
 
-    @util.min_libcurl(7, 32, 0)
-    def test_xferinfo_cb(self):
-        all_args = []
 
-        def xferinfofunction(*args):
-            all_args.append(args)
+def test_xferinfo_cb(xferinfo_curl):
+    all_args = []
 
-        self.curl.setopt(pycurl.XFERINFOFUNCTION, xferinfofunction)
-        self.curl.setopt(pycurl.NOPROGRESS, False)
+    def xferinfofunction(*args):
+        all_args.append(args)
 
-        self.curl.perform()
-        assert len(all_args) > 0
-        for args in all_args:
-            assert len(args) == 4
-            for arg in args:
-                assert isinstance(arg, int)
+    xferinfo_curl.setopt(pycurl.XFERINFOFUNCTION, xferinfofunction)
 
-    @util.min_libcurl(7, 32, 0)
-    def test_sockoptfunction_fail(self):
-        called = {}
+    xferinfo_curl.perform()
+    assert len(all_args) > 0
+    for args in all_args:
+        assert len(args) == 4
+        for arg in args:
+            assert isinstance(arg, int)
 
-        def xferinfofunction(*args):
-            called['called'] = True
-            return -1
 
-        self.curl.setopt(pycurl.XFERINFOFUNCTION, xferinfofunction)
-        self.curl.setopt(pycurl.NOPROGRESS, False)
+PROGRESS_OPTIONS = [
+    pytest.param(pycurl.XFERINFOFUNCTION, "xferinfo", id="xferinfo"),
+    pytest.param(pycurl.PROGRESSFUNCTION, "progress", id="progress"),
+]
 
-        try:
-            self.curl.perform()
-            self.fail('should have raised')
-        except pycurl.error as e:
-            assert e.args[0] in [pycurl.E_ABORTED_BY_CALLBACK], \
-                'Unexpected pycurl error code %s' % e.args[0]
-        assert called['called']
 
-    @util.min_libcurl(7, 32, 0)
-    def test_sockoptfunction_exception(self):
-        called = {}
+def _assert_aborts(curl, option, return_value):
+    called = []
 
-        def xferinfofunction(*args):
-            called['called'] = True
-            raise ValueError
+    def progressfunction(*args):
+        called.append(True)
+        return return_value
 
-        self.curl.setopt(pycurl.XFERINFOFUNCTION, xferinfofunction)
-        self.curl.setopt(pycurl.NOPROGRESS, False)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        curl.setopt(option, progressfunction)
 
-        try:
-            self.curl.perform()
-            self.fail('should have raised')
-        except pycurl.error as e:
-            assert e.args[0] in [pycurl.E_ABORTED_BY_CALLBACK], \
-                'Unexpected pycurl error code %s' % e.args[0]
-        assert called['called']
+    with pytest.raises(pycurl.error) as exc_info:
+        curl.perform()
+    assert exc_info.value.args[0] == pycurl.E_ABORTED_BY_CALLBACK
+    assert called
+
+
+@pytest.mark.parametrize("return_value", [-1, 1], ids=["negative", "one"])
+def test_xferinfo_nonzero_return_aborts(xferinfo_curl, return_value):
+    _assert_aborts(xferinfo_curl, pycurl.XFERINFOFUNCTION, return_value)
+
+
+@pytest.mark.parametrize("option, callback_name", PROGRESS_OPTIONS)
+@pytest.mark.parametrize(
+    "return_value",
+    [2**31, 2**32, 2**70],
+    ids=["int32-overflow", "int-truncates-to-zero", "long-overflow"],
+)
+def test_progress_oversized_return_aborts(
+    xferinfo_curl, option, callback_name, return_value, capfd
+):
+    _assert_aborts(xferinfo_curl, option, return_value)
+    assert (
+        f"OverflowError: {callback_name} callback returned {return_value} "
+        "which does not fit in an int"
+    ) in capfd.readouterr().err
+
+
+def test_xferinfo_exception_aborts(xferinfo_curl):
+    called = []
+
+    def xferinfofunction(*args):
+        called.append(True)
+        raise ValueError
+
+    xferinfo_curl.setopt(pycurl.XFERINFOFUNCTION, xferinfofunction)
+
+    with pytest.raises(pycurl.error) as exc_info:
+        xferinfo_curl.perform()
+    assert exc_info.value.args[0] == pycurl.E_ABORTED_BY_CALLBACK
+    assert called


### PR DESCRIPTION
- A callback returning something too large wrapped around to `0`, so asking to abort a
  transfer did nothing. `seek` and `ioctl` then checked the wrapped value against their
  valid range and let it through.
- Oversized returns are now rejected. Most raise `OverflowError`; the multi socket and
  timer callbacks report on stderr instead, because leaving an exception pending there
  leaks a socket.
- Fixed a crash printing a non-ASCII return value, and another in `set_ca_certs()` when
  OpenSSL has no message for the error.
