### PR TITLE
Remove the `CurlMulti` argument from `M_SOCKETFUNCTION` callbacks

### DIFF
--- a/doc/callbacks.rst
+++ b/doc/callbacks.rst
@@ -453,7 +453,7 @@ TIMERFUNCTION
 SOCKETFUNCTION
 --------------
 
-.. function:: SOCKETFUNCTION(what, sock_fd, multi, socketp) -> int | None
+.. function:: SOCKETFUNCTION(what: int, sock_fd: int, socketp: object) -> int | None
 
     Callback notifying the application about activity on libcurl sockets.
     Corresponds to `CURLMOPT_SOCKETFUNCTION`_.
@@ -466,9 +466,8 @@ SOCKETFUNCTION
     ``POLL_REMOVE``; see the `CURLMOPT_SOCKETFUNCTION`_ docs for their
     meaning.
 
-    The ``userp`` ("private callback pointer") argument, as described in the
-    ``CURLMOPT_SOCKETFUNCTION`` documentation, is set to the ``CurlMulti``
-    instance.
+    The callback is not passed the ``CurlMulti`` instance. A callback that
+    needs it should capture it, for example with a closure or a bound method.
 
     The ``socketp`` ("private socket pointer") argument, as described in the
     ``CURLMOPT_SOCKETFUNCTION`` documentation, is set to the value provided

--- a/doc/docstrings/multi_setopt.rst
+++ b/doc/docstrings/multi_setopt.rst
@@ -30,8 +30,8 @@ values of different types:
   ``SOCKETFUNCTION``, ``TIMERFUNCTION`` and ``NOTIFYFUNCTION``
   sections of the :ref:`callbacks <callbacks>` page.
   ``CURLMOPT_SOCKETDATA``, ``CURLMOPT_TIMERDATA`` and
-  ``CURLMOPT_NOTIFYDATA`` are reserved by PycURL (set internally to
-  the ``CurlMulti`` instance) and cannot be set from Python.
+  ``CURLMOPT_NOTIFYDATA`` are reserved by PycURL and cannot be set from
+  Python.
 
 Raises TypeError when the option value is not of a type accepted by the
 respective option, and pycurl.error exception when libcurl rejects the

--- a/examples/multi-socket_action-select.py
+++ b/examples/multi-socket_action-select.py
@@ -75,7 +75,7 @@ state = {
     'msg': None,
 }
 
-def socket_fn(what, sock_fd, multi, socketp):
+def socket_fn(what, sock_fd, socketp):
     if what == pycurl.POLL_IN or what == pycurl.POLL_INOUT:
         state['rlist'].append(sock_fd)
     elif what == pycurl.POLL_OUT or what == pycurl.POLL_INOUT:

--- a/src/multi.c
+++ b/src/multi.c
@@ -219,11 +219,6 @@ do_multi_dealloc(CurlMultiObject *self)
     PyObject_GC_UnTrack(self);
     Py_TRASHCAN_BEGIN(self, do_multi_dealloc);
 
-    /* Removing easy handles can invoke M_SOCKETFUNCTION. Clear it first so
-     * the dying CurlMulti is not handed back to Python from its own
-     * tp_dealloc. */
-    Py_CLEAR(self->s_cb);
-
     util_multi_detach_easies(self, 0, 1);
 
     util_multi_xdecref(self);
