### PR TITLE
Clear CurlMulti callbacks before deallocating attached handles

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -219,14 +219,10 @@ do_multi_dealloc(CurlMultiObject *self)
     PyObject_GC_UnTrack(self);
     Py_TRASHCAN_BEGIN(self, do_multi_dealloc);
 
-    /* Removing easy handles can invoke M_SOCKETFUNCTION. Clear callbacks
-     * first so the dying CurlMulti is not handed back to Python from its own
+    /* Removing easy handles can invoke M_SOCKETFUNCTION. Clear it first so
+     * the dying CurlMulti is not handed back to Python from its own
      * tp_dealloc. */
-    Py_CLEAR(self->t_cb);
     Py_CLEAR(self->s_cb);
-#ifdef HAVE_CURL_MULTI_NOTIFY
-    Py_CLEAR(self->n_cb);
-#endif
 
     util_multi_detach_easies(self, 0, 1);
 

--- a/src/multi.c
+++ b/src/multi.c
@@ -219,6 +219,15 @@ do_multi_dealloc(CurlMultiObject *self)
     PyObject_GC_UnTrack(self);
     Py_TRASHCAN_BEGIN(self, do_multi_dealloc);
 
+    /* Removing easy handles can invoke M_SOCKETFUNCTION. Clear callbacks
+     * first so the dying CurlMulti is not handed back to Python from its own
+     * tp_dealloc. */
+    Py_CLEAR(self->t_cb);
+    Py_CLEAR(self->s_cb);
+#ifdef HAVE_CURL_MULTI_NOTIFY
+    Py_CLEAR(self->n_cb);
+#endif
+
     util_multi_detach_easies(self, 0, 1);
 
     util_multi_xdecref(self);

--- a/tests/multi_memory_mgmt_test.py
+++ b/tests/multi_memory_mgmt_test.py
@@ -1,7 +1,5 @@
 import gc
-import subprocess
 import sys
-import textwrap
 import weakref
 
 import pycurl