@@ -333,7 +328,7 @@ multi_socket_callback(CURL *easy,
     if (py_socket == NULL) {
         goto verbose_error;
     }
-    arglist = Py_BuildValue("(iOOO)", what, py_socket, userp, (PyObject *)socketp);
+    arglist = Py_BuildValue("(iOO)", what, py_socket, (PyObject *)socketp);
     Py_DECREF(py_socket);
     if (arglist == NULL) {
         goto verbose_error;

--- a/src/pycurl/async_multi.py
+++ b/src/pycurl/async_multi.py
@@ -316,7 +316,6 @@ class AsyncCurlMulti:
         self,
         what: int,
         fd: int,
-        multi: CurlMulti,
         socketp: _SocketState | None,
     ) -> None:
         if what == POLL_REMOVE:
@@ -363,7 +362,7 @@ class AsyncCurlMulti:
         state.read_registered = want_read
         state.write_registered = want_write
         if first_observation:
-            multi.assign(fd, state)
+            self._multi.assign(fd, state)
 
     def _unregister_watchers(self, fd: int, state: _SocketState) -> None:
         assert self._loop is not None, "callback fired before _ensure_loop"

--- a/tests/multi_callback_test.py
+++ b/tests/multi_callback_test.py
@@ -90,7 +90,7 @@ def multi_ctx(app) -> Generator[MultiCtx, None, None]:
     multi = pycurl.CurlMulti()
     ctx = MultiCtx(easy=easy, multi=multi)
 
-    def socket_callback(ev_bitmask: int, sock_fd: int, multi_handle, data) -> None:
+    def socket_callback(ev_bitmask: int, sock_fd: int, data) -> None:
         logger.debug("socket_callback: fd=%d ev=%d", sock_fd, ev_bitmask)
         ctx.socket_result = (sock_fd, ev_bitmask)
         if ev_bitmask & pycurl.POLL_REMOVE:

--- a/tests/multi_memory_mgmt_test.py
+++ b/tests/multi_memory_mgmt_test.py
@@ -77,11 +77,11 @@ def test_curl_kept_alive_while_added_to_multi():
     assert ref() is None
 
 
-def test_socket_callback_not_invoked_during_multi_dealloc(app):
+def test_socket_callback_invoked_during_multi_dealloc(app):
     callbacks_during_dealloc = []
     deallocating = False
 
-    def socket_callback(event, fd, multi, data):
+    def socket_callback(event, fd, data):
         if deallocating:
             callbacks_during_dealloc.append(event)
 
@@ -98,7 +98,7 @@ def test_socket_callback_not_invoked_during_multi_dealloc(app):
     del multi
     gc.collect()
 
-    assert callbacks_during_dealloc == []
+    assert pycurl.POLL_REMOVE in callbacks_during_dealloc
     easy.close()
 
 
@@ -117,7 +117,7 @@ def test_multi_callback_cycle_is_collectable(app):
         def on_timer(self, timeout_ms):
             pass
 
-        def on_socket(self, event, fd, multi, data):
+        def on_socket(self, event, fd, data):
             pass
 
     client = Client()
@@ -126,3 +126,36 @@ def test_multi_callback_cycle_is_collectable(app):
     gc.collect()
 
     assert client_ref() is None
+
+
+@pytest.mark.thread_unsafe
+def test_socket_callback_does_not_create_cycle(app):
+    def build_and_drop():
+        events = []
+
+        def socket_callback(*args):
+            events.append(args)
+
+        easy = pycurl.Curl()
+        easy.setopt(pycurl.URL, f"{app}/success")
+        multi = pycurl.CurlMulti()
+        multi.setopt(pycurl.M_SOCKETFUNCTION, socket_callback)
+        multi.add_handle(easy)
+        for _ in range(3):
+            multi.socket_action(pycurl.SOCKET_TIMEOUT, 0)
+
+        assert events, "expected at least one socket callback"
+        ref = weakref.ref(multi)
+        multi.remove_handle(easy)
+        easy.close()
+        del multi
+        return ref
+
+    gc.collect()
+    gc.disable()
+    try:
+        ref = build_and_drop()
+    finally:
+        gc.enable()
+
+    assert ref() is None, "CurlMulti outlived its last reference without the GC"

--- a/tests/multi_socket_select_test.py
+++ b/tests/multi_socket_select_test.py
@@ -57,13 +57,13 @@ class MultiSocketSelectTest(unittest.TestCase):
         socket_events = []
 
         # socket callback
-        def socket(event, socket, multi, data):
+        def socket(event, socket, data):
             if event == pycurl.POLL_REMOVE:
                 sockets.remove(socket)
             else:
                 if socket not in sockets:
                     sockets.add(socket)
-            socket_events.append((event, multi))
+            socket_events.append((event, socket))
 
         # init
         m = self.m
@@ -117,12 +117,10 @@ class MultiSocketSelectTest(unittest.TestCase):
             self.assertEqual("success", c.body.getvalue().decode())
             self.assertEqual(200, c.http_code)
 
-            # multi, not curl handle
-            self.check(pycurl.POLL_IN, m, socket_events)
-            self.check(pycurl.POLL_REMOVE, m, socket_events)
+        self.check(pycurl.POLL_IN, socket_events)
+        self.check(pycurl.POLL_REMOVE, socket_events)
 
-    def check(self, event, multi, socket_events):
-        for event_, multi_ in socket_events:
-            if event == event_ and multi == multi_:
-                return
-        assert False, "%d %s not found in socket events" % (event, multi)
+    def check(self, event, socket_events):
+        assert any(event == event_ for event_, _ in socket_events), (
+            "%d not found in socket events: %r" % (event, socket_events)
+        )

--- a/tests/multi_socket_test.py
+++ b/tests/multi_socket_test.py
@@ -43,11 +43,10 @@ def _find_socket(multi, timeout=5.0, timer_state=None):
     return None
 
 
-def _assert_socket_event(event, multi, socket_events):
-    for event_, multi_ in socket_events:
-        if event == event_ and multi == multi_:
-            return
-    assert False, "%d %s not found in socket events" % (event, multi)
+def _assert_socket_event(event, socket_events):
+    assert any(event == event_ for event_, _ in socket_events), (
+        "%d not found in socket events: %r" % (event, socket_events)
+    )
 
 
 def _assert_within_deadline(deadline, label):
@@ -98,9 +97,8 @@ def test_multi_socket(app, multi):
     timer_state = install_timer_tracker(multi)
 
     # socket callback
-    def socket(event, socket, multi_handle, data):
-        # print(event, socket, multi_handle, data)
-        socket_events.append((event, multi_handle))
+    def socket(event, sock_fd, data):
+        socket_events.append((event, sock_fd))
 
     # init
     multi.setopt(pycurl.M_SOCKETFUNCTION, socket)
@@ -139,9 +137,8 @@ def test_multi_socket(app, multi):
         assert "success" == c.body.getvalue().decode()
         assert 200 == c.http_code
 
-        # multi, not curl handle
-        _assert_socket_event(pycurl.POLL_IN, multi, socket_events)
-        _assert_socket_event(pycurl.POLL_REMOVE, multi, socket_events)
+    _assert_socket_event(pycurl.POLL_IN, socket_events)
+    _assert_socket_event(pycurl.POLL_REMOVE, socket_events)
 
     # close handles
     for c in handles:
@@ -160,7 +157,7 @@ def test_multi_assign_objects(app, multi, reassign):
     class Sentinel:
         pass
 
-    def socket(event, sock_fd, multi_handle, data):
+    def socket(event, sock_fd, data):
         nonlocal seen_data
         if data is not None:
             seen_data = data
@@ -213,7 +210,7 @@ def test_multi_assign_inside_socket_callback(app, multi):
     events = []
     assign_errors = []
 
-    def socket(event, sock_fd, multi_handle, data):
+    def socket(event, sock_fd, data):
         events.append((sock_fd, event, data))
         if event != pycurl.POLL_REMOVE and data is None:
             try:
@@ -230,10 +227,26 @@ def test_multi_assign_inside_socket_callback(app, multi):
     )
 
 
+def test_socket_callback_receives_three_args(app, multi):
+    calls = []
+
+    def socket(*args):
+        calls.append(args)
+
+    for _ in _chunks_transfer(app, multi, socket, "arg count"):
+        pass
+
+    assert calls, "expected at least one socket callback invocation"
+    assert {len(args) for args in calls} == {3}
+    assert all(
+        isinstance(what, int) and isinstance(sock_fd, int) for what, sock_fd, _ in calls
+    )
+
+
 def test_socketp_starts_as_none(app, multi):
     seen_per_fd: dict[int, list] = {}
 
-    def socket(event, sock_fd, multi_handle, data):
+    def socket(event, sock_fd, data):
         seen_per_fd.setdefault(sock_fd, []).append(data)
 
     for _ in _chunks_transfer(app, multi, socket, "socketp starts None"):
@@ -265,7 +278,7 @@ def test_clear_assignment_inside_socket_callback_releases_ref(app, multi, clear)
     errors = []
     cleared_fds = set()
 
-    def socket(event, sock_fd, multi_handle, data):
+    def socket(event, sock_fd, data):
         # why: log primitives only -- passing `data` would pin marker via LogRecord args.
         kind = (
             "None" if data is None else ("marker" if data is marker_ref() else "other")
@@ -309,7 +322,7 @@ def _assign_marker_then_close(app):
     marker_ref = weakref.ref(marker)
     state = {"assigned": False}
 
-    def socket(event, sock_fd, multi_handle, data):
+    def socket(event, sock_fd, data):
         if event != pycurl.POLL_REMOVE and not state["assigned"]:
             multi.assign(sock_fd, marker)
             state["assigned"] = True
@@ -357,7 +370,7 @@ def test_multi_clear_assignment(app, multi, clear):
     class Sentinel:
         pass
 
-    def socket(event, sock_fd, multi_handle, data):
+    def socket(event, sock_fd, data):
         pass
 
     for timer_state in _chunks_transfer(app, multi, socket, "clear assignment"):

--- a/tests/test_async_multi.py
+++ b/tests/test_async_multi.py
@@ -421,11 +421,11 @@ def test_socket_mask_transitions() -> None:
         async with pycurl.AsyncCurlMulti() as multi:
             with _stubbed_socket_io(multi) as (stub, calls):
                 fd = 99
-                multi._on_socket(pycurl.POLL_IN, fd, stub, None)
+                multi._on_socket(pycurl.POLL_IN, fd, None)
                 state = stub.assigned[-1]
-                multi._on_socket(pycurl.POLL_INOUT, fd, stub, state)
-                multi._on_socket(pycurl.POLL_OUT, fd, stub, state)
-                multi._on_socket(pycurl.POLL_REMOVE, fd, stub, state)
+                multi._on_socket(pycurl.POLL_INOUT, fd, state)
+                multi._on_socket(pycurl.POLL_OUT, fd, state)
+                multi._on_socket(pycurl.POLL_REMOVE, fd, state)
 
             assert calls == [
                 ("add_reader", fd),
@@ -474,9 +474,9 @@ def test_poll_inout_then_remove_clears_both_watchers() -> None:
         async with pycurl.AsyncCurlMulti() as multi:
             with _stubbed_socket_io(multi) as (stub, calls):
                 fd = 77
-                multi._on_socket(pycurl.POLL_INOUT, fd, stub, None)
+                multi._on_socket(pycurl.POLL_INOUT, fd, None)
                 state = stub.assigned[-1]
-                multi._on_socket(pycurl.POLL_REMOVE, fd, stub, state)
+                multi._on_socket(pycurl.POLL_REMOVE, fd, state)
 
             assert calls == [
                 ("add_reader", fd),
@@ -494,9 +494,9 @@ def test_poll_none_keeps_assignment() -> None:
         async with pycurl.AsyncCurlMulti() as multi:
             with _stubbed_socket_io(multi) as (stub, calls):
                 fd = 88
-                multi._on_socket(pycurl.POLL_INOUT, fd, stub, None)
+                multi._on_socket(pycurl.POLL_INOUT, fd, None)
                 state = stub.assigned[-1]
-                multi._on_socket(pycurl.POLL_NONE, fd, stub, state)
+                multi._on_socket(pycurl.POLL_NONE, fd, state)
 
             assert ("remove_reader", fd) in calls
             assert ("remove_writer", fd) in calls
@@ -582,7 +582,7 @@ def test_close_time_poll_in_is_ignored() -> None:
         async with pycurl.AsyncCurlMulti() as multi:
             with _stubbed_socket_io(multi) as (stub, calls):
                 multi._closing = True
-                multi._on_socket(pycurl.POLL_IN, 99, stub, None)
+                multi._on_socket(pycurl.POLL_IN, 99, None)
             assert calls == []
             assert stub.assigned == []
             assert 99 not in multi._assigned_fds


### PR DESCRIPTION
- `M_SOCKETFUNCTION` was the only callback handed its owning object. It now takes
  `(what, sock_fd, socketp)` instead of `(what, sock_fd, multi, socketp)`. Breaking
  change.
- The argument was redundant, always being the handle the callback was installed on,
  and no other callback passes its owner. It also made reference cycles the default:
  every call put a strong reference to the multi in the argument tuple, so even a
  callback that only logged its arguments formed a cycle that only the GC could break.
- It is also what let a dying multi be handed back to Python from its own deallocator,
  the crash #1058 worked around by clearing `s_cb` before detaching handles. The workaround is dropped, its regression test inverted, and `POLL_REMOVE` reaches the callback during destruction again.
- Callbacks that need the handle capture it explicitly, with a closure, a bound method
  or `functools.partial`.

Proposed `ChangeLog` entry:

    * Breaking change: M_SOCKETFUNCTION callback no longer receives the
      CurlMulti instance. The callback now takes `what', `sock_fd' and
      `socketp'. Existing callbacks will need to be modified to drop the
      `multi' argument. (patch by Jorge Rocamora)

Assisted by Claude Opus 5.