@@ -79,99 +77,52 @@ def test_curl_kept_alive_while_added_to_multi():
     assert ref() is None
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 14),
-    reason="Python 3.14 exposes callback reentrancy during tp_dealloc",
-)
-def test_socket_callback_not_invoked_during_multi_dealloc():
-    script = textwrap.dedent(
-        """
-        import gc
-        import pycurl
+def test_socket_callback_not_invoked_during_multi_dealloc(app):
+    callbacks_during_dealloc = []
+    deallocating = False
 
-        callback_count = 0
-        deallocating = False
+    def socket_callback(event, fd, multi, data):
+        if deallocating:
+            callbacks_during_dealloc.append(event)
 
-        def socket_callback(event, fd, multi, data):
-            global callback_count
-            if deallocating:
-                callback_count += 1
+    easy = pycurl.Curl()
+    easy.setopt(pycurl.URL, f"{app}/success")
+    multi = pycurl.CurlMulti()
+    multi.setopt(pycurl.M_SOCKETFUNCTION, socket_callback)
+    multi.add_handle(easy)
 
-        easy = pycurl.Curl()
-        easy.setopt(pycurl.URL, "http://10.255.255.1:1/")
-        multi = pycurl.CurlMulti()
-        multi.setopt(pycurl.M_SOCKETFUNCTION, socket_callback)
-        multi.add_handle(easy)
+    for _ in range(3):
+        multi.socket_action(pycurl.SOCKET_TIMEOUT, 0)
 
-        for _ in range(3):
-            try:
-                multi.socket_action(pycurl.SOCKET_TIMEOUT, 0)
-            except pycurl.error:
-                pass
+    deallocating = True
+    del multi
+    gc.collect()
 
-        deallocating = True
-        del multi
-        gc.collect()
-        print(callback_count)
-        """
-    )
-
-    process = subprocess.run(
-        [sys.executable, "-c", script],
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-
-    assert process.returncode == 0, process.stderr
-    assert process.stdout.strip() == "0"
+    assert callbacks_during_dealloc == []
+    easy.close()
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 14),
-    reason="Python 3.14 exposes callback reentrancy during cyclic GC",
-)
-def test_multi_callback_cycle_is_collectable():
-    script = textwrap.dedent(
-        """
-        import gc
-        import pycurl
+def test_multi_callback_cycle_is_collectable(app):
+    class Client:
+        def __init__(self):
+            self.multi = pycurl.CurlMulti()
+            self.multi.setopt(pycurl.M_TIMERFUNCTION, self.on_timer)
+            self.multi.setopt(pycurl.M_SOCKETFUNCTION, self.on_socket)
+            self.easy = pycurl.Curl()
+            self.easy.setopt(pycurl.URL, f"{app}/success")
+            self.multi.add_handle(self.easy)
+            for _ in range(3):
+                self.multi.socket_action(pycurl.SOCKET_TIMEOUT, 0)
 
-        class Client:
-            def __init__(self):
-                self.multi = pycurl.CurlMulti()
-                self.multi.setopt(pycurl.M_TIMERFUNCTION, self.on_timer)
-                self.multi.setopt(pycurl.M_SOCKETFUNCTION, self.on_socket)
-                self.easy = pycurl.Curl()
-                self.easy.setopt(pycurl.URL, "http://10.255.255.1:1/")
-                self.multi.add_handle(self.easy)
-                for _ in range(3):
-                    try:
-                        self.multi.socket_action(pycurl.SOCKET_TIMEOUT, 0)
-                    except pycurl.error:
-                        pass
+        def on_timer(self, timeout_ms):
+            pass
 
-            def on_timer(self, timeout_ms):
-                pass
+        def on_socket(self, event, fd, multi, data):
+            pass
 
-            def on_socket(self, event, fd, multi, data):
-                pass
+    client = Client()
+    client_ref = weakref.ref(client)
+    del client
+    gc.collect()
 
-        for _ in range(100):
-            client = Client()
-            del client
-            gc.collect()
-
-        print("survived")
-        """
-    )
-
-    process = subprocess.run(
-        [sys.executable, "-c", script],
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-
-    assert process.returncode == 0, process.stderr
-    assert process.stdout.strip() == "survived"
+    assert client_ref() is None

--- a/tests/multi_memory_mgmt_test.py
+++ b/tests/multi_memory_mgmt_test.py
@@ -1,5 +1,7 @@
 import gc
+import subprocess
 import sys
+import textwrap
 import weakref
 
 import pycurl
@@ -75,3 +77,101 @@ def test_curl_kept_alive_while_added_to_multi():
     m.remove_handle(ref())
     gc.collect()
     assert ref() is None
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="Python 3.14 exposes callback reentrancy during tp_dealloc",
+)
+def test_socket_callback_not_invoked_during_multi_dealloc():
+    script = textwrap.dedent(
+        """
+        import gc
+        import pycurl
+
+        callback_count = 0
+        deallocating = False
+
+        def socket_callback(event, fd, multi, data):
+            global callback_count
+            if deallocating:
+                callback_count += 1
+
+        easy = pycurl.Curl()
+        easy.setopt(pycurl.URL, "http://10.255.255.1:1/")
+        multi = pycurl.CurlMulti()
+        multi.setopt(pycurl.M_SOCKETFUNCTION, socket_callback)
+        multi.add_handle(easy)
+
+        for _ in range(3):
+            try:
+                multi.socket_action(pycurl.SOCKET_TIMEOUT, 0)
+            except pycurl.error:
+                pass
+
+        deallocating = True
+        del multi
+        gc.collect()
+        print(callback_count)
+        """
+    )
+
+    process = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert process.returncode == 0, process.stderr
+    assert process.stdout.strip() == "0"
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="Python 3.14 exposes callback reentrancy during cyclic GC",
+)
+def test_multi_callback_cycle_is_collectable():
+    script = textwrap.dedent(
+        """
+        import gc
+        import pycurl
+
+        class Client:
+            def __init__(self):
+                self.multi = pycurl.CurlMulti()
+                self.multi.setopt(pycurl.M_TIMERFUNCTION, self.on_timer)
+                self.multi.setopt(pycurl.M_SOCKETFUNCTION, self.on_socket)
+                self.easy = pycurl.Curl()
+                self.easy.setopt(pycurl.URL, "http://10.255.255.1:1/")
+                self.multi.add_handle(self.easy)
+                for _ in range(3):
+                    try:
+                        self.multi.socket_action(pycurl.SOCKET_TIMEOUT, 0)
+                    except pycurl.error:
+                        pass
+
+            def on_timer(self, timeout_ms):
+                pass
+
+            def on_socket(self, event, fd, multi, data):
+                pass
+
+        for _ in range(100):
+            client = Client()
+            del client
+            gc.collect()
+
+        print("survived")
+        """
+    )
+
+    process = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert process.returncode == 0, process.stderr
+    assert process.stdout.strip() == "survived"


### PR DESCRIPTION
We found a reproducible crash in CurlMulti.tp_dealloc

If a CurlMulti with an active easy handle and M_SOCKETFUNCTION is garbage-collected without being explicitly closed, do_multi_dealloc() removes the easy handle before clearing callbacks. curl_multi_remove_handle() can invoke the socket callback, which exposes the zero-refcount CurlMulti to Python during its own deallocation. This can cause recursive deallocation or resurrection followed by use-after-free, eventually crashing in PyObject_GC_UnTrack.

Clearing the timer/socket/notify callbacks before detaching easy handles fixes both our minimal reproducer and our larger CI workload.

This was investigated heavily with AI assistance, so I don't claim to understand every detail or invariant but since I can’t share our proprietary core dumps I hope this test case and proposed patch are useful.  Happy to open a separate issue if this needs more discussion.